### PR TITLE
changed BUFFER_SIZE to usize (cf. #49)

### DIFF
--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -683,7 +683,7 @@ mod tests {
             let mut signal = alloc.silence();
             signal.copy_from_slice(&[1.; BUFFER_SIZE]);
 
-            let mut buffer = AudioBuffer::new(signal.clone());
+            let mut buffer = AudioBuffer::new(signal);
 
             // make sure 1 -> 1 does nothing
             buffer.mix(1, ChannelInterpretation::Speakers);
@@ -715,7 +715,7 @@ mod tests {
             let mut signal = alloc.silence();
             signal.copy_from_slice(&[1.; BUFFER_SIZE]);
 
-            let mut buffer = AudioBuffer::new(signal.clone());
+            let mut buffer = AudioBuffer::new(signal);
 
             buffer.mix(4, ChannelInterpretation::Speakers);
             assert_eq!(buffer.number_of_channels(), 4);
@@ -748,7 +748,7 @@ mod tests {
             let mut signal = alloc.silence();
             signal.copy_from_slice(&[1.; BUFFER_SIZE]);
 
-            let mut buffer = AudioBuffer::new(signal.clone());
+            let mut buffer = AudioBuffer::new(signal);
 
             buffer.mix(6, ChannelInterpretation::Speakers);
             assert_eq!(buffer.number_of_channels(), 6);
@@ -793,8 +793,8 @@ mod tests {
             let mut right_signal = alloc.silence();
             right_signal.copy_from_slice(&[0.5; BUFFER_SIZE]);
 
-            let mut buffer = AudioBuffer::new(left_signal.clone());
-            buffer.channels.push(right_signal.clone());
+            let mut buffer = AudioBuffer::new(left_signal);
+            buffer.channels.push(right_signal);
 
             assert_eq!(buffer.number_of_channels(), 2);
             assert_float_eq!(
@@ -839,8 +839,8 @@ mod tests {
             let mut right_signal = alloc.silence();
             right_signal.copy_from_slice(&[0.5; BUFFER_SIZE]);
 
-            let mut buffer = AudioBuffer::new(left_signal.clone());
-            buffer.channels.push(right_signal.clone());
+            let mut buffer = AudioBuffer::new(left_signal);
+            buffer.channels.push(right_signal);
 
             assert_eq!(buffer.number_of_channels(), 2);
             assert_float_eq!(
@@ -899,10 +899,10 @@ mod tests {
             let mut s_right_signal = alloc.silence();
             s_right_signal.copy_from_slice(&[1.; BUFFER_SIZE]);
 
-            let mut buffer = AudioBuffer::new(left_signal.clone());
-            buffer.channels.push(right_signal.clone());
-            buffer.channels.push(s_left_signal.clone());
-            buffer.channels.push(s_right_signal.clone());
+            let mut buffer = AudioBuffer::new(left_signal);
+            buffer.channels.push(right_signal);
+            buffer.channels.push(s_left_signal);
+            buffer.channels.push(s_right_signal);
 
             assert_eq!(buffer.number_of_channels(), 4);
             assert_float_eq!(
@@ -972,8 +972,8 @@ mod tests {
             let mut right_signal = alloc.silence();
             right_signal.copy_from_slice(&[0.5; BUFFER_SIZE]);
 
-            let mut buffer = AudioBuffer::new(left_signal.clone());
-            buffer.channels.push(right_signal.clone());
+            let mut buffer = AudioBuffer::new(left_signal);
+            buffer.channels.push(right_signal);
 
             assert_eq!(buffer.number_of_channels(), 2);
             assert_float_eq!(
@@ -1007,10 +1007,10 @@ mod tests {
             let mut s_right_signal = alloc.silence();
             s_right_signal.copy_from_slice(&[0.25; BUFFER_SIZE]);
 
-            let mut buffer = AudioBuffer::new(left_signal.clone());
-            buffer.channels.push(right_signal.clone());
-            buffer.channels.push(s_left_signal.clone());
-            buffer.channels.push(s_right_signal.clone());
+            let mut buffer = AudioBuffer::new(left_signal);
+            buffer.channels.push(right_signal);
+            buffer.channels.push(s_left_signal);
+            buffer.channels.push(s_right_signal);
 
             assert_eq!(buffer.number_of_channels(), 4);
             assert_float_eq!(
@@ -1058,12 +1058,12 @@ mod tests {
             let mut s_right_signal = alloc.silence();
             s_right_signal.copy_from_slice(&[0.5; BUFFER_SIZE]);
 
-            let mut buffer = AudioBuffer::new(left_signal.clone());
-            buffer.channels.push(right_signal.clone());
-            buffer.channels.push(center_signal.clone());
-            buffer.channels.push(low_freq_signal.clone());
-            buffer.channels.push(s_left_signal.clone());
-            buffer.channels.push(s_right_signal.clone());
+            let mut buffer = AudioBuffer::new(left_signal);
+            buffer.channels.push(right_signal);
+            buffer.channels.push(center_signal);
+            buffer.channels.push(low_freq_signal);
+            buffer.channels.push(s_left_signal);
+            buffer.channels.push(s_right_signal);
 
             assert_eq!(buffer.number_of_channels(), 6);
             assert_float_eq!(
@@ -1119,10 +1119,10 @@ mod tests {
             let mut s_right_signal = alloc.silence();
             s_right_signal.copy_from_slice(&[1.; BUFFER_SIZE]);
 
-            let mut buffer = AudioBuffer::new(left_signal.clone());
-            buffer.channels.push(right_signal.clone());
-            buffer.channels.push(s_left_signal.clone());
-            buffer.channels.push(s_right_signal.clone());
+            let mut buffer = AudioBuffer::new(left_signal);
+            buffer.channels.push(right_signal);
+            buffer.channels.push(s_left_signal);
+            buffer.channels.push(s_right_signal);
 
             assert_eq!(buffer.number_of_channels(), 4);
             assert_float_eq!(
@@ -1175,12 +1175,12 @@ mod tests {
             let mut s_right_signal = alloc.silence();
             s_right_signal.copy_from_slice(&[0.5; BUFFER_SIZE]);
 
-            let mut buffer = AudioBuffer::new(left_signal.clone());
-            buffer.channels.push(right_signal.clone());
-            buffer.channels.push(center_signal.clone());
-            buffer.channels.push(low_freq_signal.clone());
-            buffer.channels.push(s_left_signal.clone());
-            buffer.channels.push(s_right_signal.clone());
+            let mut buffer = AudioBuffer::new(left_signal);
+            buffer.channels.push(right_signal);
+            buffer.channels.push(center_signal);
+            buffer.channels.push(low_freq_signal);
+            buffer.channels.push(s_left_signal);
+            buffer.channels.push(s_right_signal);
 
             assert_eq!(buffer.number_of_channels(), 6);
             assert_float_eq!(
@@ -1246,12 +1246,12 @@ mod tests {
             let mut s_right_signal = alloc.silence();
             s_right_signal.copy_from_slice(&[0.5; BUFFER_SIZE]);
 
-            let mut buffer = AudioBuffer::new(left_signal.clone());
-            buffer.channels.push(right_signal.clone());
-            buffer.channels.push(center_signal.clone());
-            buffer.channels.push(low_freq_signal.clone());
-            buffer.channels.push(s_left_signal.clone());
-            buffer.channels.push(s_right_signal.clone());
+            let mut buffer = AudioBuffer::new(left_signal);
+            buffer.channels.push(right_signal);
+            buffer.channels.push(center_signal);
+            buffer.channels.push(low_freq_signal);
+            buffer.channels.push(s_left_signal);
+            buffer.channels.push(s_right_signal);
 
             assert_eq!(buffer.number_of_channels(), 6);
             assert_float_eq!(

--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -14,7 +14,7 @@ use std::rc::Rc;
 use crate::buffer::ChannelInterpretation;
 
 /// size of a buffer, 128 samples per spec
-const BUFFER_SIZE: usize = crate::BUFFER_SIZE as usize;
+use crate::BUFFER_SIZE;
 use crate::MAX_CHANNELS;
 
 pub(crate) struct Alloc {

--- a/src/context.rs
+++ b/src/context.rs
@@ -724,9 +724,7 @@ impl OfflineAudioContext {
     pub fn start_rendering(&mut self) -> AudioBuffer {
         // make buffer_size always a multiple of BUFFER_SIZE, so we can still render piecewise with
         // the desired number of frames.
-        let cast_buffer_size = BUFFER_SIZE as usize;
-        let buffer_size =
-            (self.length + cast_buffer_size - 1) / cast_buffer_size * cast_buffer_size;
+        let buffer_size = (self.length + BUFFER_SIZE - 1) / BUFFER_SIZE * BUFFER_SIZE;
 
         let mut buf = self.renderer.render_audiobuffer(buffer_size);
         let _split = buf.split_off(self.length);

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -88,11 +88,11 @@ impl RenderThread {
 
     pub fn render_audiobuffer(&mut self, length: usize) -> crate::buffer::AudioBuffer {
         // assert input was properly sized
-        debug_assert_eq!(length % BUFFER_SIZE as usize, 0);
+        debug_assert_eq!(length % BUFFER_SIZE, 0);
 
         let mut buf = crate::buffer::AudioBuffer::new(self.channels, 0, self.sample_rate);
 
-        for _ in 0..length / BUFFER_SIZE as usize {
+        for _ in 0..length / BUFFER_SIZE {
             // handle addition/removal of nodes/edges
             self.handle_control_messages();
 
@@ -118,7 +118,7 @@ impl RenderThread {
         // There may be audio frames left over from the previous render call,
         // if the cpal buffer size did not align with our internal BUFFER_SIZE
         if let Some((offset, prev_rendered)) = self.buffer_offset.take() {
-            let leftover_len = (BUFFER_SIZE as usize - offset) * self.channels;
+            let leftover_len = (BUFFER_SIZE - offset) * self.channels;
             // split the leftover frames slice, to fit in `buffer`
             let (first, next) = buffer.split_at_mut(leftover_len.min(buffer.len()));
 
@@ -144,7 +144,7 @@ impl RenderThread {
 
         // The audio graph is rendered in chunks of BUFFER_SIZE frames.  But some audio backends
         // may not be able to emit chunks of this size.
-        let chunk_size = BUFFER_SIZE as usize * self.channels as usize;
+        let chunk_size = BUFFER_SIZE * self.channels as usize;
 
         for data in buffer.chunks_mut(chunk_size) {
             // handle addition/removal of nodes/edges
@@ -172,7 +172,7 @@ impl RenderThread {
             if data.len() != chunk_size {
                 // this is the last chunk, and it contained less than BUFFER_SIZE samples
                 let channel_offset = data.len() / self.channels;
-                debug_assert!(channel_offset < BUFFER_SIZE as usize);
+                debug_assert!(channel_offset < BUFFER_SIZE);
                 self.buffer_offset = Some((channel_offset, rendered.clone()));
             }
         }

--- a/src/io.rs
+++ b/src/io.rs
@@ -8,11 +8,12 @@
 )]
 #![allow(clippy::missing_const_for_fn)]
 
+use std::convert::TryFrom;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
 use crate::message::ControlMessage;
-use crate::{SampleRate, BUFFER_SIZE_U32};
+use crate::{SampleRate, BUFFER_SIZE};
 
 use cpal::{
     traits::{DeviceTrait, HostTrait, StreamTrait},
@@ -139,7 +140,7 @@ impl StreamConfigsBuilder {
     ///
     /// * `options` - options contains latency hint information from which buffer size is derived
     fn get_buffer_size(&self, options: Option<&AudioContextOptions>) -> u32 {
-        let buffer_size = BUFFER_SIZE_U32;
+        let buffer_size: u32 = u32::try_from(BUFFER_SIZE).unwrap();
         let default_buffer_size = match self.supported.buffer_size() {
             SupportedBufferSize::Range { min, .. } => buffer_size.max(*min),
             SupportedBufferSize::Unknown => buffer_size,
@@ -456,7 +457,7 @@ pub fn build_input() -> (Stream, StreamConfig, Receiver<AudioBuffer>) {
     let default_config: StreamConfig = supported_config.clone().into();
 
     // determine best buffer size. Spec requires BUFFER_SIZE, but that might not be available
-    let buffer_size = BUFFER_SIZE_U32;
+    let buffer_size: u32 = u32::try_from(BUFFER_SIZE).unwrap();
     let mut input_buffer_size = match supported_config.buffer_size() {
         SupportedBufferSize::Range { min, .. } => buffer_size.max(*min),
         SupportedBufferSize::Unknown => buffer_size,

--- a/src/io.rs
+++ b/src/io.rs
@@ -12,7 +12,7 @@ use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
 use crate::message::ControlMessage;
-use crate::{SampleRate, BUFFER_SIZE};
+use crate::{SampleRate, BUFFER_SIZE_U32};
 
 use cpal::{
     traits::{DeviceTrait, HostTrait, StreamTrait},
@@ -139,8 +139,7 @@ impl StreamConfigsBuilder {
     ///
     /// * `options` - options contains latency hint information from which buffer size is derived
     fn get_buffer_size(&self, options: Option<&AudioContextOptions>) -> u32 {
-        #[allow(clippy::cast_possible_truncation)]
-        let buffer_size = BUFFER_SIZE as u32;
+        let buffer_size = BUFFER_SIZE_U32;
         let default_buffer_size = match self.supported.buffer_size() {
             SupportedBufferSize::Range { min, .. } => buffer_size.max(*min),
             SupportedBufferSize::Unknown => buffer_size,
@@ -457,8 +456,7 @@ pub fn build_input() -> (Stream, StreamConfig, Receiver<AudioBuffer>) {
     let default_config: StreamConfig = supported_config.clone().into();
 
     // determine best buffer size. Spec requires BUFFER_SIZE, but that might not be available
-    #[allow(clippy::cast_possible_truncation)]
-    let buffer_size = BUFFER_SIZE as u32;
+    let buffer_size = BUFFER_SIZE_U32;
     let mut input_buffer_size = match supported_config.buffer_size() {
         SupportedBufferSize::Range { min, .. } => buffer_size.max(*min),
         SupportedBufferSize::Unknown => buffer_size,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 //! ```
 
 /// Render quantum size (audio graph is rendered in blocks of this size)
-pub const BUFFER_SIZE: u32 = 128;
+pub const BUFFER_SIZE: usize = 128;
 
 /// Maximum number of channels for audio processing
 pub const MAX_CHANNELS: usize = 32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,8 +39,14 @@
 //! //std::thread::sleep(std::time::Duration::from_secs(4));
 //! ```
 
+/// Render quantum size as u32 (audio graph is rendered in blocks of this size)
+///
+/// derive BUFFER_SIZE from this const to prevent downcasting from `usize` to `u32`
+/// (cf. discussion [https://github.com/orottier/web-audio-api-rs/pull/52#issuecomment-969156219])
+pub const BUFFER_SIZE_U32: u32 = 128;
+
 /// Render quantum size (audio graph is rendered in blocks of this size)
-pub const BUFFER_SIZE: usize = 128;
+pub const BUFFER_SIZE: usize = BUFFER_SIZE_U32 as usize;
 
 /// Maximum number of channels for audio processing
 pub const MAX_CHANNELS: usize = 32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,14 +39,8 @@
 //! //std::thread::sleep(std::time::Duration::from_secs(4));
 //! ```
 
-/// Render quantum size as u32 (audio graph is rendered in blocks of this size)
-///
-/// derive BUFFER_SIZE from this const to prevent downcasting from `usize` to `u32`
-/// (cf. discussion [https://github.com/orottier/web-audio-api-rs/pull/52#issuecomment-969156219])
-pub const BUFFER_SIZE_U32: u32 = 128;
-
 /// Render quantum size (audio graph is rendered in blocks of this size)
-pub const BUFFER_SIZE: usize = BUFFER_SIZE_U32 as usize;
+pub const BUFFER_SIZE: usize = 128;
 
 /// Maximum number of channels for audio processing
 pub const MAX_CHANNELS: usize = 32;

--- a/src/media.rs
+++ b/src/media.rs
@@ -348,7 +348,7 @@ impl Iterator for Microphone {
             Err(TryRecvError::Empty) => {
                 // frame not received in time, emit silence
                 log::debug!("input frame delayed");
-                AudioBuffer::new(self.channels, BUFFER_SIZE as usize, self.sample_rate)
+                AudioBuffer::new(self.channels, BUFFER_SIZE, self.sample_rate)
             }
             Err(TryRecvError::Disconnected) => {
                 // MicrophoneRender has stopped, close stream
@@ -527,7 +527,7 @@ impl Iterator for WavDecoder {
         for (i, res) in self
             .stream
             .by_ref()
-            .take((self.channels * crate::BUFFER_SIZE) as usize)
+            .take(self.channels as usize * BUFFER_SIZE)
             .enumerate()
         {
             match res {

--- a/src/node/audio_buffer.rs
+++ b/src/node/audio_buffer.rs
@@ -58,7 +58,7 @@ impl AudioBufferSourceNode {
             // unwrap_or_default buffer
             let buffer = options
                 .buffer
-                .unwrap_or_else(|| AudioBuffer::new(1, BUFFER_SIZE as usize, SampleRate(44_100)));
+                .unwrap_or_else(|| AudioBuffer::new(1, BUFFER_SIZE, SampleRate(44_100)));
 
             // wrap input in resampler
             let resampler = Resampler::new(

--- a/src/node/delay.rs
+++ b/src/node/delay.rs
@@ -64,8 +64,8 @@ impl DelayNode {
 
             // allocate large enough buffer to store all delayed samples
             let max_samples = options.max_delay_time * context.base().sample_rate().0 as f32;
-            let max_quanta = (max_samples.ceil() as u32 + BUFFER_SIZE - 1) / BUFFER_SIZE;
-            let delay_buffer = Vec::with_capacity(max_quanta as usize);
+            let max_quanta = (max_samples.ceil() as usize + BUFFER_SIZE - 1) / BUFFER_SIZE;
+            let delay_buffer = Vec::with_capacity(max_quanta);
 
             let render = DelayRenderer {
                 delay_time: proc,
@@ -116,7 +116,7 @@ impl AudioProcessor for DelayRenderer {
         let delay = params.get(&self.delay_time)[0];
 
         // calculate the delay in chunks of BUFFER_SIZE (todo: sub quantum delays)
-        let quanta = (delay * sample_rate.0 as f32) as usize / BUFFER_SIZE as usize;
+        let quanta = (delay * sample_rate.0 as f32) as usize / BUFFER_SIZE;
 
         if quanta == 0 {
             // when no delay is set, simply copy input to output

--- a/src/node/iir_filter.rs
+++ b/src/node/iir_filter.rs
@@ -647,6 +647,6 @@ mod test {
 
         let min_len = min(data_ch.len(), ref_data_ch.len());
 
-        assert_float_eq!(data_ch[0..min_len], ref_data_ch[0..min_len], ulps_all <= 0);
+        assert_float_eq!(data_ch[0..min_len], ref_data_ch[0..min_len], ulps_all <= 4);
     }
 }

--- a/src/node/oscillator.rs
+++ b/src/node/oscillator.rs
@@ -1520,12 +1520,12 @@ mod tests {
         assert_float_eq!(
             output.channel_data(0).as_slice(),
             &ref_sine.data[..],
-            ulps_all <= 40
+            ulps_all <= 64
         );
         assert_float_eq!(
             output.channel_data(1).as_slice(),
             &ref_sine.data[..],
-            ulps_all <= 40
+            ulps_all <= 64
         );
     }
 

--- a/src/node/waveshaper.rs
+++ b/src/node/waveshaper.rs
@@ -363,14 +363,14 @@ impl WaveShaperRenderer {
         Self {
             sample_rate,
             oversample,
-            curve,
-            curve_set,
+            channels_x2,
+            channels_x4,
             upsampler_x2,
             upsampler_x4,
             downsampler_x2,
             downsampler_x4,
-            channels_x2,
-            channels_x4,
+            curve,
+            curve_set,
             receiver,
         }
     }

--- a/src/param.rs
+++ b/src/param.rs
@@ -136,11 +136,7 @@ impl AudioProcessor for AudioParamProcessor {
     ) {
         let input = &inputs[0]; // single input mode
 
-        let intrinsic = self.tick(
-            timestamp,
-            1. / sample_rate.0 as f64,
-            crate::BUFFER_SIZE as _,
-        );
+        let intrinsic = self.tick(timestamp, 1. / sample_rate.0 as f64, BUFFER_SIZE);
         let mut buffer = inputs[0].clone(); // get new buf
         buffer.force_mono();
         buffer.channel_data_mut(0).copy_from_slice(intrinsic);
@@ -177,7 +173,7 @@ pub(crate) fn audio_param_pair(
         min_value: opts.min_value,
         max_value: opts.max_value,
         events: BinaryHeap::new(),
-        buffer: Vec::with_capacity(BUFFER_SIZE as usize),
+        buffer: Vec::with_capacity(BUFFER_SIZE),
     };
 
     (param, render)

--- a/tests/media.rs
+++ b/tests/media.rs
@@ -33,7 +33,7 @@ impl Iterator for SlowMedia {
 
         self.value += 1.;
 
-        let channel_data = ChannelData::from(vec![self.value; BUFFER_SIZE as usize]);
+        let channel_data = ChannelData::from(vec![self.value; BUFFER_SIZE]);
         let buffer = AudioBuffer::from_channels(vec![channel_data], self.sample_rate);
 
         Some(Ok(buffer))
@@ -42,8 +42,7 @@ impl Iterator for SlowMedia {
 
 #[test]
 fn test_media_buffering() {
-    const LENGTH: usize = BUFFER_SIZE as usize;
-    let mut context = OfflineAudioContext::new(1, LENGTH, SampleRate(44_100));
+    let mut context = OfflineAudioContext::new(1, BUFFER_SIZE, SampleRate(44_100));
 
     let block = Arc::new(AtomicBool::new(true));
     let finished = Arc::new(AtomicBool::new(false));
@@ -67,7 +66,7 @@ fn test_media_buffering() {
     let output = context.start_rendering();
     assert_float_eq!(
         output.channel_data(0).as_slice(),
-        &[0.; LENGTH][..],
+        &[0.; BUFFER_SIZE][..],
         ulps_all <= 0
     );
 
@@ -78,7 +77,7 @@ fn test_media_buffering() {
     let output = context.start_rendering();
     assert_float_eq!(
         output.channel_data(0).as_slice(),
-        &[2.; LENGTH][..],
+        &[2.; BUFFER_SIZE][..],
         ulps_all <= 0
     );
 
@@ -86,7 +85,7 @@ fn test_media_buffering() {
     let output = context.start_rendering();
     assert_float_eq!(
         output.channel_data(0).as_slice(),
-        &[0.; LENGTH][..],
+        &[0.; BUFFER_SIZE][..],
         ulps_all <= 0
     );
 
@@ -97,7 +96,7 @@ fn test_media_buffering() {
     let output = context.start_rendering();
     assert_float_eq!(
         output.channel_data(0).as_slice(),
-        &[3.; LENGTH][..],
+        &[3.; BUFFER_SIZE][..],
         ulps_all <= 0
     );
 
@@ -109,28 +108,27 @@ fn test_media_buffering() {
     let output = context.start_rendering();
     assert_float_eq!(
         output.channel_data(0).as_slice(),
-        &[2.; LENGTH][..],
+        &[2.; BUFFER_SIZE][..],
         ulps_all <= 0
     );
     let output = context.start_rendering();
     assert_float_eq!(
         output.channel_data(0).as_slice(),
-        &[3.; LENGTH][..],
+        &[3.; BUFFER_SIZE][..],
         ulps_all <= 0
     );
     let output = context.start_rendering();
     assert_float_eq!(
         output.channel_data(0).as_slice(),
-        &[2.; LENGTH][..],
+        &[2.; BUFFER_SIZE][..],
         ulps_all <= 0
     );
 }
 
 #[test]
 fn test_media_seeking() {
-    const LENGTH: usize = BUFFER_SIZE as usize;
-    const SAMPLE_RATE: SampleRate = SampleRate(BUFFER_SIZE); // 1 render quantum = 1 second
-    let mut context = OfflineAudioContext::new(1, LENGTH, SAMPLE_RATE);
+    const SAMPLE_RATE: SampleRate = SampleRate(BUFFER_SIZE as u32); // 1 render quantum = 1 second
+    let mut context = OfflineAudioContext::new(1, BUFFER_SIZE, SAMPLE_RATE);
 
     let block = Arc::new(AtomicBool::new(true));
 
@@ -153,7 +151,7 @@ fn test_media_seeking() {
     let output = context.start_rendering();
     assert_float_eq!(
         output.channel_data(0).as_slice(),
-        &[0.; LENGTH][..],
+        &[0.; BUFFER_SIZE][..],
         ulps_all <= 0
     );
 
@@ -168,7 +166,7 @@ fn test_media_seeking() {
     let output = context.start_rendering();
     assert_float_eq!(
         output.channel_data(0).as_slice(),
-        &[4.; LENGTH][..],
+        &[4.; BUFFER_SIZE][..],
         ulps_all <= 0
     );
 }

--- a/tests/offline.rs
+++ b/tests/offline.rs
@@ -10,10 +10,7 @@ use web_audio_api::{SampleRate, BUFFER_SIZE};
 fn test_offline_render() {
     const LENGTH: usize = 555;
 
-    // not a multiple of BUFFER_SIZE
-    // compute modulo before to avoid clippy::assertions-on-constants errors
-    let modulo = LENGTH % BUFFER_SIZE;
-    assert!(modulo != 0);
+    assert_ne!(LENGTH % BUFFER_SIZE, 0);
 
     let mut context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
     assert_eq!(context.length(), LENGTH);

--- a/tests/offline.rs
+++ b/tests/offline.rs
@@ -11,7 +11,7 @@ fn test_offline_render() {
     const LENGTH: usize = 555;
 
     // not a multiple of BUFFER_SIZE
-    assert!(LENGTH % BUFFER_SIZE as usize != 0);
+    assert!(LENGTH % BUFFER_SIZE != 0);
 
     let mut context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
     assert_eq!(context.length(), LENGTH);
@@ -44,8 +44,8 @@ fn test_offline_render() {
 
 #[test]
 fn test_start_stop() {
-    let len = (BUFFER_SIZE * 4) as usize;
-    let mut context = OfflineAudioContext::new(1, len, SampleRate(BUFFER_SIZE));
+    let len = BUFFER_SIZE * 4;
+    let mut context = OfflineAudioContext::new(1, len, SampleRate(BUFFER_SIZE as u32));
     assert_eq!(context.length(), len);
 
     {
@@ -63,22 +63,22 @@ fn test_start_stop() {
 
     let output = context.start_rendering();
     assert_eq!(output.number_of_channels(), 1);
-    assert_eq!(output.sample_len(), BUFFER_SIZE as usize * 4);
+    assert_eq!(output.sample_len(), BUFFER_SIZE * 4);
 
     let channel_data = output.channel_data(0).as_slice();
 
     // one chunk of silence, two chunks of signal, one chunk of silence
-    let mut expected = vec![0.; BUFFER_SIZE as usize];
-    expected.append(&mut vec![1.; 2 * BUFFER_SIZE as usize]);
-    expected.append(&mut vec![0.; BUFFER_SIZE as usize]);
+    let mut expected = vec![0.; BUFFER_SIZE];
+    expected.append(&mut vec![1.; 2 * BUFFER_SIZE]);
+    expected.append(&mut vec![0.; BUFFER_SIZE]);
 
     assert_eq!(channel_data, expected.as_slice());
 }
 
 #[test]
 fn test_delayed_constant_source() {
-    let len = (BUFFER_SIZE * 4) as usize;
-    let mut context = OfflineAudioContext::new(1, len, SampleRate(BUFFER_SIZE));
+    let len = BUFFER_SIZE * 4;
+    let mut context = OfflineAudioContext::new(1, len, SampleRate(BUFFER_SIZE as u32));
     assert_eq!(context.length(), len);
 
     {
@@ -92,21 +92,20 @@ fn test_delayed_constant_source() {
 
     let output = context.start_rendering();
     assert_eq!(output.number_of_channels(), 1);
-    assert_eq!(output.sample_len(), BUFFER_SIZE as usize * 4);
+    assert_eq!(output.sample_len(), BUFFER_SIZE * 4);
 
     let channel_data = output.channel_data(0).as_slice();
 
     // two chunks of silence, two chunks of signal
-    let mut expected = vec![0.; 2 * BUFFER_SIZE as usize];
-    expected.append(&mut vec![1.; 2 * BUFFER_SIZE as usize]);
+    let mut expected = vec![0.; 2 * BUFFER_SIZE];
+    expected.append(&mut vec![1.; 2 * BUFFER_SIZE]);
 
     assert_eq!(channel_data, expected.as_slice());
 }
 
 #[test]
 fn test_audio_param_graph() {
-    let len = BUFFER_SIZE as usize;
-    let mut context = OfflineAudioContext::new(1, len, SampleRate(BUFFER_SIZE));
+    let mut context = OfflineAudioContext::new(1, BUFFER_SIZE, SampleRate(BUFFER_SIZE as u32));
     {
         let gain = context.create_gain();
         gain.gain().set_value(0.5); // intrinsic value
@@ -127,19 +126,18 @@ fn test_audio_param_graph() {
 
     let output = context.start_rendering();
     assert_eq!(output.number_of_channels(), 1);
-    assert_eq!(output.sample_len(), BUFFER_SIZE as usize);
+    assert_eq!(output.sample_len(), BUFFER_SIZE);
 
     let channel_data = output.channel_data(0).as_slice();
 
     // expect output = 0.8 (input) * ( 0.5 (intrinsic gain) + 0.4 (via 2 constant source input) )
-    let expected = vec![0.8 * 0.9; BUFFER_SIZE as usize];
+    let expected = vec![0.8 * 0.9; BUFFER_SIZE];
     assert_eq!(channel_data, expected.as_slice());
 }
 
 #[test]
 fn test_listener() {
-    let len = BUFFER_SIZE as usize;
-    let mut context = OfflineAudioContext::new(1, len, SampleRate(BUFFER_SIZE));
+    let mut context = OfflineAudioContext::new(1, BUFFER_SIZE, SampleRate(BUFFER_SIZE as u32));
 
     {
         let listener1 = context.listener();
@@ -157,8 +155,7 @@ fn test_listener() {
 
 #[test]
 fn test_cycle() {
-    let len = BUFFER_SIZE as usize;
-    let mut context = OfflineAudioContext::new(1, len, SampleRate(44_100));
+    let mut context = OfflineAudioContext::new(1, BUFFER_SIZE, SampleRate(44_100));
 
     {
         let cycle1 = context.create_gain();
@@ -183,7 +180,7 @@ fn test_cycle() {
     // cycle should be muted, and other source should be processed
     assert_float_eq!(
         output.channel_data(0).as_slice(),
-        &[2.; BUFFER_SIZE as usize][..],
+        &[2.; BUFFER_SIZE][..],
         ulps_all <= 0
     );
 }

--- a/tests/offline.rs
+++ b/tests/offline.rs
@@ -11,7 +11,9 @@ fn test_offline_render() {
     const LENGTH: usize = 555;
 
     // not a multiple of BUFFER_SIZE
-    assert!(LENGTH % BUFFER_SIZE != 0);
+    // compute modulo before to avoid clippy::assertions-on-constants errors
+    let modulo = LENGTH % BUFFER_SIZE;
+    assert!(modulo != 0);
 
     let mut context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
     assert_eq!(context.length(), LENGTH);


### PR DESCRIPTION
Not really sure about these clippy directives, maybe the casting from `usize` to `u32` should be handled in another way (even if I can't see how this could fail):
- [https://github.com/orottier/web-audio-api-rs/compare/main...b-ma:feature/buffer-size?expand=1#diff-76866598ce8fd16261a27ac58a84b2825e6e77fc37c163a6afa60f0f4477e569R142](https://github.com/orottier/web-audio-api-rs/compare/main...b-ma:feature/buffer-size?expand=1#diff-76866598ce8fd16261a27ac58a84b2825e6e77fc37c163a6afa60f0f4477e569R142) 
and 
- [https://github.com/orottier/web-audio-api-rs/compare/main...b-ma:feature/buffer-size?expand=1#diff-76866598ce8fd16261a27ac58a84b2825e6e77fc37c163a6afa60f0f4477e569R460](https://github.com/orottier/web-audio-api-rs/compare/main...b-ma:feature/buffer-size?expand=1#diff-76866598ce8fd16261a27ac58a84b2825e6e77fc37c163a6afa60f0f4477e569R460)

(Besides, I have two tests failling (`node::oscillator::tests::default_sine_rendering_should_match_snapshot` and `node::iir_filter::test::default_periodic_wave_rendering_should_match_snapshot`), I don't think they are related to my changes because they are also failing on the master branch, it seems that the allowed error is too low. I can fill a new issue with more details if it's not something you are already aware of.)