### PR TITLE
Rename AsBaseAudioContext -> BaseAudioContext

### DIFF
--- a/examples/amplitude_modulation.rs
+++ b/examples/amplitude_modulation.rs
@@ -1,5 +1,5 @@
 use std::{thread, time};
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{AudioContext, BaseAudioContext};
 use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 
 fn main() {

--- a/examples/biquad.rs
+++ b/examples/biquad.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{AudioContext, BaseAudioContext};
 use web_audio_api::media::{MediaDecoder, MediaElement};
 use web_audio_api::node::{AudioControllableSourceNode, AudioNode, AudioScheduledSourceNode};
 

--- a/examples/constant_source.rs
+++ b/examples/constant_source.rs
@@ -1,5 +1,5 @@
 use std::{thread, time};
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{AudioContext, BaseAudioContext};
 use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 
 fn main() {

--- a/examples/decoding.rs
+++ b/examples/decoding.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{AudioContext, BaseAudioContext};
 use web_audio_api::node::AudioNode;
 
 fn main() {

--- a/examples/feedback_delay.rs
+++ b/examples/feedback_delay.rs
@@ -1,7 +1,7 @@
 use rand::rngs::ThreadRng;
 use rand::Rng;
 use std::{thread, time};
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{AudioContext, BaseAudioContext};
 use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 
 // run in release mode

--- a/examples/granular.rs
+++ b/examples/granular.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 use std::{thread, time};
 use web_audio_api::buffer::AudioBuffer;
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{AudioContext, BaseAudioContext};
 use web_audio_api::node::AudioNode;
 
 // run in release mode

--- a/examples/iir.rs
+++ b/examples/iir.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{AudioContext, BaseAudioContext};
 use web_audio_api::media::{MediaDecoder, MediaElement};
 use web_audio_api::node::{AudioControllableSourceNode, AudioNode, AudioScheduledSourceNode};
 

--- a/examples/many_oscillators.rs
+++ b/examples/many_oscillators.rs
@@ -1,5 +1,5 @@
 use std::{thread, time};
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{AudioContext, BaseAudioContext};
 use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 
 fn trigger_sine(audio_context: &AudioContext) {

--- a/examples/many_oscillators_with_env.rs
+++ b/examples/many_oscillators_with_env.rs
@@ -1,7 +1,7 @@
 use rand::rngs::ThreadRng;
 use rand::Rng;
 use std::{thread, time};
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{AudioContext, BaseAudioContext};
 use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 
 // run in release mode

--- a/examples/media_element.rs
+++ b/examples/media_element.rs
@@ -1,4 +1,4 @@
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{AudioContext, BaseAudioContext};
 use web_audio_api::media::{MediaDecoder, MediaElement};
 use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 

--- a/examples/merger.rs
+++ b/examples/merger.rs
@@ -1,4 +1,4 @@
-use web_audio_api::context::{AsBaseAudioContext, AudioContext, AudioContextOptions, LatencyHint};
+use web_audio_api::context::{AudioContext, AudioContextOptions, BaseAudioContext, LatencyHint};
 use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 
 fn main() {

--- a/examples/mic_playback.rs
+++ b/examples/mic_playback.rs
@@ -2,7 +2,7 @@
 // `cargo run --release --example mic_playback`
 
 use web_audio_api::buffer::AudioBuffer;
-use web_audio_api::context::{AsBaseAudioContext, AudioContext, AudioContextRegistration};
+use web_audio_api::context::{AudioContext, AudioContextRegistration, BaseAudioContext};
 use web_audio_api::media::Microphone;
 use web_audio_api::node::BiquadFilterType;
 use web_audio_api::node::{
@@ -57,7 +57,7 @@ impl AudioNode for MediaRecorder {
 
 impl MediaRecorder {
     /// Construct a new MediaRecorder
-    fn new<C: AsBaseAudioContext>(context: &C) -> Self {
+    fn new<C: BaseAudioContext>(context: &C) -> Self {
         context.base().register(move |registration| {
             let (sender, receiver) = crossbeam_channel::unbounded();
 

--- a/examples/microphone.rs
+++ b/examples/microphone.rs
@@ -1,4 +1,4 @@
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{AudioContext, BaseAudioContext};
 use web_audio_api::media::Microphone;
 use web_audio_api::node::AudioNode;
 

--- a/examples/oscillators.rs
+++ b/examples/oscillators.rs
@@ -1,5 +1,5 @@
 //! This example plays each oscillator type sequentially
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{AudioContext, BaseAudioContext};
 use web_audio_api::node::{AudioNode, AudioScheduledSourceNode, OscillatorType};
 use web_audio_api::periodic_wave::PeriodicWaveOptions;
 

--- a/examples/panner_cone.rs
+++ b/examples/panner_cone.rs
@@ -1,4 +1,4 @@
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{AudioContext, BaseAudioContext};
 use web_audio_api::node::AudioNode;
 use web_audio_api::node::AudioScheduledSourceNode;
 

--- a/examples/simple_delay.rs
+++ b/examples/simple_delay.rs
@@ -1,6 +1,6 @@
 use std::fs::File;
 use std::{thread, time};
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{AudioContext, BaseAudioContext};
 use web_audio_api::node::AudioNode;
 
 fn main() {

--- a/examples/spatial.rs
+++ b/examples/spatial.rs
@@ -1,4 +1,4 @@
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{AudioContext, BaseAudioContext};
 use web_audio_api::node::AudioNode;
 use web_audio_api::node::AudioScheduledSourceNode;
 

--- a/examples/stereo.rs
+++ b/examples/stereo.rs
@@ -1,4 +1,4 @@
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{AudioContext, BaseAudioContext};
 use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 
 fn main() {

--- a/examples/trigger_soundfile.rs
+++ b/examples/trigger_soundfile.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{AudioContext, BaseAudioContext};
 use web_audio_api::node::AudioNode;
 
 fn main() {

--- a/examples/waveshaper.rs
+++ b/examples/waveshaper.rs
@@ -1,6 +1,6 @@
 use std::f32::consts::PI;
 use std::fs::File;
-use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+use web_audio_api::context::{AudioContext, BaseAudioContext};
 use web_audio_api::node::{AudioNode, OverSampleType};
 
 // use part of cosine, between [π, 2π] as shaping cureve

--- a/examples/worklet.rs
+++ b/examples/worklet.rs
@@ -1,7 +1,7 @@
 use rand::Rng;
 
 use web_audio_api::context::{
-    AsBaseAudioContext, AudioContext, AudioContextRegistration, AudioParamId,
+    AudioContext, AudioContextRegistration, AudioParamId, BaseAudioContext,
 };
 use web_audio_api::node::{AudioNode, ChannelConfig, ChannelConfigOptions};
 use web_audio_api::param::{AudioParam, AudioParamOptions, AutomationRate};
@@ -41,7 +41,7 @@ impl AudioNode for WhiteNoiseNode {
 
 impl WhiteNoiseNode {
     /// Construct a new WhiteNoiseNode
-    fn new<C: AsBaseAudioContext>(context: &C) -> Self {
+    fn new<C: BaseAudioContext>(context: &C) -> Self {
         context.base().register(move |registration| {
             // setup the amplitude audio param
             let param_opts = AudioParamOptions {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -19,7 +19,7 @@ pub struct AudioBufferOptions {
 ///
 /// - MDN documentation: <https://developer.mozilla.org/en-US/docs/Web/API/AudioBuffer>
 /// - specification: <https://webaudio.github.io/web-audio-api/#AudioBuffer>
-/// - see also: [`AsBaseAudioContext::create_buffer`](crate::context::AsBaseAudioContext::create_buffer)
+/// - see also: [`BaseAudioContext::create_buffer`](crate::context::BaseAudioContext::create_buffer)
 #[derive(Clone, Debug)]
 pub struct AudioBuffer {
     channels: Vec<ChannelData>,

--- a/src/context.rs
+++ b/src/context.rs
@@ -41,18 +41,22 @@ use cpal::{traits::StreamTrait, Stream};
 
 use crossbeam_channel::Sender;
 
-/// The `BaseAudioContext` interface represents an audio-processing graph built from audio modules
-/// linked together, each represented by an `AudioNode`. An audio context controls both the creation
-/// of the nodes it contains and the execution of the audio processing, or decoding.
+/// The struct that corresponds to the Javascript `BaseAudioContext` object.
+///
+/// Please note that in rust, we need to differentiate between the [`BaseAudioContext`] trait and
+/// the [`ConcreteBaseAudioContext`] concrete implementation.
+///
+/// This object is returned from the `base()` method on `AudioContext` and `OfflineAudioContext`,
+/// or the `context()` method on `AudioNode`s.
 // the naming comes from the web audio specfication
 #[allow(clippy::module_name_repetitions)]
 #[derive(Clone)]
-pub struct BaseAudioContext {
+pub struct ConcreteBaseAudioContext {
     /// inner makes `BaseAudioContextInner` cheap to clone
     inner: Arc<BaseAudioContextInner>,
 }
 
-impl PartialEq for BaseAudioContext {
+impl PartialEq for ConcreteBaseAudioContext {
     fn eq(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.inner, &other.inner)
     }
@@ -76,11 +80,18 @@ struct BaseAudioContextInner {
     listener_params: Option<AudioListenerParams>,
 }
 
-/// Retrieve the `BaseAudioContext` from the concrete `AudioContext`
+/// The interface representing an audio-processing graph built from audio modules linked together,
+/// each represented by an `AudioNode`.
+///
+/// An audio context controls both the creation of the nodes it contains and the execution of the
+/// audio processing, or decoding.
+///
+/// Please note that in rust, we need to differentiate between the [`BaseAudioContext`] trait and
+/// the [`ConcreteBaseAudioContext`] concrete implementation.
 #[allow(clippy::module_name_repetitions)]
-pub trait AsBaseAudioContext {
-    /// retrieves the `BaseAudioContext` associated with the concrete `AudioContext`
-    fn base(&self) -> &BaseAudioContext;
+pub trait BaseAudioContext {
+    /// retrieves the `ConcreteBaseAudioContext` associated with this `AudioContext`
+    fn base(&self) -> &ConcreteBaseAudioContext;
 
     /// Decode an [`AudioBuffer`] from a given input stream.
     ///
@@ -103,7 +114,7 @@ pub trait AsBaseAudioContext {
     /// ```no_run
     /// use std::io::Cursor;
     /// use web_audio_api::SampleRate;
-    /// use web_audio_api::context::{AsBaseAudioContext, OfflineAudioContext};
+    /// use web_audio_api::context::{BaseAudioContext, OfflineAudioContext};
     ///
     /// let input = Cursor::new(vec![0; 32]); // or a File, TcpStream, ...
     ///
@@ -351,7 +362,7 @@ pub trait AsBaseAudioContext {
     }
 
     /// The raw sample rate of the `AudioContext` (which has more precision than the float
-    /// [`sample_rate()`](AsBaseAudioContext::sample_rate) value).
+    /// [`sample_rate()`](BaseAudioContext::sample_rate) value).
     #[must_use]
     fn sample_rate_raw(&self) -> SampleRate {
         self.base().sample_rate_raw()
@@ -372,8 +383,8 @@ pub trait AsBaseAudioContext {
     }
 }
 
-impl AsBaseAudioContext for BaseAudioContext {
-    fn base(&self) -> &BaseAudioContext {
+impl BaseAudioContext for ConcreteBaseAudioContext {
+    fn base(&self) -> &ConcreteBaseAudioContext {
         self
     }
 }
@@ -413,15 +424,15 @@ pub struct AudioContextOptions {
 #[allow(clippy::module_name_repetitions)]
 pub struct AudioContext {
     /// represents the underlying `BaseAudioContext`
-    base: BaseAudioContext,
+    base: ConcreteBaseAudioContext,
 
     /// cpal stream (play/pause functionality)
     #[cfg(not(test))] // in tests, do not set up a cpal Stream
     stream: Mutex<Option<Stream>>,
 }
 
-impl AsBaseAudioContext for AudioContext {
-    fn base(&self) -> &BaseAudioContext {
+impl BaseAudioContext for AudioContext {
+    fn base(&self) -> &ConcreteBaseAudioContext {
         &self.base
     }
 }
@@ -432,15 +443,15 @@ impl AsBaseAudioContext for AudioContext {
 #[allow(clippy::module_name_repetitions)]
 pub struct OfflineAudioContext {
     /// represents the underlying `BaseAudioContext`
-    base: BaseAudioContext,
+    base: ConcreteBaseAudioContext,
     /// the size of the buffer in sample-frames
     length: usize,
     /// the rendering 'thread', fully controlled by the offline context
     renderer: RenderThread,
 }
 
-impl AsBaseAudioContext for OfflineAudioContext {
-    fn base(&self) -> &BaseAudioContext {
+impl BaseAudioContext for OfflineAudioContext {
+    fn base(&self) -> &ConcreteBaseAudioContext {
         &self.base
     }
 }
@@ -461,7 +472,7 @@ impl AudioContext {
         let channels = u32::from(config.channels);
         let sample_rate = SampleRate(config.sample_rate.0);
 
-        let base = BaseAudioContext::new(sample_rate, channels, frames_played, sender);
+        let base = ConcreteBaseAudioContext::new(sample_rate, channels, frames_played, sender);
 
         Self {
             base,
@@ -482,7 +493,7 @@ impl AudioContext {
         let channels = u32::from(options.channels.unwrap_or(2));
         let (sender, _receiver) = crossbeam_channel::unbounded();
         let frames_played = Arc::new(AtomicU64::new(0));
-        let base = BaseAudioContext::new(sample_rate, channels, frames_played, sender);
+        let base = ConcreteBaseAudioContext::new(sample_rate, channels, frames_played, sender);
 
         Self { base }
     }
@@ -564,10 +575,10 @@ impl From<&AudioParamId> for NodeIndex {
 ///
 /// This allows for communication with the render thread and lifetime management.
 ///
-/// The only way to construct this object is by calling [`BaseAudioContext::register`]
+/// The only way to construct this object is by calling [`ConcreteBaseAudioContext::register`]
 pub struct AudioContextRegistration {
     /// the audio context in wich nodes and connections lives
-    context: BaseAudioContext,
+    context: ConcreteBaseAudioContext,
     /// identify a specific `AudioNode`
     id: AudioNodeId,
 }
@@ -584,7 +595,7 @@ impl AudioContextRegistration {
     // false positive: AudioContextRegistration is not const
     #[allow(clippy::missing_const_for_fn, clippy::unused_self)]
     #[must_use]
-    pub fn context(&self) -> &BaseAudioContext {
+    pub fn context(&self) -> &ConcreteBaseAudioContext {
         &self.context
     }
 }
@@ -606,7 +617,7 @@ impl Drop for AudioContextRegistration {
     }
 }
 
-impl BaseAudioContext {
+impl ConcreteBaseAudioContext {
     /// Creates a `BaseAudioContext` instance
     fn new(
         sample_rate: SampleRate,
@@ -681,7 +692,7 @@ impl BaseAudioContext {
     }
 
     /// The raw sample rate of the `AudioContext` (which has more precision than the float
-    /// [`sample_rate()`](AsBaseAudioContext::sample_rate) value).
+    /// [`sample_rate()`](BaseAudioContext::sample_rate) value).
     #[must_use]
     pub fn sample_rate_raw(&self) -> SampleRate {
         self.inner.sample_rate
@@ -852,7 +863,7 @@ impl OfflineAudioContext {
         );
 
         // first, setup the base audio context
-        let base = BaseAudioContext::new(sample_rate, channels, frames_played, sender);
+        let base = ConcreteBaseAudioContext::new(sample_rate, channels, frames_played, sender);
 
         Self {
             base,

--- a/src/context.rs
+++ b/src/context.rs
@@ -46,14 +46,16 @@ use crossbeam_channel::Sender;
 /// Please note that in rust, we need to differentiate between the [`BaseAudioContext`] trait and
 /// the [`ConcreteBaseAudioContext`] concrete implementation.
 ///
-/// This object is returned from the `base()` method on `AudioContext` and `OfflineAudioContext`,
-/// or the `context()` method on `AudioNode`s.
+/// This object is returned from the `base()` method on [`AudioContext`] and
+/// [`OfflineAudioContext`], or the `context()` method on `AudioNode`s.
+///
+/// The `ConcreteBaseAudioContext` allows for cheap cloning (using an `Arc` internally).
 // the naming comes from the web audio specfication
 #[allow(clippy::module_name_repetitions)]
 #[derive(Clone)]
 pub struct ConcreteBaseAudioContext {
-    /// inner makes `BaseAudioContextInner` cheap to clone
-    inner: Arc<BaseAudioContextInner>,
+    /// inner makes `ConcreteBaseAudioContext` cheap to clone
+    inner: Arc<ConcreteBaseAudioContextInner>,
 }
 
 impl PartialEq for ConcreteBaseAudioContext {
@@ -62,8 +64,10 @@ impl PartialEq for ConcreteBaseAudioContext {
     }
 }
 
-/// Inner representation of the `BaseAudioContext`
-struct BaseAudioContextInner {
+/// Inner representation of the `ConcreteBaseAudioContext`
+///
+/// These fields are wrapped inside an `Arc` in the actual `ConcreteBaseAudioContext`.
+struct ConcreteBaseAudioContextInner {
     /// sample rate in Hertz
     sample_rate: SampleRate,
     /// number of speaker output channels
@@ -625,7 +629,7 @@ impl ConcreteBaseAudioContext {
         frames_played: Arc<AtomicU64>,
         render_channel: Sender<ControlMessage>,
     ) -> Self {
-        let base_inner = BaseAudioContextInner {
+        let base_inner = ConcreteBaseAudioContextInner {
             sample_rate,
             channels,
             render_channel,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! # Example
 //! ```no_run
 //! use std::fs::File;
-//! use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+//! use web_audio_api::context::{BaseAudioContext, AudioContext};
 //! use web_audio_api::media::{MediaElement, MediaDecoder};
 //! use web_audio_api::node::{AudioNode, AudioControllableSourceNode, AudioScheduledSourceNode};
 //!

--- a/src/media/decoding.rs
+++ b/src/media/decoding.rs
@@ -52,7 +52,7 @@ impl<R: Read + Send> symphonia::core::io::MediaSource for MediaInput<R> {
 ///
 /// Using the `MediaDecoder` is the preferred way to play large audio files and streams. For small
 /// soundbites, consider using
-/// [`decode_audio_data`](crate::context::AsBaseAudioContext::decode_audio_data) on the audio
+/// [`decode_audio_data`](crate::context::BaseAudioContext::decode_audio_data) on the audio
 /// context which will create a single AudioBuffer which can be played/looped with high precision
 /// in an `AudioBufferSourceNode`.
 ///
@@ -65,7 +65,7 @@ impl<R: Read + Send> symphonia::core::io::MediaSource for MediaInput<R> {
 ///
 /// ```no_run
 /// use web_audio_api::media::{MediaElement, MediaDecoder};
-/// use web_audio_api::context::{AudioContext, AsBaseAudioContext};
+/// use web_audio_api::context::{AudioContext, BaseAudioContext};
 /// use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 ///
 /// // construct the decoder

--- a/src/media/mic.rs
+++ b/src/media/mic.rs
@@ -24,7 +24,7 @@ use crossbeam_channel::{Receiver, TryRecvError};
 /// # Example
 ///
 /// ```no_run
-/// use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+/// use web_audio_api::context::{BaseAudioContext, AudioContext};
 /// use web_audio_api::media::Microphone;
 /// use web_audio_api::node::AudioNode;
 ///

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -35,7 +35,7 @@ use crossbeam_channel::{self, Receiver};
 ///
 /// ```no_run
 /// use web_audio_api::SampleRate;
-/// use web_audio_api::context::{AudioContext, AsBaseAudioContext};
+/// use web_audio_api::context::{AudioContext, BaseAudioContext};
 /// use web_audio_api::buffer::{AudioBuffer, AudioBufferOptions};
 /// use web_audio_api::node::AudioNode;
 ///
@@ -76,7 +76,7 @@ impl<M: Iterator<Item = Result<AudioBuffer, Box<dyn Error + Send + Sync>>> + Sen
 ///
 /// ```rust
 /// use web_audio_api::SampleRate;
-/// use web_audio_api::context::{AudioContext, AsBaseAudioContext};
+/// use web_audio_api::context::{AudioContext, BaseAudioContext};
 /// use web_audio_api::buffer::AudioBuffer;
 /// use web_audio_api::media::MediaElement;
 /// use web_audio_api::node::AudioControllableSourceNode;
@@ -103,7 +103,7 @@ impl<M: Iterator<Item = Result<AudioBuffer, Box<dyn Error + Send + Sync>>> + Sen
 ///               b.get_channel_data(0)[..],
 ///               vec![0.; 20][..]
 ///           )
-///       },
+///       }
 ///       Err(e) => (),
 ///   }
 /// }

--- a/src/node/analyser.rs
+++ b/src/node/analyser.rs
@@ -2,7 +2,7 @@ use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use crate::analysis::Analyser;
-use crate::context::{AsBaseAudioContext, AudioContextRegistration};
+use crate::context::{AudioContextRegistration, BaseAudioContext};
 use crate::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum};
 use crate::SampleRate;
 
@@ -77,7 +77,7 @@ impl AudioNode for AnalyserNode {
 }
 
 impl AnalyserNode {
-    pub fn new<C: AsBaseAudioContext>(context: &C, options: AnalyserOptions) -> Self {
+    pub fn new<C: BaseAudioContext>(context: &C, options: AnalyserOptions) -> Self {
         context.base().register(move |registration| {
             let fft_size = Arc::new(AtomicUsize::new(options.fft_size));
             let smoothing_time_constant = Arc::new(AtomicU32::new(

--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -3,7 +3,7 @@ use once_cell::sync::OnceCell;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::buffer::AudioBuffer;
-use crate::context::{AsBaseAudioContext, AudioContextRegistration, AudioParamId};
+use crate::context::{AudioContextRegistration, AudioParamId, BaseAudioContext};
 use crate::control::Controller;
 use crate::param::{AudioParam, AudioParamOptions, AutomationRate};
 use crate::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum};
@@ -44,13 +44,13 @@ struct AudioBufferMessage(AudioBuffer);
 ///
 /// - MDN documentation: <https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode>
 /// - specification: <https://webaudio.github.io/web-audio-api/#AudioBufferSourceNode>
-/// - see also: [`AsBaseAudioContext::create_buffer_source`](crate::context::AsBaseAudioContext::create_buffer_source)
+/// - see also: [`BaseAudioContext::create_buffer_source`](crate::context::BaseAudioContext::create_buffer_source)
 ///
 /// # Usage
 ///
 /// ```no_run
 /// use std::fs::File;
-/// use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+/// use web_audio_api::context::{BaseAudioContext, AudioContext};
 /// use web_audio_api::node::AudioNode;
 ///
 /// // create an `AudioContext`
@@ -100,7 +100,7 @@ impl AudioNode for AudioBufferSourceNode {
 
 impl AudioBufferSourceNode {
     /// Create a new [`AudioBufferSourceNode`] instance
-    pub fn new<C: AsBaseAudioContext>(context: &C, options: AudioBufferSourceOptions) -> Self {
+    pub fn new<C: BaseAudioContext>(context: &C, options: AudioBufferSourceOptions) -> Self {
         context.base().register(move |registration| {
             let AudioBufferSourceOptions {
                 buffer,
@@ -559,7 +559,7 @@ impl AudioBufferSourceRenderer {
 
 #[cfg(test)]
 mod tests {
-    use crate::context::{AsBaseAudioContext, OfflineAudioContext};
+    use crate::context::{BaseAudioContext, OfflineAudioContext};
     use crate::node::AudioNode;
     use crate::{SampleRate, RENDER_QUANTUM_SIZE};
 

--- a/src/node/biquad_filter.rs
+++ b/src/node/biquad_filter.rs
@@ -18,7 +18,7 @@ use crossbeam_channel::{Receiver, Sender};
 use num_complex::Complex;
 
 use crate::{
-    context::{AsBaseAudioContext, AudioContextRegistration, AudioParamId},
+    context::{AudioContextRegistration, AudioParamId, BaseAudioContext},
     param::{AudioParam, AudioParamOptions},
     render::{AudioParamValues, AudioProcessor, AudioRenderQuantum},
     SampleRate, MAX_CHANNELS,
@@ -163,7 +163,7 @@ impl BiquadFilterNode {
     ///
     /// * `context` - audio context in which the audio node will live.
     /// * `options` - biquad filter options
-    pub fn new<C: AsBaseAudioContext>(context: &C, options: Option<BiquadFilterOptions>) -> Self {
+    pub fn new<C: BaseAudioContext>(context: &C, options: Option<BiquadFilterOptions>) -> Self {
         context.base().register(move |registration| {
             let options = options.unwrap_or_default();
 
@@ -1097,7 +1097,7 @@ mod test {
     use float_eq::assert_float_eq;
 
     use crate::{
-        context::{AsBaseAudioContext, OfflineAudioContext},
+        context::{BaseAudioContext, OfflineAudioContext},
         SampleRate,
     };
 

--- a/src/node/channel_merger.rs
+++ b/src/node/channel_merger.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use crate::context::{AsBaseAudioContext, AudioContextRegistration};
+use crate::context::{AudioContextRegistration, BaseAudioContext};
 use crate::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum};
 use crate::SampleRate;
 
@@ -60,7 +60,7 @@ impl AudioNode for ChannelMergerNode {
 }
 
 impl ChannelMergerNode {
-    pub fn new<C: AsBaseAudioContext>(context: &C, mut options: ChannelMergerOptions) -> Self {
+    pub fn new<C: BaseAudioContext>(context: &C, mut options: ChannelMergerOptions) -> Self {
         context.base().register(move |registration| {
             options.channel_config.count = options.number_of_inputs as _;
 

--- a/src/node/channel_splitter.rs
+++ b/src/node/channel_splitter.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use crate::context::{AsBaseAudioContext, AudioContextRegistration};
+use crate::context::{AudioContextRegistration, BaseAudioContext};
 use crate::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum};
 use crate::SampleRate;
 
@@ -60,7 +60,7 @@ impl AudioNode for ChannelSplitterNode {
 }
 
 impl ChannelSplitterNode {
-    pub fn new<C: AsBaseAudioContext>(context: &C, mut options: ChannelSplitterOptions) -> Self {
+    pub fn new<C: BaseAudioContext>(context: &C, mut options: ChannelSplitterOptions) -> Self {
         context.base().register(move |registration| {
             options.channel_config.count = options.number_of_outputs as _;
 

--- a/src/node/constant_source.rs
+++ b/src/node/constant_source.rs
@@ -1,4 +1,4 @@
-use crate::context::{AsBaseAudioContext, AudioContextRegistration, AudioParamId};
+use crate::context::{AudioContextRegistration, AudioParamId, BaseAudioContext};
 use crate::control::Scheduler;
 use crate::param::{AudioParam, AudioParamOptions, AutomationRate};
 use crate::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum};
@@ -26,12 +26,12 @@ impl Default for ConstantSourceOptions {
 ///
 /// - MDN documentation: <https://developer.mozilla.org/en-US/docs/Web/API/ConstantSourceNode>
 /// - specification: <https://webaudio.github.io/web-audio-api/#ConstantSourceNode>
-/// - see also: [`AsBaseAudioContext::create_constant_source`](crate::context::AsBaseAudioContext::create_constant_source)
+/// - see also: [`BaseAudioContext::create_constant_source`](crate::context::BaseAudioContext::create_constant_source)
 ///
 /// # Usage
 ///
 /// ```no_run
-/// use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+/// use web_audio_api::context::{BaseAudioContext, AudioContext};
 /// use web_audio_api::node::AudioNode;
 ///
 /// let audio_context = AudioContext::new(None);
@@ -86,7 +86,7 @@ impl AudioScheduledSourceNode for ConstantSourceNode {
 }
 
 impl ConstantSourceNode {
-    pub fn new<C: AsBaseAudioContext>(context: &C, options: ConstantSourceOptions) -> Self {
+    pub fn new<C: BaseAudioContext>(context: &C, options: ConstantSourceOptions) -> Self {
         context.base().register(move |registration| {
             let param_opts = AudioParamOptions {
                 min_value: f32::MIN,
@@ -180,7 +180,7 @@ impl AudioProcessor for ConstantSourceRenderer {
 
 #[cfg(test)]
 mod tests {
-    use crate::context::{AsBaseAudioContext, OfflineAudioContext};
+    use crate::context::{BaseAudioContext, OfflineAudioContext};
     use crate::node::{AudioNode, AudioScheduledSourceNode};
     use crate::SampleRate;
 

--- a/src/node/delay.rs
+++ b/src/node/delay.rs
@@ -1,4 +1,4 @@
-use crate::context::{AsBaseAudioContext, AudioContextRegistration, AudioParamId};
+use crate::context::{AudioContextRegistration, AudioParamId, BaseAudioContext};
 use crate::param::{AudioParam, AudioParamOptions};
 use crate::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum};
 use crate::{SampleRate, RENDER_QUANTUM_SIZE};
@@ -32,13 +32,13 @@ impl Default for DelayOptions {
 ///
 /// - MDN documentation: <https://developer.mozilla.org/en-US/docs/Web/API/DelayNode>
 /// - specification: <https://webaudio.github.io/web-audio-api/#DelayNode>
-/// - see also: [`AsBaseAudioContext::create_delay`](crate::context::AsBaseAudioContext::create_delay)
+/// - see also: [`BaseAudioContext::create_delay`](crate::context::BaseAudioContext::create_delay)
 ///
 /// # Usage
 ///
 /// ```no_run
 /// use std::fs::File;
-/// use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+/// use web_audio_api::context::{BaseAudioContext, AudioContext};
 /// use web_audio_api::node::AudioNode;
 ///
 /// // create an `AudioContext` and load a sound file
@@ -152,7 +152,7 @@ impl AudioNode for DelayNode {
 }
 
 impl DelayNode {
-    pub fn new<C: AsBaseAudioContext>(context: &C, options: DelayOptions) -> Self {
+    pub fn new<C: BaseAudioContext>(context: &C, options: DelayOptions) -> Self {
         let sample_rate = context.sample_rate_raw().0 as f64;
 
         // Specifies the maximum delay time in seconds allowed for the delay line.

--- a/src/node/destination.rs
+++ b/src/node/destination.rs
@@ -1,4 +1,4 @@
-use crate::context::{AsBaseAudioContext, AudioContextRegistration};
+use crate::context::{AudioContextRegistration, BaseAudioContext};
 use crate::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum};
 use crate::SampleRate;
 
@@ -73,7 +73,7 @@ impl AudioNode for AudioDestinationNode {
 }
 
 impl AudioDestinationNode {
-    pub fn new<C: AsBaseAudioContext>(context: &C, channel_count: usize) -> Self {
+    pub fn new<C: BaseAudioContext>(context: &C, channel_count: usize) -> Self {
         context.base().register(move |registration| {
             let node = Self {
                 registration,

--- a/src/node/gain.rs
+++ b/src/node/gain.rs
@@ -1,4 +1,4 @@
-use crate::context::{AsBaseAudioContext, AudioContextRegistration, AudioParamId};
+use crate::context::{AudioContextRegistration, AudioParamId, BaseAudioContext};
 use crate::param::{AudioParam, AudioParamOptions};
 use crate::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum};
 use crate::SampleRate;
@@ -45,7 +45,7 @@ impl AudioNode for GainNode {
 }
 
 impl GainNode {
-    pub fn new<C: AsBaseAudioContext>(context: &C, options: GainOptions) -> Self {
+    pub fn new<C: BaseAudioContext>(context: &C, options: GainOptions) -> Self {
         context.base().register(move |registration| {
             let param_opts = AudioParamOptions {
                 min_value: f32::MIN,

--- a/src/node/iir_filter.rs
+++ b/src/node/iir_filter.rs
@@ -10,7 +10,7 @@ use num_complex::Complex;
 use std::f64::consts::PI;
 
 use crate::{
-    context::{AsBaseAudioContext, AudioContextRegistration},
+    context::{AudioContextRegistration, BaseAudioContext},
     render::{AudioParamValues, AudioProcessor, AudioRenderQuantum},
     SampleRate, MAX_CHANNELS,
 };
@@ -78,7 +78,7 @@ impl IirFilterNode {
     /// * `feedforward` or/and `feedback` is an empty vector
     /// * all `feedforward` element or/and all `feedback` element are eqaul to 0.
     /// *
-    pub fn new<C: AsBaseAudioContext>(context: &C, options: IirFilterOptions) -> Self {
+    pub fn new<C: BaseAudioContext>(context: &C, options: IirFilterOptions) -> Self {
         context.base().register(move |registration| {
             let IirFilterOptions {
                 feedforward,
@@ -348,7 +348,7 @@ mod test {
     use std::{cmp::min, fs::File};
 
     use crate::{
-        context::{AsBaseAudioContext, OfflineAudioContext},
+        context::{BaseAudioContext, OfflineAudioContext},
         media::{MediaDecoder, MediaElement},
         node::{AudioNode, AudioScheduledSourceNode},
         snapshot, SampleRate,

--- a/src/node/media_element.rs
+++ b/src/node/media_element.rs
@@ -1,5 +1,5 @@
 use crate::buffer::Resampler;
-use crate::context::{AsBaseAudioContext, AudioContextRegistration};
+use crate::context::{AudioContextRegistration, BaseAudioContext};
 use crate::control::{Controller, Scheduler};
 use crate::media::MediaElement;
 use crate::RENDER_QUANTUM_SIZE;
@@ -55,7 +55,7 @@ impl AudioNode for MediaElementAudioSourceNode {
 }
 
 impl MediaElementAudioSourceNode {
-    pub fn new<C: AsBaseAudioContext>(
+    pub fn new<C: BaseAudioContext>(
         context: &C,
         options: MediaElementAudioSourceNodeOptions,
     ) -> Self {

--- a/src/node/media_stream.rs
+++ b/src/node/media_stream.rs
@@ -1,5 +1,5 @@
 use crate::buffer::Resampler;
-use crate::context::{AsBaseAudioContext, AudioContextRegistration};
+use crate::context::{AudioContextRegistration, BaseAudioContext};
 use crate::control::Scheduler;
 use crate::media::MediaStream;
 
@@ -41,7 +41,7 @@ impl AudioNode for MediaStreamAudioSourceNode {
 }
 
 impl MediaStreamAudioSourceNode {
-    pub fn new<C: AsBaseAudioContext, M: MediaStream>(
+    pub fn new<C: BaseAudioContext, M: MediaStream>(
         context: &C,
         options: MediaStreamAudioSourceNodeOptions<M>,
     ) -> Self {

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -3,7 +3,7 @@ use std::f32::consts::PI;
 use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use crate::context::{AudioContextRegistration, AudioNodeId, BaseAudioContext};
+use crate::context::{AudioContextRegistration, AudioNodeId, ConcreteBaseAudioContext};
 use crate::control::{Controller, ScheduledState, Scheduler};
 use crate::media::MediaStream;
 use crate::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum};
@@ -180,7 +180,7 @@ impl From<ChannelConfigOptions> for ChannelConfig {
 /// to the audio hardware. Each node can have inputs and/or outputs.
 ///
 /// Note that the AudioNode is typically constructed together with an [`AudioProcessor`]
-/// (the object that lives the render thread). See [`BaseAudioContext::register`].
+/// (the object that lives the render thread). See [`ConcreteBaseAudioContext::register`].
 pub trait AudioNode {
     fn registration(&self) -> &AudioContextRegistration;
 
@@ -193,7 +193,7 @@ pub trait AudioNode {
     }
 
     /// The BaseAudioContext which owns this AudioNode.
-    fn context(&self) -> &BaseAudioContext {
+    fn context(&self) -> &ConcreteBaseAudioContext {
         self.registration().context()
     }
 

--- a/src/node/oscillator.rs
+++ b/src/node/oscillator.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 
-use crate::context::{AsBaseAudioContext, AudioContextRegistration, AudioParamId};
+use crate::context::{AudioContextRegistration, AudioParamId, BaseAudioContext};
 use crate::control::Scheduler;
 use crate::param::{AudioParam, AudioParamOptions, AutomationRate};
 use crate::periodic_wave::PeriodicWave;
@@ -84,14 +84,14 @@ impl From<u32> for OscillatorType {
 ///
 /// - MDN documentation: <https://developer.mozilla.org/en-US/docs/Web/API/OscillatorNode>
 /// - specification: <https://webaudio.github.io/web-audio-api/#OscillatorNode>
-/// - see also: [`AsBaseAudioContext::create_oscillator`](crate::context::AsBaseAudioContext::create_oscillator)
+/// - see also: [`BaseAudioContext::create_oscillator`](crate::context::BaseAudioContext::create_oscillator)
 /// - see also: [`PeriodicWave`](crate::periodic_wave::PeriodicWave)
 ///
 /// # Usage
 ///
 /// ```no_run
 /// use std::fs::File;
-/// use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+/// use web_audio_api::context::{BaseAudioContext, AudioContext};
 /// use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 ///
 /// let context = AudioContext::new(None);
@@ -158,7 +158,7 @@ impl OscillatorNode {
     ///
     /// * `context` - The `AudioContext`
     /// * `options` - The OscillatorOptions
-    pub fn new<C: AsBaseAudioContext>(context: &C, options: Option<OscillatorOptions>) -> Self {
+    pub fn new<C: BaseAudioContext>(context: &C, options: Option<OscillatorOptions>) -> Self {
         context.base().register(move |registration| {
             let sample_rate = context.sample_rate();
             let nyquist = sample_rate / 2.;
@@ -520,7 +520,7 @@ mod tests {
     use float_eq::assert_float_eq;
     use std::f64::consts::PI;
 
-    use crate::context::{AsBaseAudioContext, OfflineAudioContext};
+    use crate::context::{BaseAudioContext, OfflineAudioContext};
     use crate::node::{AudioNode, AudioScheduledSourceNode};
     use crate::periodic_wave::{PeriodicWave, PeriodicWaveOptions};
     use crate::SampleRate;

--- a/src/node/panner.rs
+++ b/src/node/panner.rs
@@ -1,7 +1,7 @@
 use std::f32::consts::PI;
 use std::sync::Arc;
 
-use crate::context::{AsBaseAudioContext, AudioContextRegistration, AudioParamId};
+use crate::context::{AudioContextRegistration, AudioParamId, BaseAudioContext};
 use crate::param::{AudioParam, AudioParamOptions};
 use crate::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum};
 use crate::{AtomicF32, SampleRate};
@@ -45,11 +45,11 @@ impl Default for PannerOptions {
 /// - specification: <https://www.w3.org/TR/webaudio/#pannernode> and
 /// <https://www.w3.org/TR/webaudio/#Spatialization>
 /// - see also:
-/// [`AsBaseAudioContext::create_panner`](crate::context::AsBaseAudioContext::create_panner)
+/// [`BaseAudioContext::create_panner`](crate::context::BaseAudioContext::create_panner)
 ///
 /// # Usage
 /// ```no_run
-/// use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+/// use web_audio_api::context::{BaseAudioContext, AudioContext};
 /// use web_audio_api::node::AudioNode;
 /// use web_audio_api::node::AudioScheduledSourceNode;
 ///
@@ -118,7 +118,7 @@ impl AudioNode for PannerNode {
 }
 
 impl PannerNode {
-    pub fn new<C: AsBaseAudioContext>(context: &C, options: PannerOptions) -> Self {
+    pub fn new<C: BaseAudioContext>(context: &C, options: PannerOptions) -> Self {
         let node = context.base().register(move |registration| {
             let id = registration.id();
 

--- a/src/node/stereo_panner.rs
+++ b/src/node/stereo_panner.rs
@@ -11,7 +11,7 @@ use std::f32::consts::PI;
 use float_eq::debug_assert_float_eq;
 
 use crate::{
-    context::{AsBaseAudioContext, AudioContextRegistration, AudioParamId},
+    context::{AudioContextRegistration, AudioParamId, BaseAudioContext},
     param::{AudioParam, AudioParamOptions},
     render::{AudioParamValues, AudioProcessor, AudioRenderQuantum},
     SampleRate,
@@ -105,7 +105,7 @@ impl StereoPannerNode {
     ///
     /// * `context` - audio context in which the audio node will live.
     /// * `options` - stereo panner options
-    pub fn new<C: AsBaseAudioContext>(context: &C, options: Option<StereoPannerOptions>) -> Self {
+    pub fn new<C: BaseAudioContext>(context: &C, options: Option<StereoPannerOptions>) -> Self {
         context.base().register(move |registration| {
             let options = options.unwrap_or_default();
 
@@ -267,7 +267,7 @@ mod test {
     use float_eq::assert_float_eq;
 
     use crate::{
-        context::{AsBaseAudioContext, OfflineAudioContext},
+        context::{BaseAudioContext, OfflineAudioContext},
         SampleRate,
     };
 

--- a/src/node/waveshaper.rs
+++ b/src/node/waveshaper.rs
@@ -8,7 +8,7 @@ use once_cell::sync::OnceCell;
 use rubato::{FftFixedInOut, Resampler};
 
 use crate::{
-    context::{AsBaseAudioContext, AudioContextRegistration},
+    context::{AudioContextRegistration, BaseAudioContext},
     render::{AudioParamValues, AudioProcessor, AudioRenderQuantum},
     SampleRate,
 };
@@ -71,13 +71,13 @@ impl Default for WaveShaperOptions {
 ///
 /// - MDN documentation: <https://developer.mozilla.org/en-US/docs/Web/API/WaveShaperNode>
 /// - specification: <https://webaudio.github.io/web-audio-api/#WaveShaperNode>
-/// - see also: [`AsBaseAudioContext::create_wave_shaper`](crate::context::AsBaseAudioContext::create_wave_shaper)
+/// - see also: [`BaseAudioContext::create_wave_shaper`](crate::context::BaseAudioContext::create_wave_shaper)
 ///
 /// # Usage
 ///
 /// ```no_run
 /// use std::fs::File;
-/// use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+/// use web_audio_api::context::{BaseAudioContext, AudioContext};
 /// use web_audio_api::node::AudioNode;
 ///
 /// # use std::f32::consts::PI;
@@ -157,7 +157,7 @@ impl WaveShaperNode {
     ///
     /// * `context` - audio context in which the audio node will live.
     /// * `options` - waveshaper options
-    pub fn new<C: AsBaseAudioContext>(context: &C, options: Option<WaveShaperOptions>) -> Self {
+    pub fn new<C: BaseAudioContext>(context: &C, options: Option<WaveShaperOptions>) -> Self {
         context.base().register(move |registration| {
             let WaveShaperOptions {
                 curve,

--- a/src/param.rs
+++ b/src/param.rs
@@ -1338,7 +1338,7 @@ pub(crate) fn audio_param_pair(
 mod tests {
     use float_eq::assert_float_eq;
 
-    use crate::context::{AsBaseAudioContext, OfflineAudioContext};
+    use crate::context::{BaseAudioContext, OfflineAudioContext};
 
     use super::*;
 

--- a/src/periodic_wave.rs
+++ b/src/periodic_wave.rs
@@ -2,7 +2,7 @@
 use std::f32::consts::PI;
 use std::sync::Arc;
 
-use crate::context::AsBaseAudioContext;
+use crate::context::BaseAudioContext;
 
 use crate::node::TABLE_LENGTH_USIZE;
 
@@ -35,13 +35,13 @@ pub struct PeriodicWaveOptions {
 ///
 /// - MDN documentation: <https://developer.mozilla.org/en-US/docs/Web/API/PeriodicWave>
 /// - specification: <https://webaudio.github.io/web-audio-api/#PeriodicWave>
-/// - see also: [`AsBaseAudioContext::create_periodic_wave`](crate::context::AsBaseAudioContext::create_periodic_wave)
+/// - see also: [`BaseAudioContext::create_periodic_wave`](crate::context::BaseAudioContext::create_periodic_wave)
 /// - see also: [`OscillatorNode`](crate::node::OscillatorNode)
 ///
 /// # Usage
 ///
 /// ```no_run
-/// use web_audio_api::context::{AsBaseAudioContext, AudioContext};
+/// use web_audio_api::context::{BaseAudioContext, AudioContext};
 /// use web_audio_api::periodic_wave::{PeriodicWave, PeriodicWaveOptions};
 /// use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 ///
@@ -88,7 +88,7 @@ impl PeriodicWave {
     /// * `imag` is defined and its length is less than 2
     /// * `real` and `imag` are defined and theirs lengths are not equal
     /// * `PeriodicWave` is more than 8192 components
-    pub fn new<C: AsBaseAudioContext>(_context: &C, options: Option<PeriodicWaveOptions>) -> Self {
+    pub fn new<C: BaseAudioContext>(_context: &C, options: Option<PeriodicWaveOptions>) -> Self {
         let (real, imag, normalize) = if let Some(PeriodicWaveOptions {
             real,
             imag,

--- a/src/render/processor.rs
+++ b/src/render/processor.rs
@@ -10,7 +10,7 @@ use super::{graph::Node, AudioRenderQuantum, NodeIndex};
 /// Interface for audio processing code that runs on the audio rendering thread.
 ///
 /// Note that the AudioProcessor is typically constructed together with an [`crate::node::AudioNode`]
-/// (the user facing object that lives in the control thread). See [`crate::context::BaseAudioContext::register`].
+/// (the user facing object that lives in the control thread). See [`crate::context::ConcreteBaseAudioContext::register`].
 ///
 /// Check the `examples/worklet.rs` file for example usage of this trait.
 pub trait AudioProcessor: Send {

--- a/src/spatial.rs
+++ b/src/spatial.rs
@@ -1,7 +1,7 @@
 //! Spatialization/Panning primitives
 //!
 //! Required for panning algorithm, distance and cone effects of [`crate::node::PannerNode`]s
-use crate::context::{AsBaseAudioContext, AudioContextRegistration, AudioParamId};
+use crate::context::{AudioContextRegistration, AudioParamId, BaseAudioContext};
 use crate::node::{
     AudioNode, ChannelConfig, ChannelConfigOptions, ChannelCountMode, ChannelInterpretation,
 };
@@ -116,7 +116,7 @@ impl AudioNode for AudioListenerNode {
 }
 
 impl AudioListenerNode {
-    pub fn new<C: AsBaseAudioContext>(context: &C) -> Self {
+    pub fn new<C: BaseAudioContext>(context: &C) -> Self {
         context.base().register(move |registration| {
             let reg_id = registration.id();
             let base = context.base();

--- a/tests/media.rs
+++ b/tests/media.rs
@@ -1,6 +1,6 @@
 use float_eq::assert_float_eq;
 use web_audio_api::buffer::AudioBuffer;
-use web_audio_api::context::AsBaseAudioContext;
+use web_audio_api::context::BaseAudioContext;
 use web_audio_api::context::OfflineAudioContext;
 use web_audio_api::media::MediaElement;
 use web_audio_api::node::{AudioControllableSourceNode, AudioNode, AudioScheduledSourceNode};

--- a/tests/offline.rs
+++ b/tests/offline.rs
@@ -1,5 +1,5 @@
 use float_eq::assert_float_eq;
-use web_audio_api::context::AsBaseAudioContext;
+use web_audio_api::context::BaseAudioContext;
 use web_audio_api::context::OfflineAudioContext;
 use web_audio_api::node::{
     AudioNode, AudioScheduledSourceNode, OscillatorNode, OscillatorOptions, OscillatorType,


### PR DESCRIPTION
and rename the struct to ConcreteBaseAudioContext. This makes user
facing code a bit nicer, you will no longer need to import an item that
is not part of the spec.

See discussion at https://github.com/orottier/web-audio-api-rs/pull/99