### PR TITLE
replace ULPS with absolute error

### DIFF
--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -497,13 +497,13 @@ mod tests {
                 // take a buffer out of the pool
                 let a = alloc.allocate();
 
-                assert_float_eq!(&a[..], &[0.; BUFFER_SIZE][..], ulps_all <= 0);
+                assert_float_eq!(&a[..], &[0.; BUFFER_SIZE][..], abs_all <= 0.);
                 assert_eq!(alloc.pool_size(), 1);
 
                 // mutating this buffer will not allocate
                 let mut a = a;
                 a.iter_mut().for_each(|v| *v += 1.);
-                assert_float_eq!(&a[..], &[1.; BUFFER_SIZE][..], ulps_all <= 0);
+                assert_float_eq!(&a[..], &[1.; BUFFER_SIZE][..], abs_all <= 0.);
                 assert_eq!(alloc.pool_size(), 1);
 
                 // clone this buffer, should not allocate
@@ -531,9 +531,9 @@ mod tests {
                 });
 
                 // dirty allocations
-                assert_float_eq!(&a[..], &[1.; BUFFER_SIZE][..], ulps_all <= 0);
-                assert_float_eq!(&b[..], &[2.; BUFFER_SIZE][..], ulps_all <= 0);
-                assert_float_eq!(&c[..], &[0.; BUFFER_SIZE][..], ulps_all <= 0);
+                assert_float_eq!(&a[..], &[1.; BUFFER_SIZE][..], abs_all <= 0.);
+                assert_float_eq!(&b[..], &[2.; BUFFER_SIZE][..], abs_all <= 0.);
+                assert_float_eq!(&c[..], &[0.; BUFFER_SIZE][..], abs_all <= 0.);
 
                 c
             };
@@ -557,7 +557,7 @@ mod tests {
                 assert_eq!(alloc.pool_size(), 2);
 
                 // but should be silent, even though a dirty buffer is taken
-                assert_float_eq!(&a_vals[..], &[0.; BUFFER_SIZE][..], ulps_all <= 0);
+                assert_float_eq!(&a_vals[..], &[0.; BUFFER_SIZE][..], abs_all <= 0.);
 
                 // is_silent is a superficial ptr check
                 assert!(!a.is_silent());
@@ -570,23 +570,23 @@ mod tests {
         let alloc = Alloc::with_capacity(1);
         let silence = alloc.silence();
 
-        assert_float_eq!(&silence[..], &[0.; BUFFER_SIZE][..], ulps_all <= 0);
+        assert_float_eq!(&silence[..], &[0.; BUFFER_SIZE][..], abs_all <= 0.);
         assert!(silence.is_silent());
 
         // changing silence is possible
         let mut changed = silence;
         changed.iter_mut().for_each(|v| *v = 1.);
-        assert_float_eq!(&changed[..], &[1.; BUFFER_SIZE][..], ulps_all <= 0);
+        assert_float_eq!(&changed[..], &[1.; BUFFER_SIZE][..], abs_all <= 0.);
         assert!(!changed.is_silent());
 
         // but should not alter new silence
         let silence = alloc.silence();
-        assert_float_eq!(&silence[..], &[0.; BUFFER_SIZE][..], ulps_all <= 0);
+        assert_float_eq!(&silence[..], &[0.; BUFFER_SIZE][..], abs_all <= 0.);
         assert!(silence.is_silent());
 
         // can also create silence from ChannelData
         let from_channel = silence.silence();
-        assert_float_eq!(&from_channel[..], &[0.; BUFFER_SIZE][..], ulps_all <= 0);
+        assert_float_eq!(&from_channel[..], &[0.; BUFFER_SIZE][..], abs_all <= 0.);
         assert!(from_channel.is_silent());
     }
 
@@ -603,16 +603,16 @@ mod tests {
 
         // test add silence to signal
         signal1.add(&silence);
-        assert_float_eq!(&signal1[..], &[1.; BUFFER_SIZE][..], ulps_all <= 0);
+        assert_float_eq!(&signal1[..], &[1.; BUFFER_SIZE][..], abs_all <= 0.);
 
         // test add signal to silence
         let mut silence = alloc.silence();
         silence.add(&signal1);
-        assert_float_eq!(&silence[..], &[1.; BUFFER_SIZE][..], ulps_all <= 0);
+        assert_float_eq!(&silence[..], &[1.; BUFFER_SIZE][..], abs_all <= 0.);
 
         // test add two signals
         signal1.add(&signal2);
-        assert_float_eq!(&signal1[..], &[3.; BUFFER_SIZE][..], ulps_all <= 0);
+        assert_float_eq!(&signal1[..], &[3.; BUFFER_SIZE][..], abs_all <= 0.);
     }
 
     #[test]
@@ -647,7 +647,7 @@ mod tests {
         assert_float_eq!(
             &buffer.channel_data(0)[..],
             &[1.; BUFFER_SIZE][..],
-            ulps_all <= 0
+            abs_all <= 0.
         );
 
         buffer.mix(2, ChannelInterpretation::Discrete);
@@ -657,12 +657,12 @@ mod tests {
         assert_float_eq!(
             &buffer.channel_data(0)[..],
             &[1.; BUFFER_SIZE][..],
-            ulps_all <= 0
+            abs_all <= 0.
         );
         assert_float_eq!(
             &buffer.channel_data(1)[..],
             &[0.; BUFFER_SIZE][..],
-            ulps_all <= 0
+            abs_all <= 0.
         );
 
         buffer.mix(1, ChannelInterpretation::Discrete);
@@ -670,7 +670,7 @@ mod tests {
         assert_float_eq!(
             &buffer.channel_data(0)[..],
             &[1.; BUFFER_SIZE][..],
-            ulps_all <= 0
+            abs_all <= 0.
         );
     }
 
@@ -691,7 +691,7 @@ mod tests {
             assert_float_eq!(
                 &buffer.channel_data(0)[..],
                 &[1.; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
 
             buffer.mix(2, ChannelInterpretation::Speakers);
@@ -701,12 +701,12 @@ mod tests {
             assert_float_eq!(
                 &buffer.channel_data(0)[..],
                 &[1.; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(1)[..],
                 &[1.; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
         }
 
@@ -724,22 +724,22 @@ mod tests {
             assert_float_eq!(
                 &buffer.channel_data(0)[..],
                 &[1.; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(1)[..],
                 &[1.; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(2)[..],
                 &[0.; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(3)[..],
                 &[0.; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
         }
 
@@ -757,32 +757,32 @@ mod tests {
             assert_float_eq!(
                 &buffer.channel_data(0)[..],
                 &[0.; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(1)[..],
                 &[0.; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(2)[..],
                 &[1.; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(3)[..],
                 &[0.; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(4)[..],
                 &[0.; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(5)[..],
                 &[0.; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
         }
 
@@ -800,12 +800,12 @@ mod tests {
             assert_float_eq!(
                 &buffer.channel_data(0)[..],
                 &[1.; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(1)[..],
                 &[0.5; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
 
             buffer.mix(4, ChannelInterpretation::Speakers);
@@ -813,22 +813,22 @@ mod tests {
             assert_float_eq!(
                 &buffer.channel_data(0)[..],
                 &[1.; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(1)[..],
                 &[0.5; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(2)[..],
                 &[0.; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(3)[..],
                 &[0.; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
         }
 
@@ -846,12 +846,12 @@ mod tests {
             assert_float_eq!(
                 &buffer.channel_data(0)[..],
                 &[1.; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(1)[..],
                 &[0.5; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
 
             buffer.mix(6, ChannelInterpretation::Speakers);
@@ -859,32 +859,32 @@ mod tests {
             assert_float_eq!(
                 &buffer.channel_data(0)[..],
                 &[1.; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(1)[..],
                 &[0.5; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(2)[..],
                 &[0.; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(3)[..],
                 &[0.; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(4)[..],
                 &[0.; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(5)[..],
                 &[0.; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
         }
 
@@ -908,22 +908,22 @@ mod tests {
             assert_float_eq!(
                 &buffer.channel_data(0)[..],
                 &[0.25; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(1)[..],
                 &[0.5; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(2)[..],
                 &[0.75; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(3)[..],
                 &[1.; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
 
             buffer.mix(6, ChannelInterpretation::Speakers);
@@ -931,32 +931,32 @@ mod tests {
             assert_float_eq!(
                 &buffer.channel_data(0)[..],
                 &[0.25; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(1)[..],
                 &[0.5; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(2)[..],
                 &[0.; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(3)[..],
                 &[0.; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(4)[..],
                 &[0.75; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(5)[..],
                 &[1.; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
         }
     }
@@ -979,12 +979,12 @@ mod tests {
             assert_float_eq!(
                 &buffer.channel_data(0)[..],
                 &[1.; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(1)[..],
                 &[0.5; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
 
             buffer.mix(1, ChannelInterpretation::Speakers);
@@ -992,7 +992,7 @@ mod tests {
             assert_float_eq!(
                 &buffer.channel_data(0)[..],
                 &[0.75; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
         }
 
@@ -1016,22 +1016,22 @@ mod tests {
             assert_float_eq!(
                 &buffer.channel_data(0)[..],
                 &[1.; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(1)[..],
                 &[0.75; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(2)[..],
                 &[0.5; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(3)[..],
                 &[0.25; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
 
             buffer.mix(1, ChannelInterpretation::Speakers);
@@ -1039,7 +1039,7 @@ mod tests {
             assert_float_eq!(
                 &buffer.channel_data(0)[..],
                 &[0.625; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
         }
 
@@ -1069,32 +1069,32 @@ mod tests {
             assert_float_eq!(
                 &buffer.channel_data(0)[..],
                 &[1.; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(1)[..],
                 &[0.9; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(2)[..],
                 &[0.8; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(3)[..],
                 &[0.7; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(4)[..],
                 &[0.6; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(5)[..],
                 &[0.5; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
 
             buffer.mix(1, ChannelInterpretation::Speakers);
@@ -1104,7 +1104,7 @@ mod tests {
             assert_float_eq!(
                 &buffer.channel_data(0)[..],
                 &[res; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
         }
 
@@ -1128,22 +1128,22 @@ mod tests {
             assert_float_eq!(
                 &buffer.channel_data(0)[..],
                 &[0.25; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(1)[..],
                 &[0.5; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(2)[..],
                 &[0.75; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(3)[..],
                 &[1.; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
 
             buffer.mix(2, ChannelInterpretation::Speakers);
@@ -1151,12 +1151,12 @@ mod tests {
             assert_float_eq!(
                 &buffer.channel_data(0)[..],
                 &[0.5; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(1)[..],
                 &[0.75; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
         }
 
@@ -1186,32 +1186,32 @@ mod tests {
             assert_float_eq!(
                 &buffer.channel_data(0)[..],
                 &[1.; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(1)[..],
                 &[0.9; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(2)[..],
                 &[0.8; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(3)[..],
                 &[0.7; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(4)[..],
                 &[0.6; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(5)[..],
                 &[0.5; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
 
             buffer.mix(2, ChannelInterpretation::Speakers);
@@ -1222,12 +1222,12 @@ mod tests {
             assert_float_eq!(
                 &buffer.channel_data(0)[..],
                 &[res_left; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(1)[..],
                 &[res_right; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
         }
 
@@ -1257,32 +1257,32 @@ mod tests {
             assert_float_eq!(
                 &buffer.channel_data(0)[..],
                 &[1.; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(1)[..],
                 &[0.9; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(2)[..],
                 &[0.8; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(3)[..],
                 &[0.7; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(4)[..],
                 &[0.6; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(5)[..],
                 &[0.5; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
 
             buffer.mix(4, ChannelInterpretation::Speakers);
@@ -1293,22 +1293,22 @@ mod tests {
             assert_float_eq!(
                 &buffer.channel_data(0)[..],
                 &[res_left; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(1)[..],
                 &[res_right; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(2)[..],
                 &[0.6; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
             assert_float_eq!(
                 &buffer.channel_data(3)[..],
                 &[0.5; BUFFER_SIZE][..],
-                ulps_all <= 0
+                abs_all <= 0.
             );
         }
     }
@@ -1332,12 +1332,12 @@ mod tests {
         assert_float_eq!(
             &buffer.channel_data(0)[..],
             &[3.; BUFFER_SIZE][..],
-            ulps_all <= 0
+            abs_all <= 0.
         );
         assert_float_eq!(
             &buffer.channel_data(1)[..],
             &[1.; BUFFER_SIZE][..],
-            ulps_all <= 0
+            abs_all <= 0.
         );
     }
 }

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -235,7 +235,7 @@ mod tests {
 
         // get data, should be padded with zeroes
         analyser.get_float_time(&mut buffer[..], LEN * 5);
-        assert_float_eq!(&buffer[..], &[0.; 5 * LEN][..], ulps_all <= 0);
+        assert_float_eq!(&buffer[..], &[0.; 5 * LEN][..], abs_all <= 0.);
 
         // feed data for more than 256 times (the ring buffer size)
         for i in 0..258 {
@@ -249,18 +249,18 @@ mod tests {
         analyser.get_float_time(&mut buffer[..], LEN * 4);
 
         // taken from the end of the ring buffer
-        assert_float_eq!(&buffer[0..LEN], &[254.; LEN][..], ulps_all <= 0);
-        assert_float_eq!(&buffer[LEN..2 * LEN], &[255.; LEN][..], ulps_all <= 0);
+        assert_float_eq!(&buffer[0..LEN], &[254.; LEN][..], abs_all <= 0.);
+        assert_float_eq!(&buffer[LEN..2 * LEN], &[255.; LEN][..], abs_all <= 0.);
         // taken from the start of the ring buffer
-        assert_float_eq!(&buffer[2 * LEN..3 * LEN], &[256.; LEN][..], ulps_all <= 0);
-        assert_float_eq!(&buffer[3 * LEN..4 * LEN], &[257.; LEN][..], ulps_all <= 0);
+        assert_float_eq!(&buffer[2 * LEN..3 * LEN], &[256.; LEN][..], abs_all <= 0.);
+        assert_float_eq!(&buffer[3 * LEN..4 * LEN], &[257.; LEN][..], abs_all <= 0.);
         // excess capacity should be left unaltered
-        assert_float_eq!(&buffer[4 * LEN..5 * LEN], &[0.; LEN][..], ulps_all <= 0);
+        assert_float_eq!(&buffer[4 * LEN..5 * LEN], &[0.; LEN][..], abs_all <= 0.);
 
         // check for small fft_size
         buffer.resize(32, 0.);
         analyser.get_float_time(&mut buffer[..], LEN);
-        assert_float_eq!(&buffer[..], &[257.; 32][..], ulps_all <= 0);
+        assert_float_eq!(&buffer[..], &[257.; 32][..], abs_all <= 0.);
     }
 
     #[test]
@@ -305,7 +305,7 @@ mod tests {
         assert_float_eq!(
             &buffer[2 * LEN + 1..],
             &[-1.; 2 * LEN - 1][..],
-            ulps_all <= 0
+            abs_all <= 0.
         );
 
         // feed data for more than 256 times (the ring buffer size)
@@ -337,11 +337,11 @@ mod tests {
 
         let min_pos = values
             .iter()
-            .position(|&v| float_eq!(v, min, ulps_all <= 0))
+            .position(|&v| float_eq!(v, min, abs_all <= 0.))
             .unwrap();
         let max_pos = values
             .iter()
-            .position(|&v| float_eq!(v, max, ulps_all <= 0))
+            .position(|&v| float_eq!(v, max, abs_all <= 0.))
             .unwrap();
         assert_eq!(min_pos, 0);
         assert_eq!(max_pos, 1024);

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -485,8 +485,8 @@ mod tests {
         assert_eq!(b.sample_len(), 10);
         assert_eq!(b.number_of_channels(), 2);
         assert_eq!(b.sample_rate().0, 44_100);
-        assert_float_eq!(b.channel_data(0).as_slice(), &[0.; 10][..], ulps_all <= 0);
-        assert_float_eq!(b.channel_data(1).as_slice(), &[0.; 10][..], ulps_all <= 0);
+        assert_float_eq!(b.channel_data(0).as_slice(), &[0.; 10][..], abs_all <= 0.);
+        assert_float_eq!(b.channel_data(1).as_slice(), &[0.; 10][..], abs_all <= 0.);
         assert_eq!(b.channels().get(2), None);
     }
 
@@ -511,19 +511,19 @@ mod tests {
         assert_float_eq!(
             b1.channel_data(0).as_slice(),
             &[0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 1., 1., 1., 1., 1.][..],
-            ulps_all <= 0
+            abs_all <= 0.
         );
 
         let split = b1.split(8);
         assert_float_eq!(
             split[0].channel_data(0).as_slice(),
             &[0., 0., 0., 0., 0., 0., 0., 0.][..],
-            ulps_all <= 0
+            abs_all <= 0.
         );
         assert_float_eq!(
             split[1].channel_data(0).as_slice(),
             &[0., 0., 1., 1., 1., 1., 1.][..],
-            ulps_all <= 0
+            abs_all <= 0.
         );
     }
 
@@ -535,7 +535,7 @@ mod tests {
         assert_float_eq!(
             buffer.channel_data(0).as_slice(),
             &[1., 1., 2., 2., 3., 3., 4., 4., 5., 5.,][..],
-            ulps_all <= 0
+            abs_all <= 0.
         );
         assert_eq!(buffer.sample_rate().0, 200);
     }
@@ -548,7 +548,7 @@ mod tests {
         assert_float_eq!(
             buffer.channel_data(0).as_slice(),
             &[2., 4.][..],
-            ulps_all <= 0
+            abs_all <= 0.
         );
         assert_eq!(buffer.sample_rate().0, 100);
     }
@@ -565,7 +565,7 @@ mod tests {
         assert_float_eq!(
             next.channel_data(0).as_slice(),
             &[1., 2., 3., 4., 5., 1., 2., 3., 4., 5.,][..],
-            ulps_all <= 0
+            abs_all <= 0.
         );
 
         let next = resampler.next().unwrap().unwrap();
@@ -573,7 +573,7 @@ mod tests {
         assert_float_eq!(
             next.channel_data(0).as_slice(),
             &[1., 2., 3., 4., 5., 0., 0., 0., 0., 0.][..],
-            ulps_all <= 0
+            abs_all <= 0.
         );
 
         assert!(resampler.next().is_none());
@@ -594,7 +594,7 @@ mod tests {
         assert_float_eq!(
             next.channel_data(0).as_slice(),
             &[1., 2., 3., 4., 5.][..],
-            ulps_all <= 0
+            abs_all <= 0.
         );
 
         let next = resampler.next().unwrap().unwrap();
@@ -602,7 +602,7 @@ mod tests {
         assert_float_eq!(
             next.channel_data(0).as_slice(),
             &[6., 7., 8., 9., 10.][..],
-            ulps_all <= 0
+            abs_all <= 0.
         );
 
         assert!(resampler.next().is_none());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,13 +133,13 @@ mod tests {
     #[test]
     fn test_atomic_f64() {
         let f = AtomicF64::new(2.0);
-        assert_float_eq!(f.load(), 2.0, ulps <= 0);
+        assert_float_eq!(f.load(), 2.0, abs <= 0.);
 
         f.store(3.0);
-        assert_float_eq!(f.load(), 3.0, ulps <= 0);
+        assert_float_eq!(f.load(), 3.0, abs <= 0.);
 
         let prev = f.swap(4.0);
-        assert_float_eq!(prev, 3.0, ulps <= 0);
-        assert_float_eq!(f.load(), 4.0, ulps <= 0);
+        assert_float_eq!(prev, 3.0, abs <= 0.);
+        assert_float_eq!(f.load(), 4.0, abs <= 0.);
     }
 }

--- a/src/node/biquad_filter.rs
+++ b/src/node/biquad_filter.rs
@@ -1142,10 +1142,10 @@ mod test {
 
         context.start_rendering();
 
-        assert_float_eq!(biquad.q().value(), default_q, ulps <= 0);
-        assert_float_eq!(biquad.detune().value(), default_detune, ulps <= 0);
-        assert_float_eq!(biquad.gain().value(), default_gain, ulps <= 0);
-        assert_float_eq!(biquad.frequency().value(), default_freq, ulps <= 0);
+        assert_float_eq!(biquad.q().value(), default_q, abs <= 0.);
+        assert_float_eq!(biquad.detune().value(), default_detune, abs <= 0.);
+        assert_float_eq!(biquad.gain().value(), default_gain, abs <= 0.);
+        assert_float_eq!(biquad.frequency().value(), default_freq, abs <= 0.);
         assert_eq!(biquad.type_(), default_type);
     }
 
@@ -1170,10 +1170,10 @@ mod test {
 
         context.start_rendering();
 
-        assert_float_eq!(biquad.q().value(), default_q, ulps <= 0);
-        assert_float_eq!(biquad.detune().value(), default_detune, ulps <= 0);
-        assert_float_eq!(biquad.gain().value(), default_gain, ulps <= 0);
-        assert_float_eq!(biquad.frequency().value(), default_freq, ulps <= 0);
+        assert_float_eq!(biquad.q().value(), default_q, abs <= 0.);
+        assert_float_eq!(biquad.detune().value(), default_detune, abs <= 0.);
+        assert_float_eq!(biquad.gain().value(), default_gain, abs <= 0.);
+        assert_float_eq!(biquad.frequency().value(), default_freq, abs <= 0.);
         assert_eq!(biquad.type_(), default_type);
     }
 
@@ -1192,10 +1192,10 @@ mod test {
 
         context.start_rendering();
 
-        assert_float_eq!(biquad.q().value(), default_q, ulps <= 0);
-        assert_float_eq!(biquad.detune().value(), default_detune, ulps <= 0);
-        assert_float_eq!(biquad.gain().value(), default_gain, ulps <= 0);
-        assert_float_eq!(biquad.frequency().value(), default_freq, ulps <= 0);
+        assert_float_eq!(biquad.q().value(), default_q, abs <= 0.);
+        assert_float_eq!(biquad.detune().value(), default_detune, abs <= 0.);
+        assert_float_eq!(biquad.gain().value(), default_gain, abs <= 0.);
+        assert_float_eq!(biquad.frequency().value(), default_freq, abs <= 0.);
         assert_eq!(biquad.type_(), default_type);
     }
 
@@ -1221,10 +1221,10 @@ mod test {
 
         context.start_rendering();
 
-        assert_float_eq!(biquad.q().value(), q, ulps <= 0);
-        assert_float_eq!(biquad.detune().value(), detune, ulps <= 0);
-        assert_float_eq!(biquad.gain().value(), gain, ulps <= 0);
-        assert_float_eq!(biquad.frequency().value(), frequency, ulps <= 0);
+        assert_float_eq!(biquad.q().value(), q, abs <= 0.);
+        assert_float_eq!(biquad.detune().value(), detune, abs <= 0.);
+        assert_float_eq!(biquad.gain().value(), gain, abs <= 0.);
+        assert_float_eq!(biquad.frequency().value(), frequency, abs <= 0.);
         assert_eq!(biquad.type_(), type_);
     }
 
@@ -1247,10 +1247,10 @@ mod test {
 
         context.start_rendering();
 
-        assert_float_eq!(biquad.q().value(), q, ulps <= 0);
-        assert_float_eq!(biquad.detune().value(), detune, ulps <= 0);
-        assert_float_eq!(biquad.gain().value(), gain, ulps <= 0);
-        assert_float_eq!(biquad.frequency().value(), frequency, ulps <= 0);
+        assert_float_eq!(biquad.q().value(), q, abs <= 0.);
+        assert_float_eq!(biquad.detune().value(), detune, abs <= 0.);
+        assert_float_eq!(biquad.gain().value(), gain, abs <= 0.);
+        assert_float_eq!(biquad.frequency().value(), frequency, abs <= 0.);
         assert_eq!(biquad.type_(), type_);
     }
 

--- a/src/node/biquad_filter.rs
+++ b/src/node/biquad_filter.rs
@@ -1299,6 +1299,6 @@ mod test {
         );
 
         let ref_arr = [0., niquyst];
-        assert_float_eq!(frequency_hz, ref_arr, ulps_all <= 0);
+        assert_float_eq!(frequency_hz, ref_arr, abs_all <= 0.);
     }
 }

--- a/src/node/iir_filter.rs
+++ b/src/node/iir_filter.rs
@@ -547,7 +547,7 @@ mod test {
         iir.get_frequency_response(&mut frequency_hz, &mut mag_response, &mut phase_response);
 
         let ref_arr = [0., niquyst];
-        assert_float_eq!(frequency_hz, ref_arr, ulps_all <= 0);
+        assert_float_eq!(frequency_hz, ref_arr, abs_all <= 0.);
     }
 
     #[test]
@@ -590,7 +590,7 @@ mod test {
 
         iir.get_frequency_response(&mut frequency_hz, &mut mag_response, &mut phase_response);
 
-        assert_float_eq!(mag_response, ref_mag, ulps_all <= 0);
+        assert_float_eq!(mag_response, ref_mag, abs_all <= 0.);
     }
 
     #[test]
@@ -647,6 +647,6 @@ mod test {
 
         let min_len = min(data_ch.len(), ref_data_ch.len());
 
-        assert_float_eq!(data_ch[0..min_len], ref_data_ch[0..min_len], ulps_all <= 0);
+        assert_float_eq!(data_ch[0..min_len], ref_data_ch[0..min_len], abs_all <= 0.);
     }
 }

--- a/src/node/oscillator.rs
+++ b/src/node/oscillator.rs
@@ -1520,12 +1520,12 @@ mod tests {
         assert_float_eq!(
             output.channel_data(0).as_slice(),
             &ref_sine.data[..],
-            ulps_all <= 40
+            abs_all <= 1.0e-10
         );
         assert_float_eq!(
             output.channel_data(1).as_slice(),
             &ref_sine.data[..],
-            ulps_all <= 40
+            abs_all <= 1.0e-10
         );
     }
 
@@ -1546,12 +1546,12 @@ mod tests {
         assert_float_eq!(
             output.channel_data(0).as_slice(),
             &ref_sine.data[..],
-            ulps_all <= 40
+            abs_all <= 1.0e-10
         );
         assert_float_eq!(
             output.channel_data(1).as_slice(),
             &ref_sine.data[..],
-            ulps_all <= 40
+            abs_all <= 1.0e-10
         );
     }
 
@@ -1572,12 +1572,12 @@ mod tests {
         assert_float_eq!(
             output.channel_data(0).as_slice(),
             &ref_sine.data[..],
-            ulps_all <= 40
+            abs_all <= 1.0e-10
         );
         assert_float_eq!(
             output.channel_data(1).as_slice(),
             &ref_sine.data[..],
-            ulps_all <= 40
+            abs_all <= 1.0e-10
         );
     }
 
@@ -1598,12 +1598,12 @@ mod tests {
         assert_float_eq!(
             output.channel_data(0).as_slice(),
             &ref_sine.data[..],
-            ulps_all <= 40
+            abs_all <= 1.0e-10
         );
         assert_float_eq!(
             output.channel_data(1).as_slice(),
             &ref_sine.data[..],
-            ulps_all <= 40
+            abs_all <= 1.0e-10
         );
     }
 
@@ -1637,12 +1637,12 @@ mod tests {
         assert_float_eq!(
             output.channel_data(0).as_slice(),
             &ref_sine.data[..],
-            ulps_all <= 40
+            abs_all <= 1.0e-10
         );
         assert_float_eq!(
             output.channel_data(1).as_slice(),
             &ref_sine.data[..],
-            ulps_all <= 40
+            abs_all <= 1.0e-10
         );
     }
 
@@ -1676,12 +1676,12 @@ mod tests {
         assert_float_eq!(
             output.channel_data(0).as_slice(),
             &ref_sine.data[..],
-            ulps_all <= 40
+            abs_all <= 1.0e-10
         );
         assert_float_eq!(
             output.channel_data(1).as_slice(),
             &ref_sine.data[..],
-            ulps_all <= 40
+            abs_all <= 1.0e-10
         );
     }
 }

--- a/src/node/oscillator.rs
+++ b/src/node/oscillator.rs
@@ -1374,8 +1374,8 @@ mod tests {
         let periodic_wave = PeriodicWave::new(&context, Some(options));
 
         // the default has to be a sine signal
-        assert_float_eq!(periodic_wave.real, vec![0., 1.], ulps_all <= 0);
-        assert_float_eq!(periodic_wave.imag, vec![0., 0.], ulps_all <= 0);
+        assert_float_eq!(periodic_wave.real, vec![0., 1.], abs_all <= 0.);
+        assert_float_eq!(periodic_wave.imag, vec![0., 0.], abs_all <= 0.);
         assert!(!periodic_wave.disable_normalization);
     }
 
@@ -1390,10 +1390,10 @@ mod tests {
         let osc = context.create_oscillator();
 
         let freq = osc.frequency.value();
-        assert_float_eq!(freq, default_freq, ulps_all <= 0);
+        assert_float_eq!(freq, default_freq, abs_all <= 0.);
 
         let det = osc.detune.value();
-        assert_float_eq!(det, default_det, ulps_all <= 0);
+        assert_float_eq!(det, default_det, abs_all <= 0.);
 
         let type_ = osc.type_.load(std::sync::atomic::Ordering::SeqCst);
         assert_eq!(type_, default_type as u32);
@@ -1410,10 +1410,10 @@ mod tests {
         let osc = OscillatorNode::new(&context, None);
 
         let freq = osc.frequency.value();
-        assert_float_eq!(freq, default_freq, ulps_all <= 0);
+        assert_float_eq!(freq, default_freq, abs_all <= 0.);
 
         let det = osc.detune.value();
-        assert_float_eq!(det, default_det, ulps_all <= 0);
+        assert_float_eq!(det, default_det, abs_all <= 0.);
 
         let type_ = osc.type_.load(std::sync::atomic::Ordering::SeqCst);
         assert_eq!(type_, default_type as u32);
@@ -1494,12 +1494,12 @@ mod tests {
         assert_float_eq!(
             output.channel_data(0).as_slice(),
             &[0.; LENGTH][..],
-            ulps_all <= 0
+            abs_all <= 0.
         );
         assert_float_eq!(
             output.channel_data(1).as_slice(),
             &[0.; LENGTH][..],
-            ulps_all <= 0
+            abs_all <= 0.
         );
     }
 

--- a/src/node/stereo_panner.rs
+++ b/src/node/stereo_panner.rs
@@ -331,7 +331,7 @@ mod test {
         // 0.00001 corresponds to a reduction of -100 dB, so even if the gain is not exactly 0.
         // it should not be audible
         assert_float_eq!(i_l, 0.0, abs <= 0.00001);
-        assert_float_eq!(i_r, 2.0, ulps <= 0);
+        assert_float_eq!(i_r, 2.0, abs <= 0.);
     }
 
     #[test]
@@ -340,8 +340,8 @@ mod test {
 
         let (i_l, i_r) = StereoPannerRenderer::stereo_tick((1., 1.), pan);
 
-        assert_float_eq!(i_l, 2.0, ulps <= 0);
-        assert_float_eq!(i_r, 0.0, ulps <= 0);
+        assert_float_eq!(i_l, 2.0, abs <= 0.);
+        assert_float_eq!(i_r, 0.0, abs <= 0.);
     }
 
     #[test]
@@ -354,7 +354,7 @@ mod test {
         // to compute the panning gains
         // 0.1 corresponds to a difference of < 1 dB, so it should not be audible
         assert_float_eq!(i_l, 1.0, abs <= 0.1);
-        assert_float_eq!(i_r, 1.0, ulps <= 0);
+        assert_float_eq!(i_r, 1.0, abs <= 0.);
     }
 
     #[test]

--- a/src/node/stereo_panner.rs
+++ b/src/node/stereo_panner.rs
@@ -298,7 +298,7 @@ mod test {
         context.start_rendering();
 
         let pan = panner.pan.value();
-        assert_float_eq!(pan, default_pan, ulps_all <= 0);
+        assert_float_eq!(pan, default_pan, abs_all <= 0.);
     }
 
     #[test]
@@ -311,13 +311,13 @@ mod test {
         let panner = StereoPannerNode::new(&context, None);
 
         let pan = panner.pan.value();
-        assert_float_eq!(pan, default_pan, ulps_all <= 0);
+        assert_float_eq!(pan, default_pan, abs_all <= 0.);
         panner.pan().set_value(new_pan);
 
         context.start_rendering();
 
         let pan = panner.pan.value();
-        assert_float_eq!(pan, new_pan, ulps_all <= 0);
+        assert_float_eq!(pan, new_pan, abs_all <= 0.);
     }
 
     #[test]
@@ -368,13 +368,13 @@ mod test {
         let panner = StereoPannerNode::new(&context, None);
 
         let pan = panner.pan.value();
-        assert_float_eq!(pan, default_pan, ulps_all <= 0);
+        assert_float_eq!(pan, default_pan, abs_all <= 0.);
         panner.pan().set_value(new_pan);
 
         context.start_rendering();
 
         let pan = panner.pan.value();
-        assert_float_eq!(pan, new_pan, ulps_all <= 0);
+        assert_float_eq!(pan, new_pan, abs_all <= 0.);
     }
 
     #[test]
@@ -388,12 +388,12 @@ mod test {
         let panner = StereoPannerNode::new(&context, None);
 
         let pan = panner.pan.value();
-        assert_float_eq!(pan, default_pan, ulps_all <= 0);
+        assert_float_eq!(pan, default_pan, abs_all <= 0.);
         panner.pan().set_value(new_pan);
 
         context.start_rendering();
 
         let pan = panner.pan.value();
-        assert_float_eq!(pan, new_pan, ulps_all <= 0);
+        assert_float_eq!(pan, new_pan, abs_all <= 0.);
     }
 }

--- a/src/param.rs
+++ b/src/param.rs
@@ -360,11 +360,11 @@ mod tests {
         assert_float_eq!(
             vs,
             &[0., 0., 5., 5., 5., 5., 5., 5., 10., 10.][..],
-            ulps_all <= 0
+            abs_all <= 0.
         );
 
         let vs = render.tick(10., 1., 10);
-        assert_float_eq!(vs, &[8.; 10][..], ulps_all <= 0);
+        assert_float_eq!(vs, &[8.; 10][..], abs_all <= 0.);
     }
 
     #[test]
@@ -383,10 +383,10 @@ mod tests {
         param.set_value_at_time_direct(8., 10.0); // should not occur 1st run
 
         let vs = render.tick(0., 1., 10);
-        assert_float_eq!(vs, &[0.; 10][..], ulps_all <= 0);
+        assert_float_eq!(vs, &[0.; 10][..], abs_all <= 0.);
 
         let vs = render.tick(10., 1., 10);
-        assert_float_eq!(vs, &[8.; 10][..], ulps_all <= 0);
+        assert_float_eq!(vs, &[8.; 10][..], abs_all <= 0.);
     }
 
     #[test]
@@ -412,7 +412,7 @@ mod tests {
         assert_float_eq!(
             vs,
             &[0., 0., 5., 6., 7., 8., 7., 6., 5., 4.][..],
-            ulps_all <= 0
+            abs_all <= 0.
         );
     }
 
@@ -437,7 +437,7 @@ mod tests {
         assert_float_eq!(
             vs,
             &[0., 1., 2., 3., 4., 5., 6., 7., 8., 9.][..],
-            ulps_all <= 0
+            abs_all <= 0.
         );
 
         // next quantum t = 10..20
@@ -445,12 +445,12 @@ mod tests {
         assert_float_eq!(
             vs,
             &[10., 11., 12., 13., 14., 15., 16., 17., 18., 19.][..],
-            ulps_all <= 0
+            abs_all <= 0.
         );
 
         // ramp finished t = 20..30
         let vs = render.tick(20., 1., 10);
-        assert_float_eq!(vs, &[20.0; 10][..], ulps_all <= 0);
+        assert_float_eq!(vs, &[20.0; 10][..], abs_all <= 0.);
     }
 
     #[test]
@@ -474,7 +474,7 @@ mod tests {
         assert_float_eq!(
             vs,
             &[0., 1., 1., 1., 1., 1., 1., 1., 1., 1.][..],
-            ulps_all <= 0
+            abs_all <= 0.
         );
     }
 }

--- a/src/spatial.rs
+++ b/src/spatial.rs
@@ -357,12 +357,12 @@ mod tests {
     fn azimuth_elevation_vertical() {
         let pos = [0., -10., 0.];
         let (azimuth, elevation) = azimuth_and_elevation(pos, LP, LF, LU);
-        assert_float_eq!(azimuth, 0., ulps <= 1);
+        assert_float_eq!(azimuth, 0., abs <= 0.001);
         assert_float_eq!(elevation, -90., abs <= 0.001);
 
         let pos = [0., 10., 0.];
         let (azimuth, elevation) = azimuth_and_elevation(pos, LP, LF, LU);
-        assert_float_eq!(azimuth, 0., ulps <= 1);
+        assert_float_eq!(azimuth, 0., abs <= 0.001);
         assert_float_eq!(elevation, 90., abs <= 0.001);
     }
 }

--- a/src/spatial.rs
+++ b/src/spatial.rs
@@ -324,8 +324,8 @@ mod tests {
         let pos = [0., 0., 0.];
         let (azimuth, elevation) = azimuth_and_elevation(pos, LP, LF, LU);
 
-        assert_float_eq!(azimuth, 0., ulps <= 0);
-        assert_float_eq!(elevation, 0., ulps <= 0);
+        assert_float_eq!(azimuth, 0., abs <= 0.);
+        assert_float_eq!(elevation, 0., abs <= 0.);
     }
 
     #[test]
@@ -335,22 +335,22 @@ mod tests {
         let pos = [10., 0., 0.];
         let (azimuth, elevation) = azimuth_and_elevation(pos, LP, LF, LU);
         assert_float_eq!(azimuth, 90., abs <= 0.001);
-        assert_float_eq!(elevation, 0., ulps <= 0);
+        assert_float_eq!(elevation, 0., abs <= 0.);
 
         let pos = [-10., 0., 0.];
         let (azimuth, elevation) = azimuth_and_elevation(pos, LP, LF, LU);
         assert_float_eq!(azimuth, -90., abs <= 0.001);
-        assert_float_eq!(elevation, 0., ulps <= 0);
+        assert_float_eq!(elevation, 0., abs <= 0.);
 
         let pos = [10., 0., -10.];
         let (azimuth, elevation) = azimuth_and_elevation(pos, LP, LF, LU);
         assert_float_eq!(azimuth, 45., abs <= 0.001);
-        assert_float_eq!(elevation, 0., ulps <= 0);
+        assert_float_eq!(elevation, 0., abs <= 0.);
 
         let pos = [-10., 0., -10.];
         let (azimuth, elevation) = azimuth_and_elevation(pos, LP, LF, LU);
         assert_float_eq!(azimuth, -45., abs <= 0.001);
-        assert_float_eq!(elevation, 0., ulps <= 0);
+        assert_float_eq!(elevation, 0., abs <= 0.);
     }
 
     #[test]

--- a/tests/media.rs
+++ b/tests/media.rs
@@ -68,7 +68,7 @@ fn test_media_buffering() {
     assert_float_eq!(
         output.channel_data(0).as_slice(),
         &[0.; LENGTH][..],
-        ulps_all <= 0
+        abs_all <= 0.
     );
 
     block.store(false, Ordering::SeqCst); // emit single chunk
@@ -79,7 +79,7 @@ fn test_media_buffering() {
     assert_float_eq!(
         output.channel_data(0).as_slice(),
         &[2.; LENGTH][..],
-        ulps_all <= 0
+        abs_all <= 0.
     );
 
     // should be silent since the media stream did not yield any output
@@ -87,7 +87,7 @@ fn test_media_buffering() {
     assert_float_eq!(
         output.channel_data(0).as_slice(),
         &[0.; LENGTH][..],
-        ulps_all <= 0
+        abs_all <= 0.
     );
 
     block.store(false, Ordering::SeqCst); // emit single chunk
@@ -98,7 +98,7 @@ fn test_media_buffering() {
     assert_float_eq!(
         output.channel_data(0).as_slice(),
         &[3.; LENGTH][..],
-        ulps_all <= 0
+        abs_all <= 0.
     );
 
     finished.store(true, Ordering::SeqCst); // signal stream ended
@@ -110,19 +110,19 @@ fn test_media_buffering() {
     assert_float_eq!(
         output.channel_data(0).as_slice(),
         &[2.; LENGTH][..],
-        ulps_all <= 0
+        abs_all <= 0.
     );
     let output = context.start_rendering();
     assert_float_eq!(
         output.channel_data(0).as_slice(),
         &[3.; LENGTH][..],
-        ulps_all <= 0
+        abs_all <= 0.
     );
     let output = context.start_rendering();
     assert_float_eq!(
         output.channel_data(0).as_slice(),
         &[2.; LENGTH][..],
-        ulps_all <= 0
+        abs_all <= 0.
     );
 }
 
@@ -154,7 +154,7 @@ fn test_media_seeking() {
     assert_float_eq!(
         output.channel_data(0).as_slice(),
         &[0.; LENGTH][..],
-        ulps_all <= 0
+        abs_all <= 0.
     );
 
     block.store(false, Ordering::SeqCst); // emit single chunk
@@ -169,6 +169,6 @@ fn test_media_seeking() {
     assert_float_eq!(
         output.channel_data(0).as_slice(),
         &[4.; LENGTH][..],
-        ulps_all <= 0
+        abs_all <= 0.
     );
 }

--- a/tests/offline.rs
+++ b/tests/offline.rs
@@ -33,12 +33,12 @@ fn test_offline_render() {
     assert_float_eq!(
         output.channel_data(0).as_slice(),
         &[-2.; LENGTH][..],
-        ulps_all <= 0
+        abs_all <= 0.
     );
     assert_float_eq!(
         output.channel_data(1).as_slice(),
         &[-2.; LENGTH][..],
-        ulps_all <= 0
+        abs_all <= 0.
     );
 }
 
@@ -184,6 +184,6 @@ fn test_cycle() {
     assert_float_eq!(
         output.channel_data(0).as_slice(),
         &[2.; BUFFER_SIZE as usize][..],
-        ulps_all <= 0
+        abs_all <= 0.
     );
 }

--- a/tests/offline.rs
+++ b/tests/offline.rs
@@ -151,8 +151,8 @@ fn test_listener() {
     let _ = context.start_rendering();
 
     let listener = context.listener();
-    assert_float_eq!(listener.position_y().value(), 2., ulps <= 0);
-    assert_float_eq!(listener.position_x().value(), 1., ulps <= 0);
+    assert_float_eq!(listener.position_y().value(), 2., abs <= 0.);
+    assert_float_eq!(listener.position_x().value(), 1., abs <= 0.);
 }
 
 #[test]


### PR DESCRIPTION
Remove all ULPS
- 0 ULPS -> 0. absolute error
- [sound] 40 ULPS -> 1.0e-10 absolute error (correspond to 200 db audio dynamic)
- [angle] 1 ULPS -> 0.001 absolute error (minimum audible angle is about 1-3 degrees) 

related to #53 