### PR TITLE
Avoid allocation during AudioParamProcessor::tick calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,8 @@ rand = "0.8.*"
 alloc_counter = "0.0.4"
 float_eq = "0.6"
 env_logger = "0.9.0"
+
+# Uncomment the following lines to enable debug symbols
+# during CPU profiling
+[profile.release]
+debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,5 +28,5 @@ env_logger = "0.9.0"
 
 # Uncomment the following lines to enable debug symbols
 # during CPU profiling
-[profile.release]
-debug = true
+# [profile.release]
+# debug = true

--- a/src/param.rs
+++ b/src/param.rs
@@ -8,7 +8,7 @@ use crate::buffer::{ChannelConfig, ChannelConfigOptions, ChannelCountMode, Chann
 use crate::context::AudioContextRegistration;
 use crate::node::AudioNode;
 use crate::process::{AudioParamValues, AudioProcessor};
-use crate::{AtomicF64, SampleRate};
+use crate::{AtomicF64, SampleRate, BUFFER_SIZE};
 
 use crossbeam_channel::{Receiver, Sender};
 
@@ -122,6 +122,7 @@ pub(crate) struct AudioParamProcessor {
     min_value: f32,
     max_value: f32,
     events: BinaryHeap<AutomationEvent>,
+    buffer: Vec<f32>,
 }
 
 impl AudioProcessor for AudioParamProcessor {
@@ -178,6 +179,7 @@ pub(crate) fn audio_param_pair(
         min_value: opts.min_value,
         max_value: opts.max_value,
         events: BinaryHeap::new(),
+        buffer: Vec::with_capacity(BUFFER_SIZE as usize),
     };
 
     (param, render)


### PR DESCRIPTION
Remove `Vec` allocations at each call to `tick`.

Instead the `Vec` is created at instantion of `AudioParamProcessor` an reused at each `tick` call

With this optimization, memory allocation is greatly reduced 1MB (fixed) instead of 80MB (linearly growing with execution time).

Allocation measurements have been made with Heaptrack.

#16