### PR TITLE
Support cyclic audio graph when it contains DelayNodes

### DIFF
--- a/examples/cyclic_graph.rs
+++ b/examples/cyclic_graph.rs
@@ -5,7 +5,7 @@ use web_audio_api::context::{AsBaseAudioContext, AudioContext};
 use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 
 // run in release mode
-// `cargo run --release --example many_oscillators_with_env`
+// `cargo run --release --example cyclic_graph`
 
 fn trigger_sine(context: &AudioContext, rng: &mut ThreadRng, cycle: &dyn AudioNode) {
     let osc = context.create_oscillator();

--- a/examples/cyclic_graph.rs
+++ b/examples/cyclic_graph.rs
@@ -1,0 +1,47 @@
+use rand::rngs::ThreadRng;
+use rand::Rng;
+use std::{thread, time};
+use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
+
+// run in release mode
+// `cargo run --release --example many_oscillators_with_env`
+
+fn trigger_sine(context: &AudioContext, rng: &mut ThreadRng, cycle: &dyn AudioNode) {
+    let osc = context.create_oscillator();
+    osc.connect(&context.destination());
+    osc.connect(cycle);
+
+    let now = context.current_time();
+
+    let freq = rng.gen_range(100..3000) as f32;
+    osc.frequency().set_value(freq);
+
+    osc.start_at(now);
+    osc.stop_at(now + 0.1);
+}
+
+fn main() {
+    let context = AudioContext::new(None);
+
+    let gain = context.create_gain();
+    gain.gain().set_value(0.5); // echo decay
+    gain.connect(&context.destination());
+
+    let delay = context.create_delay(1.);
+    delay.delay_time().set_value(0.3);
+    delay.connect(&gain);
+
+    // add cycle to get echo effect
+    gain.connect(&delay);
+
+    let mut rng = rand::thread_rng();
+
+    // mimic setInterval
+    loop {
+        trigger_sine(&context, &mut rng, &delay);
+
+        let period = rng.gen_range(170..1000);
+        thread::sleep(time::Duration::from_millis(period));
+    }
+}

--- a/src/node/delay.rs
+++ b/src/node/delay.rs
@@ -228,6 +228,10 @@ impl AudioProcessor for DelayReader {
         // calculate the delay in chunks of BUFFER_SIZE (todo: sub quantum delays)
         let quanta = (delay * sample_rate.0 as f32) as usize / BUFFER_SIZE;
 
+        // a delay of zero quanta is not allowed (in cycles, we don't know wether the reader or
+        // writer renders first and the ordering may change on every graph update - causing clicks)
+        let quanta = quanta.max(1);
+
         let buffer = self.delay_buffer.borrow_mut();
 
         let delayed_index = (self.index + buffer.capacity() - quanta) % buffer.capacity();

--- a/src/node/delay.rs
+++ b/src/node/delay.rs
@@ -28,6 +28,9 @@ impl Default for DelayOptions {
 }
 
 /// Node that delays the incoming audio signal by a certain amount
+///
+/// The current implementation does not allow for zero delay. The minimum delay is one render
+/// quantum (e.g. ~2.9ms at 44.1kHz).
 /*
  * For simplicity in the audio graph rendering, we have made the conscious decision to deviate from
  * the spec and split the delay node up front in a reader and writer node (instead of during the

--- a/src/node/delay.rs
+++ b/src/node/delay.rs
@@ -7,6 +7,9 @@ use crate::{SampleRate, BUFFER_SIZE};
 
 use super::AudioNode;
 
+use std::cell::RefCell;
+use std::rc::Rc;
+
 /// Options for constructing a DelayNode
 pub struct DelayOptions {
     pub max_delay_time: f32,
@@ -25,15 +28,26 @@ impl Default for DelayOptions {
 }
 
 /// Node that delays the incoming audio signal by a certain amount
+/*
+ * For simplicity in the audio graph rendering, we have made the conscious decision to deviate from
+ * the spec and split the delay node up front in a reader and writer node (instead of during the
+ * render loop - see https://webaudio.github.io/web-audio-api/#rendering-loop )
+ */
 pub struct DelayNode {
-    registration: AudioContextRegistration,
+    reader_registration: AudioContextRegistration,
+    writer_registration: AudioContextRegistration,
     delay_time: AudioParam,
     channel_config: ChannelConfig,
 }
 
 impl AudioNode for DelayNode {
+    /*
+     * We set the writer node as 'main' registration.  This means other nodes can say
+     * `node.connect(delaynode)` and they will connect to the writer.
+     * Below, we override the (dis)connect methods as they should operate on the reader node.
+     */
     fn registration(&self) -> &AudioContextRegistration {
-        &self.registration
+        &self.writer_registration
     }
 
     fn channel_config_raw(&self) -> &ChannelConfig {
@@ -46,41 +60,92 @@ impl AudioNode for DelayNode {
     fn number_of_outputs(&self) -> u32 {
         1
     }
+
+    /// Connect a specific output of this AudioNode to a specific input of another node.
+    fn connect_at<'a>(
+        &self,
+        dest: &'a dyn AudioNode,
+        output: u32,
+        input: u32,
+    ) -> Result<&'a dyn AudioNode, crate::IndexSizeError> {
+        if self.context() != dest.context() {
+            panic!("attempting to connect nodes from different contexts");
+        }
+
+        if self.number_of_outputs() <= output || dest.number_of_inputs() <= input {
+            return Err(crate::IndexSizeError {});
+        }
+
+        self.context()
+            .connect(self.reader_registration.id(), dest.id(), output, input);
+
+        Ok(dest)
+    }
+
+    /// Disconnects all outputs of the AudioNode that go to a specific destination AudioNode.
+    fn disconnect<'a>(&self, dest: &'a dyn AudioNode) -> &'a dyn AudioNode {
+        if self.context() != dest.context() {
+            panic!("attempting to disconnect nodes from different contexts");
+        }
+
+        self.context()
+            .disconnect(self.reader_registration.id(), dest.id());
+
+        dest
+    }
+
+    /// Disconnects all outgoing connections from the AudioNode.
+    fn disconnect_all(&self) {
+        self.context().disconnect_all(self.reader_registration.id());
+    }
 }
 
 impl DelayNode {
     pub fn new<C: AsBaseAudioContext>(context: &C, options: DelayOptions) -> Self {
-        context.base().register(move |registration| {
-            let param_opts = AudioParamOptions {
-                min_value: 0.,
-                max_value: options.max_delay_time,
-                default_value: 0.,
-                automation_rate: crate::param::AutomationRate::A,
-            };
-            let (param, proc) = context
-                .base()
-                .create_audio_param(param_opts, registration.id());
+        // allocate large enough buffer to store all delayed samples
+        let max_samples = options.max_delay_time * context.base().sample_rate().0 as f32;
+        let max_quanta = (max_samples.ceil() as usize + BUFFER_SIZE - 1) / BUFFER_SIZE;
+        let delay_buffer = Vec::with_capacity(max_quanta);
 
-            param.set_value_at_time(options.delay_time, 0.);
+        let shared_buffer = Rc::new(RefCell::new(delay_buffer));
+        let shared_buffer_clone = shared_buffer.clone();
 
-            // allocate large enough buffer to store all delayed samples
-            let max_samples = options.max_delay_time * context.base().sample_rate().0 as f32;
-            let max_quanta = (max_samples.ceil() as usize + BUFFER_SIZE - 1) / BUFFER_SIZE;
-            let delay_buffer = Vec::with_capacity(max_quanta);
+        context.base().register(move |writer_registration| {
+            let node = context.base().register(move |reader_registration| {
+                let param_opts = AudioParamOptions {
+                    min_value: 0.,
+                    max_value: options.max_delay_time,
+                    default_value: 0.,
+                    automation_rate: crate::param::AutomationRate::A,
+                };
+                let (param, proc) = context
+                    .base()
+                    .create_audio_param(param_opts, reader_registration.id());
 
-            let render = DelayRenderer {
-                delay_time: proc,
-                delay_buffer,
+                param.set_value_at_time(options.delay_time, 0.);
+
+                let reader_render = DelayReader {
+                    delay_time: proc,
+                    delay_buffer: shared_buffer_clone,
+                    index: 0,
+                };
+
+                let node = DelayNode {
+                    reader_registration,
+                    writer_registration,
+                    channel_config: options.channel_config.into(),
+                    delay_time: param,
+                };
+
+                (node, Box::new(reader_render))
+            });
+
+            let writer_render = DelayWriter {
+                delay_buffer: shared_buffer,
                 index: 0,
             };
 
-            let node = DelayNode {
-                registration,
-                channel_config: options.channel_config.into(),
-                delay_time: param,
-            };
-
-            (node, Box::new(render))
+            (node, Box::new(writer_render))
         })
     }
 
@@ -89,18 +154,24 @@ impl DelayNode {
     }
 }
 
-struct DelayRenderer {
+struct DelayReader {
     delay_time: AudioParamId,
-    delay_buffer: Vec<AudioBuffer>,
+    delay_buffer: Rc<RefCell<Vec<AudioBuffer>>>,
+    index: usize,
+}
+
+struct DelayWriter {
+    delay_buffer: Rc<RefCell<Vec<AudioBuffer>>>,
     index: usize,
 }
 
 // SAFETY:
 // AudioBuffers are not Send but we promise the `delay_buffer` Vec is empty before we ship it to
 // the render thread.
-unsafe impl Send for DelayRenderer {}
+unsafe impl Send for DelayReader {}
+unsafe impl Send for DelayWriter {}
 
-impl AudioProcessor for DelayRenderer {
+impl AudioProcessor for DelayWriter {
     fn process(
         &mut self,
         inputs: &[AudioBuffer],
@@ -109,6 +180,24 @@ impl AudioProcessor for DelayRenderer {
         _timestamp: f64,
         sample_rate: SampleRate,
     ) -> bool {
+        todo!()
+    }
+}
+
+impl AudioProcessor for DelayReader {
+    fn process(
+        &mut self,
+        inputs: &[AudioBuffer],
+        outputs: &mut [AudioBuffer],
+        params: AudioParamValues,
+        _timestamp: f64,
+        sample_rate: SampleRate,
+    ) -> bool {
+        todo!()
+    }
+}
+
+/*
         // single input/output node
         let input = &inputs[0];
         let output = &mut outputs[0];
@@ -135,5 +224,4 @@ impl AudioProcessor for DelayRenderer {
 
         // todo: return false when all inputs disconnected and buffer exhausted
         true
-    }
-}
+*/

--- a/src/node/delay.rs
+++ b/src/node/delay.rs
@@ -1,3 +1,4 @@
+use crate::alloc::AudioBuffer;
 use crate::buffer::{ChannelConfig, ChannelConfigOptions};
 use crate::context::{AsBaseAudioContext, AudioContextRegistration, AudioParamId};
 use crate::param::{AudioParam, AudioParamOptions};
@@ -90,20 +91,20 @@ impl DelayNode {
 
 struct DelayRenderer {
     delay_time: AudioParamId,
-    delay_buffer: Vec<crate::alloc::AudioBuffer>,
+    delay_buffer: Vec<AudioBuffer>,
     index: usize,
 }
 
 // SAFETY:
-// AudioBuffers are not Send but we promise the `delay_buffer` Vec is emtpy before we ship it to
+// AudioBuffers are not Send but we promise the `delay_buffer` Vec is empty before we ship it to
 // the render thread.
 unsafe impl Send for DelayRenderer {}
 
 impl AudioProcessor for DelayRenderer {
     fn process(
         &mut self,
-        inputs: &[crate::alloc::AudioBuffer],
-        outputs: &mut [crate::alloc::AudioBuffer],
+        inputs: &[AudioBuffer],
+        outputs: &mut [AudioBuffer],
         params: AudioParamValues,
         _timestamp: f64,
         sample_rate: SampleRate,


### PR DESCRIPTION
It's not 100% spec compliant, but it's a decent step to feature completeness.
Check it out with `cargo run  --release --example cyclic_graph`

I've tried to document the trade-offs in `src/node/delay.rs`

Fixes #26 