### PR TITLE
proof of concept: delegation.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ float_eq = "0.7"
 smallvec = "1.7.0"
 once_cell = "1.9.0"
 symphonia = { version = "0.4.0", default-features = false }
+delegate-attr = {git = "https://github.com/upsuper/delegate-attr.git", rev ="32cda21a40f6e8a1b069d6178455318d8ecd6803" }
 
 [dev-dependencies]
 rand = "0.8.*"

--- a/examples/amplitude_modulation.rs
+++ b/examples/amplitude_modulation.rs
@@ -1,5 +1,5 @@
 use std::{thread, time};
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{Context, AudioContext};
 use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 
 fn main() {

--- a/examples/amplitude_modulation.rs
+++ b/examples/amplitude_modulation.rs
@@ -1,5 +1,5 @@
 use std::{thread, time};
-use web_audio_api::context::{Context, AudioContext};
+use web_audio_api::context::{AudioContext, Context};
 use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 
 fn main() {

--- a/examples/biquad.rs
+++ b/examples/biquad.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use web_audio_api::context::{Context, AudioContext};
+use web_audio_api::context::{AudioContext, Context};
 use web_audio_api::media::{MediaDecoder, MediaElement};
 use web_audio_api::node::{AudioControllableSourceNode, AudioNode, AudioScheduledSourceNode};
 

--- a/examples/biquad.rs
+++ b/examples/biquad.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{Context, AudioContext};
 use web_audio_api::media::{MediaDecoder, MediaElement};
 use web_audio_api::node::{AudioControllableSourceNode, AudioNode, AudioScheduledSourceNode};
 

--- a/examples/constant_source.rs
+++ b/examples/constant_source.rs
@@ -1,5 +1,5 @@
 use std::{thread, time};
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{Context, AudioContext};
 use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 
 fn main() {

--- a/examples/constant_source.rs
+++ b/examples/constant_source.rs
@@ -1,5 +1,5 @@
 use std::{thread, time};
-use web_audio_api::context::{Context, AudioContext};
+use web_audio_api::context::{AudioContext, Context};
 use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 
 fn main() {

--- a/examples/decoding.rs
+++ b/examples/decoding.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use web_audio_api::context::{Context, AudioContext};
+use web_audio_api::context::{AudioContext, Context};
 use web_audio_api::node::AudioNode;
 
 fn main() {

--- a/examples/decoding.rs
+++ b/examples/decoding.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{Context, AudioContext};
 use web_audio_api::node::AudioNode;
 
 fn main() {

--- a/examples/feedback_delay.rs
+++ b/examples/feedback_delay.rs
@@ -1,7 +1,7 @@
 use rand::rngs::ThreadRng;
 use rand::Rng;
 use std::{thread, time};
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{Context, AudioContext};
 use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 
 // run in release mode

--- a/examples/feedback_delay.rs
+++ b/examples/feedback_delay.rs
@@ -1,7 +1,7 @@
 use rand::rngs::ThreadRng;
 use rand::Rng;
 use std::{thread, time};
-use web_audio_api::context::{Context, AudioContext};
+use web_audio_api::context::{AudioContext, Context};
 use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 
 // run in release mode

--- a/examples/granular.rs
+++ b/examples/granular.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 use std::{thread, time};
 use web_audio_api::buffer::AudioBuffer;
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{Context, AudioContext};
 use web_audio_api::node::AudioNode;
 
 // run in release mode

--- a/examples/granular.rs
+++ b/examples/granular.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 use std::{thread, time};
 use web_audio_api::buffer::AudioBuffer;
-use web_audio_api::context::{Context, AudioContext};
+use web_audio_api::context::{AudioContext, Context};
 use web_audio_api::node::AudioNode;
 
 // run in release mode

--- a/examples/iir.rs
+++ b/examples/iir.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use web_audio_api::context::{Context, AudioContext};
+use web_audio_api::context::{AudioContext, Context};
 use web_audio_api::media::{MediaDecoder, MediaElement};
 use web_audio_api::node::{AudioControllableSourceNode, AudioNode, AudioScheduledSourceNode};
 

--- a/examples/iir.rs
+++ b/examples/iir.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{Context, AudioContext};
 use web_audio_api::media::{MediaDecoder, MediaElement};
 use web_audio_api::node::{AudioControllableSourceNode, AudioNode, AudioScheduledSourceNode};
 

--- a/examples/many_oscillators.rs
+++ b/examples/many_oscillators.rs
@@ -1,5 +1,5 @@
 use std::{thread, time};
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{Context, AudioContext};
 use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 
 fn trigger_sine(audio_context: &AudioContext) {

--- a/examples/many_oscillators.rs
+++ b/examples/many_oscillators.rs
@@ -1,5 +1,5 @@
 use std::{thread, time};
-use web_audio_api::context::{Context, AudioContext};
+use web_audio_api::context::{AudioContext, Context};
 use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 
 fn trigger_sine(audio_context: &AudioContext) {

--- a/examples/many_oscillators_with_env.rs
+++ b/examples/many_oscillators_with_env.rs
@@ -1,7 +1,7 @@
 use rand::rngs::ThreadRng;
 use rand::Rng;
 use std::{thread, time};
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{Context, AudioContext};
 use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 
 // run in release mode

--- a/examples/many_oscillators_with_env.rs
+++ b/examples/many_oscillators_with_env.rs
@@ -1,7 +1,7 @@
 use rand::rngs::ThreadRng;
 use rand::Rng;
 use std::{thread, time};
-use web_audio_api::context::{Context, AudioContext};
+use web_audio_api::context::{AudioContext, Context};
 use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 
 // run in release mode

--- a/examples/media_element.rs
+++ b/examples/media_element.rs
@@ -1,4 +1,4 @@
-use web_audio_api::context::{Context, AudioContext};
+use web_audio_api::context::{AudioContext, Context};
 use web_audio_api::media::{MediaDecoder, MediaElement};
 use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 

--- a/examples/media_element.rs
+++ b/examples/media_element.rs
@@ -1,4 +1,4 @@
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{Context, AudioContext};
 use web_audio_api::media::{MediaDecoder, MediaElement};
 use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 

--- a/examples/merger.rs
+++ b/examples/merger.rs
@@ -1,4 +1,4 @@
-use web_audio_api::context::{AsBaseAudioContext, AudioContext, AudioContextOptions, LatencyHint};
+use web_audio_api::context::{Context, AudioContext, AudioContextOptions, LatencyHint};
 use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 
 fn main() {

--- a/examples/merger.rs
+++ b/examples/merger.rs
@@ -1,4 +1,4 @@
-use web_audio_api::context::{Context, AudioContext, AudioContextOptions, LatencyHint};
+use web_audio_api::context::{AudioContext, AudioContextOptions, Context, LatencyHint};
 use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 
 fn main() {

--- a/examples/microphone.rs
+++ b/examples/microphone.rs
@@ -1,4 +1,4 @@
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{Context, AudioContext};
 use web_audio_api::media::Microphone;
 use web_audio_api::node::AudioNode;
 

--- a/examples/microphone.rs
+++ b/examples/microphone.rs
@@ -1,4 +1,4 @@
-use web_audio_api::context::{Context, AudioContext};
+use web_audio_api::context::{AudioContext, Context};
 use web_audio_api::media::Microphone;
 use web_audio_api::node::AudioNode;
 

--- a/examples/oscillators.rs
+++ b/examples/oscillators.rs
@@ -1,5 +1,5 @@
 //! This example plays each oscillator type sequentially
-use web_audio_api::context::{Context, AudioContext};
+use web_audio_api::context::{AudioContext, Context};
 use web_audio_api::node::{AudioNode, AudioScheduledSourceNode, OscillatorType};
 use web_audio_api::periodic_wave::PeriodicWaveOptions;
 

--- a/examples/oscillators.rs
+++ b/examples/oscillators.rs
@@ -1,5 +1,5 @@
 //! This example plays each oscillator type sequentially
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{Context, AudioContext};
 use web_audio_api::node::{AudioNode, AudioScheduledSourceNode, OscillatorType};
 use web_audio_api::periodic_wave::PeriodicWaveOptions;
 

--- a/examples/panner_cone.rs
+++ b/examples/panner_cone.rs
@@ -1,4 +1,4 @@
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{Context, AudioContext};
 use web_audio_api::node::AudioNode;
 use web_audio_api::node::AudioScheduledSourceNode;
 

--- a/examples/panner_cone.rs
+++ b/examples/panner_cone.rs
@@ -1,4 +1,4 @@
-use web_audio_api::context::{Context, AudioContext};
+use web_audio_api::context::{AudioContext, Context};
 use web_audio_api::node::AudioNode;
 use web_audio_api::node::AudioScheduledSourceNode;
 

--- a/examples/simple_delay.rs
+++ b/examples/simple_delay.rs
@@ -1,6 +1,6 @@
 use std::fs::File;
 use std::{thread, time};
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{Context, AudioContext};
 use web_audio_api::node::AudioNode;
 
 fn main() {

--- a/examples/simple_delay.rs
+++ b/examples/simple_delay.rs
@@ -1,6 +1,6 @@
 use std::fs::File;
 use std::{thread, time};
-use web_audio_api::context::{Context, AudioContext};
+use web_audio_api::context::{AudioContext, Context};
 use web_audio_api::node::AudioNode;
 
 fn main() {

--- a/examples/spatial.rs
+++ b/examples/spatial.rs
@@ -1,4 +1,4 @@
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{Context, AudioContext};
 use web_audio_api::node::AudioNode;
 use web_audio_api::node::AudioScheduledSourceNode;
 

--- a/examples/spatial.rs
+++ b/examples/spatial.rs
@@ -1,4 +1,4 @@
-use web_audio_api::context::{Context, AudioContext};
+use web_audio_api::context::{AudioContext, Context};
 use web_audio_api::node::AudioNode;
 use web_audio_api::node::AudioScheduledSourceNode;
 

--- a/examples/stereo.rs
+++ b/examples/stereo.rs
@@ -1,4 +1,4 @@
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{Context, AudioContext};
 use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 
 fn main() {

--- a/examples/stereo.rs
+++ b/examples/stereo.rs
@@ -1,4 +1,4 @@
-use web_audio_api::context::{Context, AudioContext};
+use web_audio_api::context::{AudioContext, Context};
 use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 
 fn main() {

--- a/examples/trigger_soundfile.rs
+++ b/examples/trigger_soundfile.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use web_audio_api::context::{Context, AudioContext};
+use web_audio_api::context::{AudioContext, Context};
 use web_audio_api::node::AudioNode;
 
 fn main() {

--- a/examples/trigger_soundfile.rs
+++ b/examples/trigger_soundfile.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{Context, AudioContext};
 use web_audio_api::node::AudioNode;
 
 fn main() {

--- a/examples/waveshaper.rs
+++ b/examples/waveshaper.rs
@@ -1,6 +1,6 @@
 use std::f32::consts::PI;
 use std::fs::File;
-use web_audio_api::context::{Context, AudioContext};
+use web_audio_api::context::{AudioContext, Context};
 use web_audio_api::node::{AudioNode, OverSampleType};
 
 // use part of cosine, between [π, 2π] as shaping cureve

--- a/examples/waveshaper.rs
+++ b/examples/waveshaper.rs
@@ -1,6 +1,6 @@
 use std::f32::consts::PI;
 use std::fs::File;
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{Context, AudioContext};
 use web_audio_api::node::{AudioNode, OverSampleType};
 
 // use part of cosine, between [π, 2π] as shaping cureve

--- a/examples/worklet.rs
+++ b/examples/worklet.rs
@@ -1,7 +1,7 @@
 use rand::Rng;
 
 use web_audio_api::context::{
-    AsBaseAudioContext, AudioContext, AudioContextRegistration, AudioParamId,
+    Context, AudioContext, AudioContextRegistration, AudioParamId,
 };
 use web_audio_api::node::{AudioNode, ChannelConfig, ChannelConfigOptions};
 use web_audio_api::param::{AudioParam, AudioParamOptions, AutomationRate};
@@ -41,8 +41,8 @@ impl AudioNode for WhiteNoiseNode {
 
 impl WhiteNoiseNode {
     /// Construct a new WhiteNoiseNode
-    fn new<C: AsBaseAudioContext>(context: &C) -> Self {
-        context.base().register(move |registration| {
+    fn new<C: Context>(context: &C) -> Self {
+        context.register(move |registration| {
             // setup the amplitude audio param
             let param_opts = AudioParamOptions {
                 min_value: 0.,
@@ -50,9 +50,7 @@ impl WhiteNoiseNode {
                 default_value: 1.,
                 automation_rate: AutomationRate::A,
             };
-            let (param, proc) = context
-                .base()
-                .create_audio_param(param_opts, registration.id());
+            let (param, proc) = context.create_audio_param(param_opts, registration.id());
 
             // setup the processor, this will run in the render thread
             let render = WhiteNoiseProcessor { amplitude: proc };

--- a/examples/worklet.rs
+++ b/examples/worklet.rs
@@ -1,8 +1,6 @@
 use rand::Rng;
 
-use web_audio_api::context::{
-    Context, AudioContext, AudioContextRegistration, AudioParamId,
-};
+use web_audio_api::context::{AudioContext, AudioContextRegistration, AudioParamId, Context};
 use web_audio_api::node::{AudioNode, ChannelConfig, ChannelConfigOptions};
 use web_audio_api::param::{AudioParam, AudioParamOptions, AutomationRate};
 use web_audio_api::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum};

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -19,7 +19,7 @@ pub struct AudioBufferOptions {
 ///
 /// - MDN documentation: <https://developer.mozilla.org/en-US/docs/Web/API/AudioBuffer>
 /// - specification: <https://webaudio.github.io/web-audio-api/#AudioBuffer>
-/// - see also: [`AsBaseAudioContext::create_buffer`](crate::context::AsBaseAudioContext::create_buffer)
+/// - see also: [`Context::create_buffer`](crate::context::Context::create_buffer)
 #[derive(Clone, Debug)]
 pub struct AudioBuffer {
     channels: Vec<ChannelData>,

--- a/src/context.rs
+++ b/src/context.rs
@@ -61,7 +61,7 @@ impl PartialEq for BaseAudioContext {
 }
 
 /// Inner representation of the `BaseAudioContext`
-/// 
+///
 /// Required for internal synchronization.
 struct BaseAudioContextInner {
     /// sample rate in Hertz
@@ -602,7 +602,11 @@ impl AudioContextRegistration {
 
     pub(crate) fn disconnect_all(&self, from: &AudioNodeId);
 
-    pub(crate) fn pass_audio_param_event(&self, to: &Sender<AudioParamEvent>, event: AudioParamEvent);
+    pub(crate) fn pass_audio_param_event(
+        &self,
+        to: &Sender<AudioParamEvent>,
+        event: AudioParamEvent,
+    );
 }
 
 impl AudioContextRegistration {
@@ -1027,7 +1031,11 @@ impl BaseAudioContext {
     ///
     /// This clunky setup (wrapping a Sender in a message sent by another Sender) ensures
     /// automation events will never be handled out of order.
-    pub(crate) fn pass_audio_param_event(&self, to: &Sender<AudioParamEvent>, event: AudioParamEvent) {
+    pub(crate) fn pass_audio_param_event(
+        &self,
+        to: &Sender<AudioParamEvent>,
+        event: AudioParamEvent,
+    ) {
         let message = ControlMessage::AudioParamEvent {
             to: to.clone(),
             event,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! # Example
 //! ```no_run
 //! use std::fs::File;
-//! use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+//! use web_audio_api::context::{Context, AudioContext};
 //! use web_audio_api::media::{MediaElement, MediaDecoder};
 //! use web_audio_api::node::{AudioNode, AudioControllableSourceNode, AudioScheduledSourceNode};
 //!

--- a/src/media/decoding.rs
+++ b/src/media/decoding.rs
@@ -52,7 +52,7 @@ impl<R: Read + Send> symphonia::core::io::MediaSource for MediaInput<R> {
 ///
 /// Using the `MediaDecoder` is the preferred way to play large audio files and streams. For small
 /// soundbites, consider using
-/// [`decode_audio_data`](crate::context::AsBaseAudioContext::decode_audio_data) on the audio
+/// [`decode_audio_data`](crate::context::Context::decode_audio_data) on the audio
 /// context which will create a single AudioBuffer which can be played/looped with high precision
 /// in an `AudioBufferSourceNode`.
 ///
@@ -65,7 +65,7 @@ impl<R: Read + Send> symphonia::core::io::MediaSource for MediaInput<R> {
 ///
 /// ```no_run
 /// use web_audio_api::media::{MediaElement, MediaDecoder};
-/// use web_audio_api::context::{AudioContext, AsBaseAudioContext};
+/// use web_audio_api::context::{AudioContext, Context};
 /// use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 ///
 /// // construct the decoder

--- a/src/media/mic.rs
+++ b/src/media/mic.rs
@@ -24,7 +24,7 @@ use crossbeam_channel::{Receiver, TryRecvError};
 /// # Example
 ///
 /// ```no_run
-/// use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+/// use web_audio_api::context::{Context, AudioContext};
 /// use web_audio_api::media::Microphone;
 /// use web_audio_api::node::AudioNode;
 ///

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -35,7 +35,7 @@ use crossbeam_channel::{self, Receiver};
 ///
 /// ```no_run
 /// use web_audio_api::SampleRate;
-/// use web_audio_api::context::{AudioContext, AsBaseAudioContext};
+/// use web_audio_api::context::{AudioContext, Context};
 /// use web_audio_api::buffer::{AudioBuffer, AudioBufferOptions};
 /// use web_audio_api::node::AudioNode;
 ///
@@ -76,7 +76,7 @@ impl<M: Iterator<Item = Result<AudioBuffer, Box<dyn Error + Send + Sync>>> + Sen
 ///
 /// ```rust
 /// use web_audio_api::SampleRate;
-/// use web_audio_api::context::{AudioContext, AsBaseAudioContext};
+/// use web_audio_api::context::{AudioContext, Context};
 /// use web_audio_api::buffer::AudioBuffer;
 /// use web_audio_api::media::MediaElement;
 /// use web_audio_api::node::AudioControllableSourceNode;

--- a/src/node/analyzer.rs
+++ b/src/node/analyzer.rs
@@ -2,7 +2,7 @@ use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use crate::analysis::Analyser;
-use crate::context::{Context,AudioContextRegistration};
+use crate::context::{AudioContextRegistration, Context};
 use crate::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum};
 use crate::SampleRate;
 

--- a/src/node/analyzer.rs
+++ b/src/node/analyzer.rs
@@ -2,7 +2,7 @@ use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use crate::analysis::Analyser;
-use crate::context::{AsBaseAudioContext, AudioContextRegistration};
+use crate::context::{Context,AudioContextRegistration};
 use crate::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum};
 use crate::SampleRate;
 
@@ -77,8 +77,8 @@ impl AudioNode for AnalyserNode {
 }
 
 impl AnalyserNode {
-    pub fn new<C: AsBaseAudioContext>(context: &C, options: AnalyserOptions) -> Self {
-        context.base().register(move |registration| {
+    pub fn new<C: Context>(context: &C, options: AnalyserOptions) -> Self {
+        context.register(move |registration| {
             let fft_size = Arc::new(AtomicUsize::new(options.fft_size));
             let smoothing_time_constant = Arc::new(AtomicU32::new(
                 (options.smoothing_time_constant * 100.) as u32,

--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -3,7 +3,7 @@ use once_cell::sync::OnceCell;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::buffer::AudioBuffer;
-use crate::context::{Context, AudioContextRegistration, AudioParamId};
+use crate::context::{AudioContextRegistration, AudioParamId, Context};
 use crate::control::Controller;
 use crate::param::{AudioParam, AudioParamOptions, AutomationRate};
 use crate::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum};
@@ -121,9 +121,8 @@ impl AudioBufferSourceNode {
                 default_value: 0.,
                 automation_rate: AutomationRate::K,
             };
-            let (d_param, d_proc) = context
-                
-                .create_audio_param(detune_param_options, registration.id());
+            let (d_param, d_proc) =
+                context.create_audio_param(detune_param_options, registration.id());
 
             d_param.set_value(detune);
 
@@ -133,9 +132,8 @@ impl AudioBufferSourceNode {
                 default_value: 1.,
                 automation_rate: AutomationRate::K,
             };
-            let (pr_param, pr_proc) = context
-                
-                .create_audio_param(playback_rate_param_options, registration.id());
+            let (pr_param, pr_proc) =
+                context.create_audio_param(playback_rate_param_options, registration.id());
 
             pr_param.set_value(playback_rate);
 

--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -3,7 +3,7 @@ use once_cell::sync::OnceCell;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::buffer::AudioBuffer;
-use crate::context::{AsBaseAudioContext, AudioContextRegistration, AudioParamId};
+use crate::context::{Context, AudioContextRegistration, AudioParamId};
 use crate::control::Controller;
 use crate::param::{AudioParam, AudioParamOptions, AutomationRate};
 use crate::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum};
@@ -44,13 +44,13 @@ struct AudioBufferMessage(AudioBuffer);
 ///
 /// - MDN documentation: <https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode>
 /// - specification: <https://webaudio.github.io/web-audio-api/#AudioBufferSourceNode>
-/// - see also: [`AsBaseAudioContext::create_buffer_source`](crate::context::AsBaseAudioContext::create_buffer_source)
+/// - see also: [`Context::create_buffer_source`](crate::context::Context::create_buffer_source)
 ///
 /// # Usage
 ///
 /// ```no_run
 /// use std::fs::File;
-/// use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+/// use web_audio_api::context::{Context, AudioContext};
 /// use web_audio_api::node::AudioNode;
 ///
 /// // create an `AudioContext`
@@ -100,8 +100,8 @@ impl AudioNode for AudioBufferSourceNode {
 
 impl AudioBufferSourceNode {
     /// Create a new [`AudioBufferSourceNode`] instance
-    pub fn new<C: AsBaseAudioContext>(context: &C, options: AudioBufferSourceOptions) -> Self {
-        context.base().register(move |registration| {
+    pub fn new<C: Context>(context: &C, options: AudioBufferSourceOptions) -> Self {
+        context.register(move |registration| {
             let AudioBufferSourceOptions {
                 buffer,
                 detune,
@@ -122,7 +122,7 @@ impl AudioBufferSourceNode {
                 automation_rate: AutomationRate::K,
             };
             let (d_param, d_proc) = context
-                .base()
+                
                 .create_audio_param(detune_param_options, registration.id());
 
             d_param.set_value(detune);
@@ -134,7 +134,7 @@ impl AudioBufferSourceNode {
                 automation_rate: AutomationRate::K,
             };
             let (pr_param, pr_proc) = context
-                .base()
+                
                 .create_audio_param(playback_rate_param_options, registration.id());
 
             pr_param.set_value(playback_rate);
@@ -206,7 +206,7 @@ impl AudioBufferSourceNode {
 
     /// Start the playback on next block
     pub fn start(&self) {
-        let start = self.registration.context().current_time();
+        let start = self.registration.current_time();
         self.start_at_with_offset_and_duration(start, 0., f64::MAX);
     }
 
@@ -233,7 +233,7 @@ impl AudioBufferSourceNode {
 
     /// Stop the playback on next block
     pub fn stop(&self) {
-        let stop = self.registration.context().current_time();
+        let stop = self.registration.current_time();
         self.stop_at(stop);
     }
 
@@ -559,7 +559,7 @@ impl AudioBufferSourceRenderer {
 
 #[cfg(test)]
 mod tests {
-    use crate::context::{AsBaseAudioContext, OfflineAudioContext};
+    use crate::context::{Context, OfflineAudioContext};
     use crate::node::AudioNode;
     use crate::{SampleRate, RENDER_QUANTUM_SIZE};
 

--- a/src/node/biquad_filter.rs
+++ b/src/node/biquad_filter.rs
@@ -18,7 +18,7 @@ use crossbeam_channel::{Receiver, Sender};
 use num_complex::Complex;
 
 use crate::{
-    context::{Context,AudioContextRegistration, AudioParamId},
+    context::{AudioContextRegistration, AudioParamId, Context},
     param::{AudioParam, AudioParamOptions},
     render::{AudioParamValues, AudioProcessor, AudioRenderQuantum},
     SampleRate, MAX_CHANNELS,
@@ -184,9 +184,7 @@ impl BiquadFilterNode {
                 default_value: default_q,
                 automation_rate: crate::param::AutomationRate::A,
             };
-            let (q_param, q_proc) = context
-                
-                .create_audio_param(q_param_opts, registration.id());
+            let (q_param, q_proc) = context.create_audio_param(q_param_opts, registration.id());
 
             q_param.set_value(q_value);
 
@@ -196,9 +194,7 @@ impl BiquadFilterNode {
                 default_value: default_det,
                 automation_rate: crate::param::AutomationRate::A,
             };
-            let (d_param, d_proc) = context
-                
-                .create_audio_param(d_param_opts, registration.id());
+            let (d_param, d_proc) = context.create_audio_param(d_param_opts, registration.id());
 
             d_param.set_value(d_value);
 
@@ -209,9 +205,7 @@ impl BiquadFilterNode {
                 default_value: default_freq,
                 automation_rate: crate::param::AutomationRate::A,
             };
-            let (f_param, f_proc) = context
-                
-                .create_audio_param(f_param_opts, registration.id());
+            let (f_param, f_proc) = context.create_audio_param(f_param_opts, registration.id());
 
             f_param.set_value(f_value);
 
@@ -221,9 +215,7 @@ impl BiquadFilterNode {
                 default_value: default_gain,
                 automation_rate: crate::param::AutomationRate::A,
             };
-            let (g_param, g_proc) = context
-                
-                .create_audio_param(g_param_opts, registration.id());
+            let (g_param, g_proc) = context.create_audio_param(g_param_opts, registration.id());
 
             g_param.set_value(g_value);
 

--- a/src/node/biquad_filter.rs
+++ b/src/node/biquad_filter.rs
@@ -18,7 +18,7 @@ use crossbeam_channel::{Receiver, Sender};
 use num_complex::Complex;
 
 use crate::{
-    context::{AsBaseAudioContext, AudioContextRegistration, AudioParamId},
+    context::{Context,AudioContextRegistration, AudioParamId},
     param::{AudioParam, AudioParamOptions},
     render::{AudioParamValues, AudioProcessor, AudioRenderQuantum},
     SampleRate, MAX_CHANNELS,
@@ -163,8 +163,8 @@ impl BiquadFilterNode {
     ///
     /// * `context` - audio context in which the audio node will live.
     /// * `options` - biquad filter options
-    pub fn new<C: AsBaseAudioContext>(context: &C, options: Option<BiquadFilterOptions>) -> Self {
-        context.base().register(move |registration| {
+    pub fn new<C: Context>(context: &C, options: Option<BiquadFilterOptions>) -> Self {
+        context.register(move |registration| {
             let options = options.unwrap_or_default();
 
             let default_freq = 350.;
@@ -185,7 +185,7 @@ impl BiquadFilterNode {
                 automation_rate: crate::param::AutomationRate::A,
             };
             let (q_param, q_proc) = context
-                .base()
+                
                 .create_audio_param(q_param_opts, registration.id());
 
             q_param.set_value(q_value);
@@ -197,7 +197,7 @@ impl BiquadFilterNode {
                 automation_rate: crate::param::AutomationRate::A,
             };
             let (d_param, d_proc) = context
-                .base()
+                
                 .create_audio_param(d_param_opts, registration.id());
 
             d_param.set_value(d_value);
@@ -210,7 +210,7 @@ impl BiquadFilterNode {
                 automation_rate: crate::param::AutomationRate::A,
             };
             let (f_param, f_proc) = context
-                .base()
+                
                 .create_audio_param(f_param_opts, registration.id());
 
             f_param.set_value(f_value);
@@ -222,7 +222,7 @@ impl BiquadFilterNode {
                 automation_rate: crate::param::AutomationRate::A,
             };
             let (g_param, g_proc) = context
-                .base()
+                
                 .create_audio_param(g_param_opts, registration.id());
 
             g_param.set_value(g_value);
@@ -325,7 +325,7 @@ impl BiquadFilterNode {
             Ok([b0, b1, b2, a1, a2]) => {
                 for (i, &f) in frequency_hz.iter().enumerate() {
                     let f = f64::from(f);
-                    let sample_rate = f64::from(self.context().sample_rate_raw().0);
+                    let sample_rate = f64::from(self.registration().sample_rate_raw().0);
                     let num = b0
                         + Complex::from_polar(b1, -1.0 * 2.0 * PI * f / sample_rate)
                         + Complex::from_polar(b2, -2.0 * 2.0 * PI * f / sample_rate);
@@ -364,7 +364,7 @@ impl BiquadFilterNode {
 
         // Ensures that given frequencies are in the correct range
         let min = 0.;
-        let max = self.context().sample_rate() / 2.;
+        let max = self.registration().sample_rate() / 2.;
         for f in frequency_hz.iter_mut() {
             *f = f.clamp(min, max);
         }
@@ -1097,7 +1097,7 @@ mod test {
     use float_eq::assert_float_eq;
 
     use crate::{
-        context::{AsBaseAudioContext, OfflineAudioContext},
+        context::{Context, OfflineAudioContext},
         SampleRate,
     };
 

--- a/src/node/channel_merger.rs
+++ b/src/node/channel_merger.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use crate::context::{Context,AudioContextRegistration};
+use crate::context::{AudioContextRegistration, Context};
 use crate::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum};
 use crate::SampleRate;
 

--- a/src/node/channel_merger.rs
+++ b/src/node/channel_merger.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use crate::context::{AsBaseAudioContext, AudioContextRegistration};
+use crate::context::{Context,AudioContextRegistration};
 use crate::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum};
 use crate::SampleRate;
 
@@ -60,8 +60,8 @@ impl AudioNode for ChannelMergerNode {
 }
 
 impl ChannelMergerNode {
-    pub fn new<C: AsBaseAudioContext>(context: &C, mut options: ChannelMergerOptions) -> Self {
-        context.base().register(move |registration| {
+    pub fn new<C: Context>(context: &C, mut options: ChannelMergerOptions) -> Self {
+        context.register(move |registration| {
             options.channel_config.count = options.number_of_inputs as _;
 
             let node = ChannelMergerNode {

--- a/src/node/channel_splitter.rs
+++ b/src/node/channel_splitter.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use crate::context::{Context,AudioContextRegistration};
+use crate::context::{AudioContextRegistration, Context};
 use crate::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum};
 use crate::SampleRate;
 

--- a/src/node/channel_splitter.rs
+++ b/src/node/channel_splitter.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use crate::context::{AsBaseAudioContext, AudioContextRegistration};
+use crate::context::{Context,AudioContextRegistration};
 use crate::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum};
 use crate::SampleRate;
 
@@ -60,8 +60,8 @@ impl AudioNode for ChannelSplitterNode {
 }
 
 impl ChannelSplitterNode {
-    pub fn new<C: AsBaseAudioContext>(context: &C, mut options: ChannelSplitterOptions) -> Self {
-        context.base().register(move |registration| {
+    pub fn new<C: Context>(context: &C, mut options: ChannelSplitterOptions) -> Self {
+        context.register(move |registration| {
             options.channel_config.count = options.number_of_outputs as _;
 
             let node = ChannelSplitterNode {

--- a/src/node/constant_source.rs
+++ b/src/node/constant_source.rs
@@ -1,4 +1,4 @@
-use crate::context::{AsBaseAudioContext, AudioContextRegistration, AudioParamId};
+use crate::context::{Context,AudioContextRegistration, AudioParamId};
 use crate::control::Scheduler;
 use crate::param::{AudioParam, AudioParamOptions, AutomationRate};
 use crate::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum};
@@ -26,12 +26,12 @@ impl Default for ConstantSourceOptions {
 ///
 /// - MDN documentation: <https://developer.mozilla.org/en-US/docs/Web/API/ConstantSourceNode>
 /// - specification: <https://webaudio.github.io/web-audio-api/#ConstantSourceNode>
-/// - see also: [`AsBaseAudioContext::create_constant_source`](crate::context::AsBaseAudioContext::create_constant_source)
+/// - see also: [`Context::create_constant_source`](crate::context::Context::create_constant_source)
 ///
 /// # Usage
 ///
 /// ```no_run
-/// use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+/// use web_audio_api::context::{Context, AudioContext};
 /// use web_audio_api::node::AudioNode;
 ///
 /// let audio_context = AudioContext::new(None);
@@ -86,8 +86,8 @@ impl AudioScheduledSourceNode for ConstantSourceNode {
 }
 
 impl ConstantSourceNode {
-    pub fn new<C: AsBaseAudioContext>(context: &C, options: ConstantSourceOptions) -> Self {
-        context.base().register(move |registration| {
+    pub fn new<C: Context>(context: &C, options: ConstantSourceOptions) -> Self {
+        context.register(move |registration| {
             let param_opts = AudioParamOptions {
                 min_value: f32::MIN,
                 max_value: f32::MAX,
@@ -95,7 +95,7 @@ impl ConstantSourceNode {
                 automation_rate: AutomationRate::A,
             };
             let (param, proc) = context
-                .base()
+                
                 .create_audio_param(param_opts, registration.id());
             param.set_value(options.offset);
 
@@ -180,7 +180,7 @@ impl AudioProcessor for ConstantSourceRenderer {
 
 #[cfg(test)]
 mod tests {
-    use crate::context::{AsBaseAudioContext, OfflineAudioContext};
+    use crate::context::{Context, OfflineAudioContext};
     use crate::node::{AudioNode, AudioScheduledSourceNode};
     use crate::SampleRate;
 

--- a/src/node/constant_source.rs
+++ b/src/node/constant_source.rs
@@ -1,4 +1,4 @@
-use crate::context::{Context,AudioContextRegistration, AudioParamId};
+use crate::context::{AudioContextRegistration, AudioParamId, Context};
 use crate::control::Scheduler;
 use crate::param::{AudioParam, AudioParamOptions, AutomationRate};
 use crate::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum};
@@ -94,9 +94,7 @@ impl ConstantSourceNode {
                 default_value: 1.,
                 automation_rate: AutomationRate::A,
             };
-            let (param, proc) = context
-                
-                .create_audio_param(param_opts, registration.id());
+            let (param, proc) = context.create_audio_param(param_opts, registration.id());
             param.set_value(options.offset);
 
             let scheduler = Scheduler::new();

--- a/src/node/delay.rs
+++ b/src/node/delay.rs
@@ -127,7 +127,8 @@ impl AudioNode for DelayNode {
             panic!("IndexSizeError: input port {} is out of bounds", input);
         }
 
-        self.registration().connect(self.reader_registration.id(), dest.id(), output, input);
+        self.registration()
+            .connect(self.reader_registration.id(), dest.id(), output, input);
 
         dest
     }
@@ -146,7 +147,8 @@ impl AudioNode for DelayNode {
 
     /// Disconnects all outgoing connections from the AudioNode.
     fn disconnect_all(&self) {
-        self.registration().disconnect_all(self.reader_registration.id());
+        self.registration()
+            .disconnect_all(self.reader_registration.id());
     }
 }
 

--- a/src/node/destination.rs
+++ b/src/node/destination.rs
@@ -1,4 +1,4 @@
-use crate::context::{AsBaseAudioContext, AudioContextRegistration};
+use crate::context::{AudioContextRegistration, Context};
 use crate::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum};
 use crate::SampleRate;
 
@@ -73,8 +73,8 @@ impl AudioNode for AudioDestinationNode {
 }
 
 impl AudioDestinationNode {
-    pub fn new<C: AsBaseAudioContext>(context: &C, channel_count: usize) -> Self {
-        context.base().register(move |registration| {
+    pub fn new<C: Context>(context: &C, channel_count: usize) -> Self {
+        context.register(move |registration| {
             let node = Self {
                 registration,
                 channel_count,
@@ -88,6 +88,6 @@ impl AudioDestinationNode {
     /// The maximum number of channels that the channelCount attribute can be set to
     /// This is the limit number that audio hardware can support.
     pub fn max_channels_count(&self) -> u32 {
-        self.registration.context().base().channels()
+        self.registration.channels()
     }
 }

--- a/src/node/gain.rs
+++ b/src/node/gain.rs
@@ -1,4 +1,4 @@
-use crate::context::{AsBaseAudioContext, AudioContextRegistration, AudioParamId};
+use crate::context::{Context,AudioContextRegistration, AudioParamId};
 use crate::param::{AudioParam, AudioParamOptions};
 use crate::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum};
 use crate::SampleRate;
@@ -45,8 +45,8 @@ impl AudioNode for GainNode {
 }
 
 impl GainNode {
-    pub fn new<C: AsBaseAudioContext>(context: &C, options: GainOptions) -> Self {
-        context.base().register(move |registration| {
+    pub fn new<C: Context>(context: &C, options: GainOptions) -> Self {
+        context.register(move |registration| {
             let param_opts = AudioParamOptions {
                 min_value: f32::MIN,
                 max_value: f32::MAX,
@@ -54,7 +54,7 @@ impl GainNode {
                 automation_rate: crate::param::AutomationRate::A,
             };
             let (param, proc) = context
-                .base()
+                
                 .create_audio_param(param_opts, registration.id());
 
             param.set_value_at_time(options.gain, 0.);

--- a/src/node/gain.rs
+++ b/src/node/gain.rs
@@ -1,4 +1,4 @@
-use crate::context::{Context,AudioContextRegistration, AudioParamId};
+use crate::context::{AudioContextRegistration, AudioParamId, Context};
 use crate::param::{AudioParam, AudioParamOptions};
 use crate::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum};
 use crate::SampleRate;
@@ -53,9 +53,7 @@ impl GainNode {
                 default_value: 1.,
                 automation_rate: crate::param::AutomationRate::A,
             };
-            let (param, proc) = context
-                
-                .create_audio_param(param_opts, registration.id());
+            let (param, proc) = context.create_audio_param(param_opts, registration.id());
 
             param.set_value_at_time(options.gain, 0.);
 

--- a/src/node/iir_filter.rs
+++ b/src/node/iir_filter.rs
@@ -10,7 +10,7 @@ use num_complex::Complex;
 use std::f64::consts::PI;
 
 use crate::{
-    context::{AsBaseAudioContext, AudioContextRegistration},
+    context::{Context,AudioContextRegistration},
     render::{AudioParamValues, AudioProcessor, AudioRenderQuantum},
     SampleRate, MAX_CHANNELS,
 };
@@ -78,8 +78,8 @@ impl IirFilterNode {
     /// * `feedforward` or/and `feedback` is an empty vector
     /// * all `feedforward` element or/and all `feedback` element are eqaul to 0.
     /// *
-    pub fn new<C: AsBaseAudioContext>(context: &C, options: IirFilterOptions) -> Self {
-        context.base().register(move |registration| {
+    pub fn new<C: Context>(context: &C, options: IirFilterOptions) -> Self {
+        context.register(move |registration| {
             let IirFilterOptions {
                 feedforward,
                 feedback,
@@ -126,7 +126,7 @@ impl IirFilterNode {
         phase_response: &mut [f32],
     ) {
         self.validate_inputs(frequency_hz, mag_response, phase_response);
-        let sample_rate = f64::from(self.context().sample_rate_raw().0);
+        let sample_rate = f64::from(self.registration().sample_rate_raw().0);
 
         for (i, &f) in frequency_hz.iter().enumerate() {
             let mut num: Complex<f64> = Complex::new(0., 0.);
@@ -175,7 +175,7 @@ impl IirFilterNode {
 
         // Ensures that given frequencies are in the correct range
         let min = 0.;
-        let max = self.context().sample_rate() / 2.;
+        let max = self.registration().sample_rate() / 2.;
         for f in frequency_hz.iter_mut() {
             *f = f.clamp(min, max);
         }
@@ -348,7 +348,7 @@ mod test {
     use std::{cmp::min, fs::File};
 
     use crate::{
-        context::{AsBaseAudioContext, OfflineAudioContext},
+        context::{Context, OfflineAudioContext},
         media::{MediaDecoder, MediaElement},
         node::{AudioNode, AudioScheduledSourceNode},
         snapshot, SampleRate,

--- a/src/node/iir_filter.rs
+++ b/src/node/iir_filter.rs
@@ -10,7 +10,7 @@ use num_complex::Complex;
 use std::f64::consts::PI;
 
 use crate::{
-    context::{Context,AudioContextRegistration},
+    context::{AudioContextRegistration, Context},
     render::{AudioParamValues, AudioProcessor, AudioRenderQuantum},
     SampleRate, MAX_CHANNELS,
 };

--- a/src/node/media_element.rs
+++ b/src/node/media_element.rs
@@ -1,5 +1,5 @@
 use crate::buffer::Resampler;
-use crate::context::{Context, AudioContextRegistration};
+use crate::context::{AudioContextRegistration, Context};
 use crate::control::{Controller, Scheduler};
 use crate::media::MediaElement;
 use crate::RENDER_QUANTUM_SIZE;
@@ -55,10 +55,7 @@ impl AudioNode for MediaElementAudioSourceNode {
 }
 
 impl MediaElementAudioSourceNode {
-    pub fn new<C: Context>(
-        context: &C,
-        options: MediaElementAudioSourceNodeOptions,
-    ) -> Self {
+    pub fn new<C: Context>(context: &C, options: MediaElementAudioSourceNodeOptions) -> Self {
         context.register(move |registration| {
             let controller = options.media.controller().clone();
             let scheduler = controller.scheduler().clone();

--- a/src/node/media_element.rs
+++ b/src/node/media_element.rs
@@ -1,5 +1,5 @@
 use crate::buffer::Resampler;
-use crate::context::{AsBaseAudioContext, AudioContextRegistration};
+use crate::context::{Context, AudioContextRegistration};
 use crate::control::{Controller, Scheduler};
 use crate::media::MediaElement;
 use crate::RENDER_QUANTUM_SIZE;
@@ -55,11 +55,11 @@ impl AudioNode for MediaElementAudioSourceNode {
 }
 
 impl MediaElementAudioSourceNode {
-    pub fn new<C: AsBaseAudioContext>(
+    pub fn new<C: Context>(
         context: &C,
         options: MediaElementAudioSourceNodeOptions,
     ) -> Self {
-        context.base().register(move |registration| {
+        context.register(move |registration| {
             let controller = options.media.controller().clone();
             let scheduler = controller.scheduler().clone();
 

--- a/src/node/media_stream.rs
+++ b/src/node/media_stream.rs
@@ -1,5 +1,5 @@
 use crate::buffer::Resampler;
-use crate::context::{AsBaseAudioContext, AudioContextRegistration};
+use crate::context::{Context, AudioContextRegistration};
 use crate::control::Scheduler;
 use crate::media::MediaStream;
 
@@ -41,11 +41,11 @@ impl AudioNode for MediaStreamAudioSourceNode {
 }
 
 impl MediaStreamAudioSourceNode {
-    pub fn new<C: AsBaseAudioContext, M: MediaStream>(
+    pub fn new<C: Context, M: MediaStream>(
         context: &C,
         options: MediaStreamAudioSourceNodeOptions<M>,
     ) -> Self {
-        context.base().register(move |registration| {
+        context.register(move |registration| {
             let node = MediaStreamAudioSourceNode {
                 registration,
                 channel_config: options.channel_config.into(),

--- a/src/node/media_stream.rs
+++ b/src/node/media_stream.rs
@@ -1,5 +1,5 @@
 use crate::buffer::Resampler;
-use crate::context::{Context, AudioContextRegistration};
+use crate::context::{AudioContextRegistration, Context};
 use crate::control::Scheduler;
 use crate::media::MediaStream;
 

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -226,7 +226,8 @@ pub trait AudioNode {
             panic!("IndexSizeError: input port {} is out of bounds", input);
         }
 
-        self.registration().connect(self.id(), dest.id(), output, input);
+        self.registration()
+            .connect(self.id(), dest.id(), output, input);
         dest
     }
 

--- a/src/node/panner.rs
+++ b/src/node/panner.rs
@@ -1,7 +1,9 @@
 use std::f32::consts::PI;
 use std::sync::Arc;
 
-use crate::context::{AudioContextRegistration, AudioParamId, Context, ConnectListenerToPannerRole};
+use crate::context::{
+    AudioContextRegistration, AudioParamId, ConnectListenerToPannerRole, Context,
+};
 use crate::param::{AudioParam, AudioParamOptions};
 use crate::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum};
 use crate::{AtomicF32, SampleRate};

--- a/src/node/stereo_panner.rs
+++ b/src/node/stereo_panner.rs
@@ -11,7 +11,7 @@ use std::f32::consts::PI;
 use float_eq::debug_assert_float_eq;
 
 use crate::{
-    context::{Context, AudioContextRegistration, AudioParamId},
+    context::{AudioContextRegistration, AudioParamId, Context},
     param::{AudioParam, AudioParamOptions},
     render::{AudioParamValues, AudioProcessor, AudioRenderQuantum},
     SampleRate,
@@ -105,7 +105,7 @@ impl StereoPannerNode {
     ///
     /// * `context` - audio context in which the audio node will live.
     /// * `options` - stereo panner options
-    pub fn new<C: Context+?Sized>(context: &C, options: Option<StereoPannerOptions>) -> Self {
+    pub fn new<C: Context + ?Sized>(context: &C, options: Option<StereoPannerOptions>) -> Self {
         context.register(move |registration| {
             let options = options.unwrap_or_default();
 
@@ -128,9 +128,8 @@ impl StereoPannerNode {
                 default_value: default_pan,
                 automation_rate: crate::param::AutomationRate::A,
             };
-            let (pan_param, pan_proc) = context
-                
-                .create_audio_param(pan_param_opts, registration.id());
+            let (pan_param, pan_proc) =
+                context.create_audio_param(pan_param_opts, registration.id());
 
             pan_param.set_value(pan_value);
 

--- a/src/node/stereo_panner.rs
+++ b/src/node/stereo_panner.rs
@@ -11,7 +11,7 @@ use std::f32::consts::PI;
 use float_eq::debug_assert_float_eq;
 
 use crate::{
-    context::{AsBaseAudioContext, AudioContextRegistration, AudioParamId},
+    context::{Context, AudioContextRegistration, AudioParamId},
     param::{AudioParam, AudioParamOptions},
     render::{AudioParamValues, AudioProcessor, AudioRenderQuantum},
     SampleRate,
@@ -105,8 +105,8 @@ impl StereoPannerNode {
     ///
     /// * `context` - audio context in which the audio node will live.
     /// * `options` - stereo panner options
-    pub fn new<C: AsBaseAudioContext>(context: &C, options: Option<StereoPannerOptions>) -> Self {
-        context.base().register(move |registration| {
+    pub fn new<C: Context+?Sized>(context: &C, options: Option<StereoPannerOptions>) -> Self {
+        context.register(move |registration| {
             let options = options.unwrap_or_default();
 
             assert!(
@@ -129,7 +129,7 @@ impl StereoPannerNode {
                 automation_rate: crate::param::AutomationRate::A,
             };
             let (pan_param, pan_proc) = context
-                .base()
+                
                 .create_audio_param(pan_param_opts, registration.id());
 
             pan_param.set_value(pan_value);
@@ -267,7 +267,7 @@ mod test {
     use float_eq::assert_float_eq;
 
     use crate::{
-        context::{AsBaseAudioContext, OfflineAudioContext},
+        context::{Context, OfflineAudioContext},
         SampleRate,
     };
 

--- a/src/node/waveshaper.rs
+++ b/src/node/waveshaper.rs
@@ -8,7 +8,7 @@ use once_cell::sync::OnceCell;
 use rubato::{FftFixedInOut, Resampler};
 
 use crate::{
-    context::{Context, AudioContextRegistration},
+    context::{AudioContextRegistration, Context},
     render::{AudioParamValues, AudioProcessor, AudioRenderQuantum},
     SampleRate,
 };

--- a/src/node/waveshaper.rs
+++ b/src/node/waveshaper.rs
@@ -8,7 +8,7 @@ use once_cell::sync::OnceCell;
 use rubato::{FftFixedInOut, Resampler};
 
 use crate::{
-    context::{AsBaseAudioContext, AudioContextRegistration},
+    context::{Context, AudioContextRegistration},
     render::{AudioParamValues, AudioProcessor, AudioRenderQuantum},
     SampleRate,
 };
@@ -71,13 +71,13 @@ impl Default for WaveShaperOptions {
 ///
 /// - MDN documentation: <https://developer.mozilla.org/en-US/docs/Web/API/WaveShaperNode>
 /// - specification: <https://webaudio.github.io/web-audio-api/#WaveShaperNode>
-/// - see also: [`AsBaseAudioContext::create_wave_shaper`](crate::context::AsBaseAudioContext::create_wave_shaper)
+/// - see also: [`Context::create_wave_shaper`](crate::context::Context::create_wave_shaper)
 ///
 /// # Usage
 ///
 /// ```no_run
 /// use std::fs::File;
-/// use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+/// use web_audio_api::context::{Context, AudioContext};
 /// use web_audio_api::node::AudioNode;
 ///
 /// # use std::f32::consts::PI;
@@ -157,8 +157,8 @@ impl WaveShaperNode {
     ///
     /// * `context` - audio context in which the audio node will live.
     /// * `options` - waveshaper options
-    pub fn new<C: AsBaseAudioContext>(context: &C, options: Option<WaveShaperOptions>) -> Self {
-        context.base().register(move |registration| {
+    pub fn new<C: Context>(context: &C, options: Option<WaveShaperOptions>) -> Self {
+        context.register(move |registration| {
             let WaveShaperOptions {
                 curve,
                 oversample,

--- a/src/param.rs
+++ b/src/param.rs
@@ -436,7 +436,8 @@ impl AudioParam {
             // bypass audiocontext enveloping of control messages for simpler testing
             self.sender.send(event).unwrap();
         } else {
-            self.registration().pass_audio_param_event(&self.sender, event);
+            self.registration()
+                .pass_audio_param_event(&self.sender, event);
         }
     }
 }

--- a/src/param.rs
+++ b/src/param.rs
@@ -436,7 +436,7 @@ impl AudioParam {
             // bypass audiocontext enveloping of control messages for simpler testing
             self.sender.send(event).unwrap();
         } else {
-            self.context().pass_audio_param_event(&self.sender, event);
+            self.registration().pass_audio_param_event(&self.sender, event);
         }
     }
 }
@@ -1338,7 +1338,7 @@ pub(crate) fn audio_param_pair(
 mod tests {
     use float_eq::assert_float_eq;
 
-    use crate::context::{AsBaseAudioContext, OfflineAudioContext};
+    use crate::context::{Context, OfflineAudioContext};
 
     use super::*;
 

--- a/src/periodic_wave.rs
+++ b/src/periodic_wave.rs
@@ -2,9 +2,8 @@
 use std::f32::consts::PI;
 use std::sync::Arc;
 
-use crate::context::AsBaseAudioContext;
-
 use crate::node::TABLE_LENGTH_USIZE;
+use crate::context::Context;
 
 /// Options for constructing an `PeriodicWave`
 pub struct PeriodicWaveOptions {
@@ -35,13 +34,13 @@ pub struct PeriodicWaveOptions {
 ///
 /// - MDN documentation: <https://developer.mozilla.org/en-US/docs/Web/API/PeriodicWave>
 /// - specification: <https://webaudio.github.io/web-audio-api/#PeriodicWave>
-/// - see also: [`AsBaseAudioContext::create_periodic_wave`](crate::context::AsBaseAudioContext::create_periodic_wave)
+/// - see also: [`Context::create_periodic_wave`](crate::context::Context::create_periodic_wave)
 /// - see also: [`OscillatorNode`](crate::node::OscillatorNode)
 ///
 /// # Usage
 ///
 /// ```no_run
-/// use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+/// use web_audio_api::context::{Context, AudioContext};
 /// use web_audio_api::periodic_wave::{PeriodicWave, PeriodicWaveOptions};
 /// use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 ///
@@ -88,7 +87,7 @@ impl PeriodicWave {
     /// * `imag` is defined and its length is less than 2
     /// * `real` and `imag` are defined and theirs lengths are not equal
     /// * `PeriodicWave` is more than 8192 components
-    pub fn new<C: AsBaseAudioContext>(_context: &C, options: Option<PeriodicWaveOptions>) -> Self {
+    pub fn new<C: Context>(_context: &C, options: Option<PeriodicWaveOptions>) -> Self {
         let (real, imag, normalize) = if let Some(PeriodicWaveOptions {
             real,
             imag,

--- a/src/periodic_wave.rs
+++ b/src/periodic_wave.rs
@@ -2,8 +2,8 @@
 use std::f32::consts::PI;
 use std::sync::Arc;
 
-use crate::node::TABLE_LENGTH_USIZE;
 use crate::context::Context;
+use crate::node::TABLE_LENGTH_USIZE;
 
 /// Options for constructing an `PeriodicWave`
 pub struct PeriodicWaveOptions {

--- a/src/render/processor.rs
+++ b/src/render/processor.rs
@@ -10,7 +10,7 @@ use super::{graph::Node, AudioRenderQuantum, NodeIndex};
 /// Interface for audio processing code that runs on the audio rendering thread.
 ///
 /// Note that the AudioProcessor is typically constructed together with an [`crate::node::AudioNode`]
-/// (the user facing object that lives in the control thread). See [`crate::context::BaseAudioContext::register`].
+/// (the user facing object that lives in the control thread). See [`crate::context::Context::register`].
 ///
 /// Check the `examples/worklet.rs` file for example usage of this trait.
 pub trait AudioProcessor: Send {

--- a/src/spatial.rs
+++ b/src/spatial.rs
@@ -1,7 +1,7 @@
 //! Spatialization/Panning primitives
 //!
 //! Required for panning algorithm, distance and cone effects of [`crate::node::PannerNode`]s
-use crate::context::{AsBaseAudioContext, AudioContextRegistration, AudioParamId};
+use crate::context::{AudioContextRegistration, AudioParamId, Context};
 use crate::node::{
     AudioNode, ChannelConfig, ChannelConfigOptions, ChannelCountMode, ChannelInterpretation,
 };
@@ -116,10 +116,10 @@ impl AudioNode for AudioListenerNode {
 }
 
 impl AudioListenerNode {
-    pub fn new<C: AsBaseAudioContext>(context: &C) -> Self {
-        context.base().register(move |registration| {
+    pub fn new<C: Context>(context: &C) -> Self {
+        context.register(move |registration| {
             let reg_id = registration.id();
-            let base = context.base();
+            let base = context;
 
             let forward_z_opts = AudioParamOptions {
                 default_value: -1.,

--- a/tests/media.rs
+++ b/tests/media.rs
@@ -1,7 +1,6 @@
 use float_eq::assert_float_eq;
 use web_audio_api::buffer::AudioBuffer;
-use web_audio_api::context::AsBaseAudioContext;
-use web_audio_api::context::OfflineAudioContext;
+use web_audio_api::context::{Context, OfflineAudioContext};
 use web_audio_api::media::MediaElement;
 use web_audio_api::node::{AudioControllableSourceNode, AudioNode, AudioScheduledSourceNode};
 use web_audio_api::{SampleRate, RENDER_QUANTUM_SIZE};

--- a/tests/offline.rs
+++ b/tests/offline.rs
@@ -1,6 +1,5 @@
 use float_eq::assert_float_eq;
-use web_audio_api::context::AsBaseAudioContext;
-use web_audio_api::context::OfflineAudioContext;
+use web_audio_api::context::{Context, OfflineAudioContext};
 use web_audio_api::node::{
     AudioNode, AudioScheduledSourceNode, OscillatorNode, OscillatorOptions, OscillatorType,
 };


### PR DESCRIPTION
The point of this exploration is to see if we can hide some of the internals of the (base)audiocontext implementation from the user facing code as discussed in #76 
Ideally AsBaseAudioContext should go, as it is not part of the official spec and might surprise users that they have to import that trait. I'm not entirely sure if we can drop it though as it is used in the generics setup. We should be able to drop it from user facing code though
The BaseAudioContext must stay as it is part of the spec