### PR TITLE
test k-rate param return buffer of 1 length

### DIFF
--- a/src/render/processor.rs
+++ b/src/render/processor.rs
@@ -61,7 +61,11 @@ impl<'a> AudioParamValues<'a> {
 
     /// Get the computed values for the given [`crate::param::AudioParam`]
     ///
-    /// For both A & K-rate params, it will provide a slice of length [`crate::RENDER_QUANTUM_SIZE`]
+    /// For A-Rate params, the slice will be of length [`crate::RENDER_QUANTUM_SIZE`]
+    /// For K-Rate params, the slice will be of length 1
+    ///
+    /// This is compliant with the AudioWorklet specification, cf.
+    /// <https://www.w3.org/TR/webaudio/#audioworkletprocess-callback-parameters>
     pub fn get(&self, index: &AudioParamId) -> &[f32] {
         &self.get_raw(index).channel_data(0)[..]
     }


### PR DESCRIPTION
_Warning: this is broken_

Hey, this is just a rapid test for the `k-rate` parameters returning a buffer of length 1 (plus minor changes to separate more clearly `a-rate` logic from the rest).

- From the param point of view, it didn't changed much actually, the test are passing with very minor (and expected) changes.
- Some tests are failing (in `AudioBufferSource` `Delay` and `WaveShaper`) where probably I didn't checked the rate properly, I didn't fixed them for now.

What do you think? should we continue on that vein? 

I'm personally not that sure as on the one hand, it will complicate all the nodes rendering to basically just replace a `buf.resize(128)` with a `buf.resize(1)`, but on the other hand, probably it will allow to improve perf on some points. 

So no strong opinion on my side, if you think it worth the case I can explore further what it means for the broken nodes to properly support both k-rate and a-rate, would allow to see the overhead it requires