### PR TITLE
New Oscillator rendering based on wavetables and polyBLEP

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ hound = "3.4.0"
 log = "0.4.14"
 realfft = "2.0.1"
 crossbeam-channel = "0.5.1"
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 rand = "0.8.*"

--- a/src/context.rs
+++ b/src/context.rs
@@ -13,7 +13,7 @@ use crate::buffer::{AudioBuffer, ChannelConfigOptions, ChannelCountMode, Channel
 use crate::graph::{NodeIndex, RenderThread};
 use crate::media::{MediaElement, MediaStream};
 use crate::message::ControlMessage;
-use crate::node::{self, AudioNode};
+use crate::node::{self, AudioNode, PeriodicWave, PeriodicWaveConstraints};
 use crate::param::{AudioParam, AudioParamOptions, AutomationEvent};
 use crate::process::AudioProcessor;
 use crate::spatial::{AudioListener, AudioListenerParams};
@@ -154,6 +154,20 @@ pub trait AsBaseAudioContext {
     /// Creates a AnalyserNode
     fn create_analyser(&self) -> node::AnalyserNode {
         node::AnalyserNode::new(self.base(), Default::default())
+    }
+
+    /// Creates a periodic wave
+    //
+    // dictionary PeriodicWaveConstraints {
+    //   boolean disableNormalization = false;
+    // };
+    fn create_periodic_wave(
+        &self,
+        real: Vec<f32>,
+        imag: Vec<f32>,
+        constraints: Option<PeriodicWaveConstraints>,
+    ) -> PeriodicWave {
+        PeriodicWave::new(real, imag, constraints)
     }
 
     /// Create an AudioParam.

--- a/src/node.rs
+++ b/src/node.rs
@@ -344,7 +344,6 @@ pub struct OscillatorNode {
     channel_config: ChannelConfig,
     frequency: AudioParam,
     type_: Arc<AtomicU32>,
-    periodic_wave: Option<PeriodicWave>,
     scheduler: Scheduler,
 }
 
@@ -420,7 +419,6 @@ impl OscillatorNode {
                 registration,
                 channel_config: options.channel_config.into(),
                 frequency: f_param,
-                periodic_wave: options.periodic_wave,
                 type_,
                 scheduler,
             };
@@ -448,10 +446,12 @@ impl OscillatorNode {
     /// a perdioc waveform following the PeriodicWave characteristics
     //
     //  TODO: The current implementation doesn't communicate its state
-    //  to the OscillatorRenderer, and so has no effect on the rendering
-    pub fn set_periodic_wave(&mut self, periodic_wave: PeriodicWave) {
+    //  to the OscillatorRenderer, and so has no effect on the rendering.
+    //  This function should send the updated periodics waveform characteristics
+    //  to the OscillatorRenderer and more specifically to the CustomRenderer
+    pub fn set_periodic_wave(&mut self, _periodic_wave: PeriodicWave) {
         self.set_type(OscillatorType::Custom);
-        self.periodic_wave = Some(periodic_wave);
+        todo!();
     }
 }
 


### PR DESCRIPTION
## Updated oscillator renderers
- `SineRenderer` : New Sine renderer based on **wavetable**
-  `SquareRenderer` and `SawtoothRenderer`: New Square and Sawtooth renderers based on **wavetable** and **polyBLEP**

## New oscillator renderers
- `TriangleRenderer` : New Triangle renderer based on **wavetable** and **polyBLEP**
-  `CustomRenderer`: New Custom renderer based on **wavetable**

### Goals
- Wavetable might be a more efficient algorithm than transcendental function (sin,cos,...)
- Wavetable might allowa more efficient implementation of `custom` oscillator type
- polyBLEP algorithm might reduce aliasing behavior for non bandlimited signal (`square`, `triangle`, and `sawtooth`).

## Todos
- `detune` has not been implemented
- Controls of `OscillatorNode` over `CustomRenderer` is partial. `set_periodic_wave` is currently a no-op
-  Algorithm correctness has been tested but not exhaustively, **and** tests are still not included
-  **No benchmarking between the original rendering implementation and the new one has been done yet**

I 'd like to know what you think about this first draft and improve on you remarks.
I don't know how to pass `PeriodicWave` between the controller and renderer nodes. I thought to send the data via a lock-free channel. 

### Docs
- [polyBLEP doc1](https://www.kvraudio.com/forum/viewtopic.php?t=375517)
- [polyBLEP doc2](http://www.martin-finke.de/blog/articles/audio-plugins-018-polyblep-oscillator/)