### PR TITLE
Attempt to harmonize options, defaults, etc

### DIFF
--- a/examples/mic_playback.rs
+++ b/examples/mic_playback.rs
@@ -230,7 +230,7 @@ fn poll_frequency_graph(
     width: u16,
     height: u16,
 ) -> ! {
-    let bin_count = analyser.frequency_bin_count();
+    let bin_count = analyser.frequency_bin_count() as usize;
     let mut freq_buffer = Some(vec![0.; bin_count]);
 
     loop {

--- a/examples/oscillators.rs
+++ b/examples/oscillators.rs
@@ -16,11 +16,11 @@ fn main() {
     osc.connect(&context.destination());
 
     // defined periodic wave characteristics
-    let options = Some(PeriodicWaveOptions {
+    let options = PeriodicWaveOptions {
         real: Some(vec![0., 0.5, 0.5]),
         imag: Some(vec![0., 0., 0.]),
-        disable_normalization: Some(false),
-    });
+        disable_normalization: false,
+    };
 
     // Create a custom periodic wave
     let periodic_wave = context.create_periodic_wave(options);

--- a/src/context.rs
+++ b/src/context.rs
@@ -268,7 +268,7 @@ pub trait AsBaseAudioContext {
     }
 
     /// Creates a periodic wave
-    fn create_periodic_wave(&self, options: Option<PeriodicWaveOptions>) -> PeriodicWave {
+    fn create_periodic_wave(&self, options: PeriodicWaveOptions) -> PeriodicWave {
         PeriodicWave::new(self.base(), options)
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -159,12 +159,12 @@ pub trait AsBaseAudioContext {
     /// Creates an `OscillatorNode`, a source representing a periodic waveform. It basically
     /// generates a tone.
     fn create_oscillator(&self) -> node::OscillatorNode {
-        node::OscillatorNode::new(self.base(), None)
+        node::OscillatorNode::new(self.base(), node::OscillatorOptions::default())
     }
 
     /// Creates an `StereoPannerNode` to pan a stereo output
     fn create_stereo_panner(&self) -> node::StereoPannerNode {
-        node::StereoPannerNode::new(self.base(), None)
+        node::StereoPannerNode::new(self.base(), node::StereoPannerOptions::default())
     }
 
     /// Creates an `GainNode`, to control audio volume
@@ -205,12 +205,12 @@ pub trait AsBaseAudioContext {
 
     /// Creates an `BiquadFilterNode` which implements a second order filter
     fn create_biquad_filter(&self) -> node::BiquadFilterNode {
-        node::BiquadFilterNode::new(self.base(), None)
+        node::BiquadFilterNode::new(self.base(), node::BiquadFilterOptions::default())
     }
 
     /// Creates a `WaveShaperNode`
     fn create_wave_shaper(&self) -> node::WaveShaperNode {
-        node::WaveShaperNode::new(self.base(), None)
+        node::WaveShaperNode::new(self.base(), node::WaveShaperOptions::default())
     }
 
     /// Creates a `ChannelSplitterNode`

--- a/src/node/analyser.rs
+++ b/src/node/analyser.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 
 use crate::analysis::Analyser;
@@ -10,14 +10,21 @@ use super::{AudioNode, ChannelConfig, ChannelConfigOptions, ChannelInterpretatio
 
 use crossbeam_channel::{self, Receiver, Sender};
 
-/// Options for constructing an AnalyserNode
+/// Options for constructing an [`AnalyserNode`]
+// dictionary AnalyserOptions : AudioNodeOptions {
+//   unsigned long fftSize = 2048;
+//   double maxDecibels = -30;
+//   double minDecibels = -100;
+//   double smoothingTimeConstant = 0.8;
+// };
+#[derive(Clone, Debug)]
 pub struct AnalyserOptions {
-    pub fft_size: usize,
-    pub smoothing_time_constant: f32,
-    /*
-    pub max_decibels: f32,
-    pub min_decibels: f32,
-    */
+    pub fft_size: u32,
+    #[allow(dead_code)]
+    pub max_decibels: f64,
+    #[allow(dead_code)]
+    pub min_decibels: f64,
+    pub smoothing_time_constant: f64,
     pub channel_config: ChannelConfigOptions,
 }
 
@@ -25,11 +32,9 @@ impl Default for AnalyserOptions {
     fn default() -> Self {
         Self {
             fft_size: 2048,
-            smoothing_time_constant: 0.8,
-            /*
             max_decibels: -30.,
             min_decibels: 100.,
-            */
+            smoothing_time_constant: 0.8,
             channel_config: ChannelConfigOptions::default(),
         }
     }
@@ -50,13 +55,9 @@ enum AnalyserRequest {
 pub struct AnalyserNode {
     registration: AudioContextRegistration,
     channel_config: ChannelConfig,
-    fft_size: Arc<AtomicUsize>,
+    fft_size: Arc<AtomicU32>,
     smoothing_time_constant: Arc<AtomicU32>,
     sender: Sender<AnalyserRequest>,
-    /*
-    max_decibels: f32,
-    min_decibels: f32,
-    */
 }
 
 impl AudioNode for AnalyserNode {
@@ -71,6 +72,7 @@ impl AudioNode for AnalyserNode {
     fn number_of_inputs(&self) -> u32 {
         1
     }
+
     fn number_of_outputs(&self) -> u32 {
         1
     }
@@ -79,7 +81,7 @@ impl AudioNode for AnalyserNode {
 impl AnalyserNode {
     pub fn new<C: AsBaseAudioContext>(context: &C, options: AnalyserOptions) -> Self {
         context.base().register(move |registration| {
-            let fft_size = Arc::new(AtomicUsize::new(options.fft_size));
+            let fft_size = Arc::new(AtomicU32::new(options.fft_size));
             let smoothing_time_constant = Arc::new(AtomicU32::new(
                 (options.smoothing_time_constant * 100.) as u32,
             ));
@@ -87,7 +89,7 @@ impl AnalyserNode {
             let (sender, receiver) = crossbeam_channel::bounded(0);
 
             let render = AnalyserRenderer {
-                analyser: Analyser::new(options.fft_size),
+                analyser: Analyser::new(options.fft_size as usize),
                 fft_size: fft_size.clone(),
                 smoothing_time_constant: smoothing_time_constant.clone(),
                 receiver,
@@ -106,31 +108,31 @@ impl AnalyserNode {
     }
 
     /// Half the FFT size
-    pub fn frequency_bin_count(&self) -> usize {
+    pub fn frequency_bin_count(&self) -> u32 {
         self.fft_size.load(Ordering::SeqCst) / 2
     }
 
     /// The size of the FFT used for frequency-domain analysis (in sample-frames)
-    pub fn fft_size(&self) -> usize {
+    pub fn fft_size(&self) -> u32 {
         self.fft_size.load(Ordering::SeqCst)
     }
 
     /// This MUST be a power of two in the range 32 to 32768
-    pub fn set_fft_size(&self, fft_size: usize) {
+    pub fn set_fft_size(&self, fft_size: u32) {
         // todo assert size
         self.fft_size.store(fft_size, Ordering::SeqCst);
     }
 
     /// Time averaging parameter with the last analysis frame.
-    pub fn smoothing_time_constant(&self) -> f32 {
-        self.smoothing_time_constant.load(Ordering::SeqCst) as f32 / 100.
+    pub fn smoothing_time_constant(&self) -> f64 {
+        self.smoothing_time_constant.load(Ordering::SeqCst) as f64 / 100.
     }
 
     /// Set smoothing time constant, this MUST be a value between 0 and 1
-    pub fn set_smoothing_time_constant(&self, v: f32) {
+    pub fn set_smoothing_time_constant(&self, value: f64) {
         // todo assert range
         self.smoothing_time_constant
-            .store((v * 100.) as u32, Ordering::SeqCst);
+            .store((value * 100.) as u32, Ordering::SeqCst);
     }
 
     /// Copies the current time domain data (waveform data) into the provided buffer
@@ -152,7 +154,7 @@ impl AnalyserNode {
 
 struct AnalyserRenderer {
     pub analyser: Analyser,
-    pub fft_size: Arc<AtomicUsize>,
+    pub fft_size: Arc<AtomicU32>,
     pub smoothing_time_constant: Arc<AtomicU32>,
     pub receiver: Receiver<AnalyserRequest>,
 }
@@ -185,7 +187,7 @@ impl AudioProcessor for AnalyserRenderer {
         self.analyser.add_data(mono_data);
 
         // calculate frequency domain every `fft_size` samples
-        let fft_size = self.fft_size.load(Ordering::Relaxed);
+        let fft_size = self.fft_size.load(Ordering::Relaxed) as usize;
         let resized = self.analyser.current_fft_size() != fft_size;
         let complete_cycle = self.analyser.check_complete_cycle(fft_size);
         if resized || complete_cycle {

--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -12,6 +12,15 @@ use crate::{SampleRate, RENDER_QUANTUM_SIZE};
 use super::{AudioNode, ChannelConfig, ChannelConfigOptions};
 
 /// Options for constructing an [`AudioBufferSourceNode`]
+// dictionary AudioBufferSourceOptions {
+//   AudioBuffer? buffer;
+//   float detune = 0;
+//   boolean loop = false;
+//   double loopEnd = 0;
+//   double loopStart = 0;
+//   float playbackRate = 1;
+// };
+#[derive(Clone, Debug)]
 pub struct AudioBufferSourceOptions {
     pub buffer: Option<AudioBuffer>,
     pub detune: f32,
@@ -31,7 +40,7 @@ impl Default for AudioBufferSourceOptions {
             loop_start: 0.,
             loop_end: 0.,
             playback_rate: 1.,
-            channel_config: Default::default(),
+            channel_config: ChannelConfigOptions::default(),
         }
     }
 }
@@ -93,6 +102,7 @@ impl AudioNode for AudioBufferSourceNode {
     fn number_of_inputs(&self) -> u32 {
         0
     }
+
     fn number_of_outputs(&self) -> u32 {
         1
     }

--- a/src/node/biquad_filter.rs
+++ b/src/node/biquad_filter.rs
@@ -1,10 +1,4 @@
 //! The biquad filter control and renderer parts
-#![warn(
-    clippy::all,
-    clippy::pedantic,
-    clippy::perf,
-    clippy::missing_docs_in_private_items
-)]
 use std::{
     f64::consts::{PI, SQRT_2},
     sync::{
@@ -33,8 +27,6 @@ struct CoeffsReq(Sender<[f64; 5]>);
 
 /// enumerates all the biquad filter types
 #[derive(Debug, Clone, Copy, PartialEq)]
-// the naming comes from the web audio specfication
-#[allow(clippy::module_name_repetitions)]
 pub enum BiquadFilterType {
     /// Allows frequencies below the cutoff frequency to pass through and attenuates frequencies above the cutoff. (12dB/oct rolloff)
     Lowpass,
@@ -80,42 +72,38 @@ impl From<u32> for BiquadFilterType {
     }
 }
 
-/// `BiquadFilterOptions` is used to pass options
-/// during the construction of `BiquadFilterNode` using its
-/// constructor method `new`
-// the naming comes from the web audio specfication
-#[allow(clippy::module_name_repetitions)]
+/// Options for constructing a [`BiquadFilterNode`]
+// dictionary BiquadFilterOptions : AudioNodeOptions {
+//   BiquadFilterType type = "lowpass";
+//   float Q = 1;
+//   float detune = 0;
+//   float frequency = 350;
+//   float gain = 0;
+// };
+#[derive(Clone, Debug)]
 pub struct BiquadFilterOptions {
-    /// The desired initial value for Q, if None default to 1.
-    pub q: Option<f32>,
-    /// The desired initial value for detune, if None default to 0.
-    pub detune: Option<f32>,
-    /// The desired initial value for frequency, if None default to 350.
-    pub frequency: Option<f32>,
-    /// The desired initial value for gain, if None default to 0.
-    pub gain: Option<f32>,
-    /// The desired initial value for type, if None default to Lowpass.
-    pub type_: Option<BiquadFilterType>,
-    /// audio node options
+    pub q: f32,
+    pub detune: f32,
+    pub frequency: f32,
+    pub gain: f32,
+    pub type_: BiquadFilterType,
     pub channel_config: ChannelConfigOptions,
 }
 
 impl Default for BiquadFilterOptions {
     fn default() -> Self {
         Self {
-            q: Some(1.),
-            detune: Some(0.),
-            frequency: Some(350.),
-            gain: Some(0.),
-            type_: Some(BiquadFilterType::default()),
+            q: 1.,
+            detune: 0.,
+            frequency: 350.,
+            gain: 0.,
+            type_: BiquadFilterType::default(),
             channel_config: ChannelConfigOptions::default(),
         }
     }
 }
 
 /// `BiquadFilterNode` is a second order IIR filter
-// the naming comes from the web audio specfication
-#[allow(clippy::module_name_repetitions)]
 pub struct BiquadFilterNode {
     /// Represents the node instance and its associated audio context
     registration: AudioContextRegistration,
@@ -151,6 +139,7 @@ impl AudioNode for BiquadFilterNode {
     fn number_of_inputs(&self) -> u32 {
         1
     }
+
     fn number_of_outputs(&self) -> u32 {
         1
     }
@@ -163,25 +152,18 @@ impl BiquadFilterNode {
     ///
     /// * `context` - audio context in which the audio node will live.
     /// * `options` - biquad filter options
-    pub fn new<C: AsBaseAudioContext>(context: &C, options: Option<BiquadFilterOptions>) -> Self {
+    pub fn new<C: AsBaseAudioContext>(context: &C, options: BiquadFilterOptions) -> Self {
         context.base().register(move |registration| {
-            let options = options.unwrap_or_default();
-
-            let default_freq = 350.;
-            let default_gain = 0.;
-            let default_det = 0.;
-            let default_q = 1.;
-
-            let q_value = options.q.unwrap_or(default_q);
-            let d_value = options.detune.unwrap_or(default_det);
-            let f_value = options.frequency.unwrap_or(default_freq);
-            let g_value = options.gain.unwrap_or(default_gain);
-            let t_value = options.type_.unwrap_or(BiquadFilterType::Lowpass);
+            let q_value = options.q;
+            let d_value = options.detune;
+            let f_value = options.frequency;
+            let g_value = options.gain;
+            let t_value = options.type_;
 
             let q_param_opts = AudioParamOptions {
                 min_value: f32::MIN,
                 max_value: f32::MAX,
-                default_value: default_q,
+                default_value: 1.,
                 automation_rate: crate::param::AutomationRate::A,
             };
             let (q_param, q_proc) = context
@@ -193,7 +175,7 @@ impl BiquadFilterNode {
             let d_param_opts = AudioParamOptions {
                 min_value: -153_600.,
                 max_value: 153_600.,
-                default_value: default_det,
+                default_value: 0.,
                 automation_rate: crate::param::AutomationRate::A,
             };
             let (d_param, d_proc) = context
@@ -206,7 +188,7 @@ impl BiquadFilterNode {
             let f_param_opts = AudioParamOptions {
                 min_value: 0.,
                 max_value: niquyst,
-                default_value: default_freq,
+                default_value: 350.,
                 automation_rate: crate::param::AutomationRate::A,
             };
             let (f_param, f_proc) = context
@@ -218,7 +200,7 @@ impl BiquadFilterNode {
             let g_param_opts = AudioParamOptions {
                 min_value: f32::MIN,
                 max_value: f32::MAX,
-                default_value: default_gain,
+                default_value: 0.,
                 automation_rate: crate::param::AutomationRate::A,
             };
             let (g_param, g_proc) = context
@@ -1101,14 +1083,14 @@ mod test {
         SampleRate,
     };
 
-    use super::{BiquadFilterNode, BiquadFilterOptions, BiquadFilterType, ChannelConfigOptions};
+    use super::{BiquadFilterNode, BiquadFilterOptions, BiquadFilterType};
 
     const LENGTH: usize = 555;
 
     #[test]
     fn build_with_new() {
         let context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
-        let _biquad = BiquadFilterNode::new(&context, None);
+        let _biquad = BiquadFilterNode::new(&context, BiquadFilterOptions::default());
     }
 
     #[test]
@@ -1118,64 +1100,15 @@ mod test {
     }
 
     #[test]
-    fn default_audio_params_are_correct_with_no_options() {
-        let default_q = 1.0;
-        let default_detune = 0.;
-        let default_gain = 0.;
-        let default_freq = 350.;
-        let default_type = BiquadFilterType::Lowpass;
-        let mut context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
-        let biquad = BiquadFilterNode::new(&context, None);
-
-        context.start_rendering();
-
-        assert_float_eq!(biquad.q().value(), default_q, abs <= 0.);
-        assert_float_eq!(biquad.detune().value(), default_detune, abs <= 0.);
-        assert_float_eq!(biquad.gain().value(), default_gain, abs <= 0.);
-        assert_float_eq!(biquad.frequency().value(), default_freq, abs <= 0.);
-        assert_eq!(biquad.type_(), default_type);
-    }
-
-    #[test]
-    fn default_audio_params_are_correct_with_no_options_in_options() {
+    fn test_default_audio_params() {
         let default_q = 1.0;
         let default_detune = 0.;
         let default_gain = 0.;
         let default_freq = 350.;
         let default_type = BiquadFilterType::Lowpass;
 
-        let options = BiquadFilterOptions {
-            q: None,
-            detune: None,
-            frequency: None,
-            gain: None,
-            type_: None,
-            channel_config: ChannelConfigOptions::default(),
-        };
         let mut context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
-        let biquad = BiquadFilterNode::new(&context, Some(options));
-
-        context.start_rendering();
-
-        assert_float_eq!(biquad.q().value(), default_q, abs <= 0.);
-        assert_float_eq!(biquad.detune().value(), default_detune, abs <= 0.);
-        assert_float_eq!(biquad.gain().value(), default_gain, abs <= 0.);
-        assert_float_eq!(biquad.frequency().value(), default_freq, abs <= 0.);
-        assert_eq!(biquad.type_(), default_type);
-    }
-
-    #[test]
-    fn default_audio_params_are_correct_with_default_options() {
-        let default_q = 1.0;
-        let default_detune = 0.;
-        let default_gain = 0.;
-        let default_freq = 350.;
-        let default_type = BiquadFilterType::Lowpass;
-        let mut context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
-
-        let options = BiquadFilterOptions::default();
-
-        let biquad = BiquadFilterNode::new(&context, Some(options));
+        let biquad = BiquadFilterNode::new(&context, BiquadFilterOptions::default());
 
         context.start_rendering();
 
@@ -1196,15 +1129,15 @@ mod test {
         let mut context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
 
         let options = BiquadFilterOptions {
-            q: Some(q),
-            detune: Some(detune),
-            gain: Some(gain),
-            frequency: Some(frequency),
-            type_: Some(type_),
+            q,
+            detune,
+            gain,
+            frequency,
+            type_,
             ..BiquadFilterOptions::default()
         };
 
-        let biquad = BiquadFilterNode::new(&context, Some(options));
+        let biquad = BiquadFilterNode::new(&context, options);
 
         context.start_rendering();
 
@@ -1224,7 +1157,7 @@ mod test {
         let type_ = BiquadFilterType::Highpass;
         let mut context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
 
-        let biquad = BiquadFilterNode::new(&context, None);
+        let biquad = BiquadFilterNode::new(&context, BiquadFilterOptions::default());
 
         biquad.q().set_value(q);
         biquad.detune().set_value(detune);
@@ -1245,7 +1178,7 @@ mod test {
     #[should_panic]
     fn panics_when_not_the_same_length() {
         let context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
-        let biquad = BiquadFilterNode::new(&context, None);
+        let biquad = BiquadFilterNode::new(&context, BiquadFilterOptions::default());
 
         let mut frequency_hz = [0.];
         let mut mag_response = [0., 1.0];
@@ -1258,7 +1191,7 @@ mod test {
     #[should_panic]
     fn panics_when_not_the_same_length_2() {
         let context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
-        let biquad = BiquadFilterNode::new(&context, None);
+        let biquad = BiquadFilterNode::new(&context, BiquadFilterOptions::default());
 
         let mut frequency_hz = [0.];
         let mut mag_response = [0.];
@@ -1270,7 +1203,7 @@ mod test {
     #[test]
     fn frequencies_are_clamped() {
         let context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
-        let biquad = BiquadFilterNode::new(&context, None);
+        let biquad = BiquadFilterNode::new(&context, BiquadFilterOptions::default());
         let niquyst = context.sample_rate() / 2.0;
 
         let mut frequency_hz = [-100., 1_000_000.];

--- a/src/node/channel_merger.rs
+++ b/src/node/channel_merger.rs
@@ -8,7 +8,11 @@ use super::{
     AudioNode, ChannelConfig, ChannelConfigOptions, ChannelCountMode, ChannelInterpretation,
 };
 
-/// Options for constructing a ChannelMergerNode
+/// Options for constructing a [`ChannelMergerNode`]
+// dictionary ChannelMergerOptions : AudioNodeOptions {
+//   unsigned long numberOfInputs = 6;
+// };
+#[derive(Clone, Debug)]
 pub struct ChannelMergerOptions {
     pub number_of_inputs: u32,
     pub channel_config: ChannelConfigOptions,
@@ -41,12 +45,15 @@ impl AudioNode for ChannelMergerNode {
     fn channel_config_raw(&self) -> &ChannelConfig {
         &self.channel_config
     }
+
     fn set_channel_count(&self, _v: usize) {
         panic!("Cannot edit channel count of ChannelMergerNode")
     }
+
     fn set_channel_count_mode(&self, _v: ChannelCountMode) {
         panic!("Cannot edit channel count mode of ChannelMergerNode")
     }
+
     fn set_channel_interpretation(&self, _v: ChannelInterpretation) {
         panic!("Cannot edit channel interpretation of ChannelMergerNode")
     }
@@ -54,6 +61,7 @@ impl AudioNode for ChannelMergerNode {
     fn number_of_inputs(&self) -> u32 {
         self.channel_count() as _
     }
+
     fn number_of_outputs(&self) -> u32 {
         1
     }

--- a/src/node/channel_splitter.rs
+++ b/src/node/channel_splitter.rs
@@ -8,7 +8,11 @@ use super::{
     AudioNode, ChannelConfig, ChannelConfigOptions, ChannelCountMode, ChannelInterpretation,
 };
 
-/// Options for constructing a ChannelSplitterNode
+/// Options for constructing a [`ChannelSplitterNode`]
+// dictionary ChannelSplitterOptions : AudioNodeOptions {
+//   unsigned long numberOfOutputs = 6;
+// };
+#[derive(Clone, Debug)]
 pub struct ChannelSplitterOptions {
     pub number_of_outputs: u32,
     pub channel_config: ChannelConfigOptions,
@@ -41,12 +45,15 @@ impl AudioNode for ChannelSplitterNode {
     fn channel_config_raw(&self) -> &ChannelConfig {
         &self.channel_config
     }
+
     fn set_channel_count(&self, _v: usize) {
         panic!("Cannot edit channel count of ChannelSplitterNode")
     }
+
     fn set_channel_count_mode(&self, _v: ChannelCountMode) {
         panic!("Cannot edit channel count mode of ChannelSplitterNode")
     }
+
     fn set_channel_interpretation(&self, _v: ChannelInterpretation) {
         panic!("Cannot edit channel interpretation of ChannelSplitterNode")
     }
@@ -54,6 +61,7 @@ impl AudioNode for ChannelSplitterNode {
     fn number_of_inputs(&self) -> u32 {
         1
     }
+
     fn number_of_outputs(&self) -> u32 {
         self.channel_count() as _
     }

--- a/src/node/constant_source.rs
+++ b/src/node/constant_source.rs
@@ -6,7 +6,11 @@ use crate::{SampleRate, RENDER_QUANTUM_SIZE};
 
 use super::{AudioNode, AudioScheduledSourceNode, ChannelConfig, ChannelConfigOptions};
 
-/// Options for constructing an ConstantSourceNode
+/// Options for constructing an [`ConstantSourceNode`]
+// dictionary ConstantSourceOptions {
+//   float offset = 1;
+// };
+#[derive(Clone, Debug)]
 pub struct ConstantSourceOptions {
     pub offset: f32,
     pub channel_config: ChannelConfigOptions,
@@ -74,6 +78,7 @@ impl AudioNode for ConstantSourceNode {
     fn number_of_inputs(&self) -> u32 {
         0
     }
+
     fn number_of_outputs(&self) -> u32 {
         1
     }

--- a/src/node/delay.rs
+++ b/src/node/delay.rs
@@ -8,7 +8,12 @@ use super::{AudioNode, ChannelConfig, ChannelConfigOptions, ChannelInterpretatio
 use std::cell::{Cell, RefCell, RefMut};
 use std::rc::Rc;
 
-/// Options for constructing a DelayNode
+/// Options for constructing a [`DelayNode`]
+// dictionary DelayOptions : AudioNodeOptions {
+//   double maxDelayTime = 1;
+//   double delayTime = 0;
+// };
+#[derive(Clone, Debug)]
 pub struct DelayOptions {
     pub max_delay_time: f64,
     pub delay_time: f64,
@@ -106,6 +111,7 @@ impl AudioNode for DelayNode {
     fn number_of_inputs(&self) -> u32 {
         1
     }
+
     fn number_of_outputs(&self) -> u32 {
         1
     }

--- a/src/node/gain.rs
+++ b/src/node/gain.rs
@@ -5,7 +5,11 @@ use crate::SampleRate;
 
 use super::{AudioNode, ChannelConfig, ChannelConfigOptions};
 
-/// Options for constructing a GainNode
+/// Options for constructing a [`GainNode`]
+// dictionary GainOptions : AudioNodeOptions {
+//   float gain = 1.0;
+// };
+#[derive(Clone, Debug)]
 pub struct GainOptions {
     pub gain: f32,
     pub channel_config: ChannelConfigOptions,
@@ -39,6 +43,7 @@ impl AudioNode for GainNode {
     fn number_of_inputs(&self) -> u32 {
         1
     }
+
     fn number_of_outputs(&self) -> u32 {
         1
     }

--- a/src/node/iir_filter.rs
+++ b/src/node/iir_filter.rs
@@ -1,11 +1,11 @@
 //! The IIR filter control and renderer parts
-#![warn(
-    clippy::all,
-    clippy::pedantic,
-    clippy::nursery,
-    clippy::perf,
-    clippy::missing_docs_in_private_items
-)]
+// #![warn(
+//     clippy::all,
+//     clippy::pedantic,
+//     clippy::nursery,
+//     clippy::perf,
+//     clippy::missing_docs_in_private_items
+// )]
 use num_complex::Complex;
 use std::f64::consts::PI;
 
@@ -20,21 +20,21 @@ use super::{AudioNode, ChannelConfig, ChannelConfigOptions};
 /// Filter order is limited to 20
 const MAX_IIR_COEFFS_LEN: usize = 20;
 
-/// The `IirFilterOptions` is used to specify the filter coefficients
-// the naming comes from the web audio specfication
-#[allow(clippy::module_name_repetitions)]
+/// Options for constructing a [`IirFilterNode`]
+// dictionary IIRFilterOptions : AudioNodeOptions {
+//   required sequence<double> feedforward;
+//   required sequence<double> feedback;
+// };
 pub struct IirFilterOptions {
     /// audio node options
     pub channel_config: ChannelConfigOptions,
     /// feedforward coefficients
-    pub feedforward: Vec<f64>,
+    pub feedforward: Vec<f64>, // go for Option<Vec<f32>> w/ default to None?
     /// feedback coefficients
-    pub feedback: Vec<f64>,
+    pub feedback: Vec<f64>, // go for Option<Vec<f32>> w/ default to None?
 }
 
 /// An `AudioNode` implementing a general IIR filter
-// the naming comes from the web audio specfication
-#[allow(clippy::module_name_repetitions)]
 pub struct IirFilterNode {
     /// Represents the node instance and its associated audio context
     registration: AudioContextRegistration,
@@ -58,6 +58,7 @@ impl AudioNode for IirFilterNode {
     fn number_of_inputs(&self) -> u32 {
         1
     }
+
     fn number_of_outputs(&self) -> u32 {
         1
     }

--- a/src/node/media_element.rs
+++ b/src/node/media_element.rs
@@ -9,10 +9,14 @@ use super::{
     ChannelConfigOptions, MediaStreamRenderer,
 };
 
-/// Options for constructing a MediaElementAudioSourceNode
+/// Options for constructing a [`MediaElementAudioSourceNode`]
+// dictionary MediaElementAudioSourceOptions {
+//   required HTMLMediaElement mediaElement;
+// };
+// note that `MediaElementAudioSourceOptions` does not extend `AudioNodeOptions`
 pub struct MediaElementAudioSourceNodeOptions {
     pub media: MediaElement,
-    pub channel_config: ChannelConfigOptions,
+    pub channel_config: ChannelConfigOptions, // should not have this
 }
 
 /// An audio source from a [`MediaElement`] (e.g. .ogg, .wav, .mp3 files)
@@ -42,6 +46,7 @@ impl AudioNode for MediaElementAudioSourceNode {
     fn registration(&self) -> &AudioContextRegistration {
         &self.registration
     }
+
     fn channel_config_raw(&self) -> &ChannelConfig {
         &self.channel_config
     }
@@ -49,6 +54,7 @@ impl AudioNode for MediaElementAudioSourceNode {
     fn number_of_inputs(&self) -> u32 {
         0
     }
+
     fn number_of_outputs(&self) -> u32 {
         1
     }

--- a/src/node/media_stream.rs
+++ b/src/node/media_stream.rs
@@ -7,10 +7,14 @@ use crate::RENDER_QUANTUM_SIZE;
 
 use super::{AudioNode, ChannelConfig, ChannelConfigOptions, MediaStreamRenderer};
 
-/// Options for constructing a MediaStreamAudioSourceNode
+/// Options for constructing a [`MediaStreamAudioSourceNode`]
+// dictionary MediaStreamAudioSourceOptions {
+//   required MediaStream mediaStream;
+// };
+// note that `MediaElementAudioSourceOptions` does not extend `AudioNodeOptions`
 pub struct MediaStreamAudioSourceNodeOptions<M> {
     pub media: M,
-    pub channel_config: ChannelConfigOptions,
+    pub channel_config: ChannelConfigOptions, // should not have this
 }
 
 /// An audio source from a [`MediaStream`] (e.g. microphone input)
@@ -35,6 +39,7 @@ impl AudioNode for MediaStreamAudioSourceNode {
     fn number_of_inputs(&self) -> u32 {
         0
     }
+
     fn number_of_outputs(&self) -> u32 {
         1
     }

--- a/src/node/oscillator.rs
+++ b/src/node/oscillator.rs
@@ -583,13 +583,7 @@ mod tests {
 
         let context = OfflineAudioContext::new(2, 1, SampleRate(44_100));
 
-        let periodic_opt = PeriodicWaveOptions {
-            real: None,
-            imag: None,
-            disable_normalization: None,
-        };
-
-        let periodic_wave = PeriodicWave::new(&context, Some(periodic_opt));
+        let periodic_wave = PeriodicWave::new(&context, PeriodicWaveOptions::default());
 
         let options = OscillatorOptions {
             periodic_wave: Some(periodic_wave),
@@ -608,13 +602,7 @@ mod tests {
 
         let context = OfflineAudioContext::new(2, 1, SampleRate(44_100));
 
-        let periodic_opt = PeriodicWaveOptions {
-            real: None,
-            imag: None,
-            disable_normalization: None,
-        };
-
-        let periodic_wave = PeriodicWave::new(&context, Some(periodic_opt));
+        let periodic_wave = PeriodicWave::new(&context, PeriodicWaveOptions::default());
 
         let options = OscillatorOptions {
             periodic_wave: Some(periodic_wave),
@@ -852,11 +840,11 @@ mod tests {
             let mut context =
                 OfflineAudioContext::new(1, sample_rate, SampleRate(sample_rate as u32));
 
-            let options = Some(PeriodicWaveOptions {
+            let options = PeriodicWaveOptions {
                 real: Some(vec![0., 0.]),
                 imag: Some(vec![0., 1.]), // sine is in imaginary component
-                disable_normalization: Some(false),
-            });
+                disable_normalization: false,
+            };
 
             let periodic_wave = context.create_periodic_wave(options);
 
@@ -899,12 +887,12 @@ mod tests {
             let mut context =
                 OfflineAudioContext::new(1, sample_rate, SampleRate(sample_rate as u32));
 
-            let options = Some(PeriodicWaveOptions {
+            let options = PeriodicWaveOptions {
                 real: Some(vec![0., 0., 0.]),
                 imag: Some(vec![0., 0.5, 0.5]),
                 // disable norm, is already tested in `PeriodicWave`
-                disable_normalization: Some(true),
-            });
+                disable_normalization: true,
+            };
 
             let periodic_wave = context.create_periodic_wave(options);
 

--- a/src/node/panner.rs
+++ b/src/node/panner.rs
@@ -4,34 +4,76 @@ use std::sync::Arc;
 use crate::context::{AsBaseAudioContext, AudioContextRegistration, AudioParamId};
 use crate::param::{AudioParam, AudioParamOptions};
 use crate::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum};
-use crate::{AtomicF32, SampleRate};
+use crate::{AtomicF64, SampleRate};
 
 use super::{
     AudioNode, ChannelConfig, ChannelConfigOptions, ChannelCountMode, ChannelInterpretation,
 };
 
-/// Options for constructing a PannerNode
+#[derive(Copy, Clone, Debug)]
+pub enum PanningModelType {
+    EqualPower,
+    HRTF,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum DistanceModelType {
+    Linear,
+    Inverse,
+    Exponential,
+}
+
+/// Options for constructing a [`PannerNode`]
+// dictionary PannerOptions : AudioNodeOptions {
+//   PanningModelType panningModel = "equalpower";
+//   DistanceModelType distanceModel = "inverse";
+//   float positionX = 0;
+//   float positionY = 0;
+//   float positionZ = 0;
+//   float orientationX = 1;
+//   float orientationY = 0;
+//   float orientationZ = 0;
+//   double refDistance = 1;
+//   double maxDistance = 10000;
+//   double rolloffFactor = 1;
+//   double coneInnerAngle = 360;
+//   double coneOuterAngle = 360;
+//   double coneOuterGain = 0;
+// };
+#[derive(Clone, Debug)]
 pub struct PannerOptions {
+    #[allow(dead_code)]
+    pub panning_model: PanningModelType,
+    #[allow(dead_code)]
+    pub distance_model: DistanceModelType,
     pub position_x: f32,
     pub position_y: f32,
     pub position_z: f32,
     pub orientation_x: f32,
     pub orientation_y: f32,
     pub orientation_z: f32,
-    pub cone_inner_angle: f32,
-    pub cone_outer_angle: f32,
-    pub cone_outer_gain: f32,
+    #[allow(dead_code)]
+    pub ref_distance: f64,
+    #[allow(dead_code)]
+    pub max_distance: f64,
+    pub cone_inner_angle: f64,
+    pub cone_outer_angle: f64,
+    pub cone_outer_gain: f64,
 }
 
 impl Default for PannerOptions {
     fn default() -> Self {
         PannerOptions {
+            panning_model: PanningModelType::EqualPower,
+            distance_model: DistanceModelType::Inverse,
             position_x: 0.,
             position_y: 0.,
             position_z: 0.,
             orientation_x: 1.,
             orientation_y: 0.,
             orientation_z: 0.,
+            ref_distance: 1.,
+            max_distance: 10000.,
             cone_inner_angle: 360.,
             cone_outer_angle: 360.,
             cone_outer_gain: 0.,
@@ -95,9 +137,9 @@ pub struct PannerNode {
     orientation_x: AudioParam,
     orientation_y: AudioParam,
     orientation_z: AudioParam,
-    cone_inner_angle: Arc<AtomicF32>,
-    cone_outer_angle: Arc<AtomicF32>,
-    cone_outer_gain: Arc<AtomicF32>,
+    cone_inner_angle: Arc<AtomicF64>,
+    cone_outer_angle: Arc<AtomicF64>,
+    cone_outer_gain: Arc<AtomicF64>,
 }
 
 impl AudioNode for PannerNode {
@@ -112,6 +154,7 @@ impl AudioNode for PannerNode {
     fn number_of_inputs(&self) -> u32 {
         1 + 9 // todo, user should not be able to see these ports
     }
+
     fn number_of_outputs(&self) -> u32 {
         1
     }
@@ -145,9 +188,9 @@ impl PannerNode {
             orientation_z.set_value_at_time(options.orientation_z, 0.);
 
             // cone attributes
-            let cone_inner_angle = Arc::new(AtomicF32::new(options.cone_inner_angle));
-            let cone_outer_angle = Arc::new(AtomicF32::new(options.cone_outer_angle));
-            let cone_outer_gain = Arc::new(AtomicF32::new(options.cone_outer_gain));
+            let cone_inner_angle = Arc::new(AtomicF64::new(options.cone_inner_angle));
+            let cone_outer_angle = Arc::new(AtomicF64::new(options.cone_outer_angle));
+            let cone_outer_gain = Arc::new(AtomicF64::new(options.cone_outer_gain));
 
             let render = PannerRenderer {
                 position_x: render_px,
@@ -213,27 +256,27 @@ impl PannerNode {
         &self.orientation_z
     }
 
-    pub fn cone_inner_angle(&self) -> f32 {
+    pub fn cone_inner_angle(&self) -> f64 {
         self.cone_inner_angle.load()
     }
 
-    pub fn set_cone_inner_angle(&self, value: f32) {
+    pub fn set_cone_inner_angle(&self, value: f64) {
         self.cone_inner_angle.store(value);
     }
 
-    pub fn cone_outer_angle(&self) -> f32 {
+    pub fn cone_outer_angle(&self) -> f64 {
         self.cone_outer_angle.load()
     }
 
-    pub fn set_cone_outer_angle(&self, value: f32) {
+    pub fn set_cone_outer_angle(&self, value: f64) {
         self.cone_outer_angle.store(value);
     }
 
-    pub fn cone_outer_gain(&self) -> f32 {
+    pub fn cone_outer_gain(&self) -> f64 {
         self.cone_outer_gain.load()
     }
 
-    pub fn set_cone_outer_gain(&self, value: f32) {
+    pub fn set_cone_outer_gain(&self, value: f64) {
         self.cone_outer_gain.store(value);
     }
 }
@@ -245,9 +288,9 @@ struct PannerRenderer {
     orientation_x: AudioParamId,
     orientation_y: AudioParamId,
     orientation_z: AudioParamId,
-    cone_inner_angle: Arc<AtomicF32>,
-    cone_outer_angle: Arc<AtomicF32>,
-    cone_outer_gain: Arc<AtomicF32>,
+    cone_inner_angle: Arc<AtomicF64>,
+    cone_outer_angle: Arc<AtomicF64>,
+    cone_outer_gain: Arc<AtomicF64>,
 }
 
 impl AudioProcessor for PannerRenderer {
@@ -327,12 +370,12 @@ impl AudioProcessor for PannerRenderer {
         let dist_gain = 1. / distance; // inverse distance model is assumed (todo issue #44)
 
         // determine cone effect gain
-        let abs_inner_angle = self.cone_inner_angle.load().abs() / 2.;
-        let abs_outer_angle = self.cone_outer_angle.load().abs() / 2.;
+        let abs_inner_angle = self.cone_inner_angle.load().abs() as f32 / 2.;
+        let abs_outer_angle = self.cone_outer_angle.load().abs() as f32 / 2.;
         let cone_gain = if abs_inner_angle >= 180. && abs_outer_angle >= 180. {
             1. // no cone specified
         } else {
-            let cone_outer_gain = self.cone_outer_gain.load();
+            let cone_outer_gain = self.cone_outer_gain.load() as f32;
 
             let abs_angle =
                 crate::spatial::angle(source_position, source_orientation, listener_position);

--- a/src/node/stereo_panner.rs
+++ b/src/node/stereo_panner.rs
@@ -1,14 +1,13 @@
 //! The stereo panner control and renderer parts
-#![warn(
-    clippy::all,
-    clippy::pedantic,
-    clippy::perf,
-    clippy::missing_docs_in_private_items
-)]
-
-use std::f32::consts::PI;
+// #![warn(
+//     clippy::all,
+//     clippy::pedantic,
+//     clippy::perf,
+//     clippy::missing_docs_in_private_items
+// )]
 
 use float_eq::debug_assert_float_eq;
+use std::f32::consts::PI;
 
 use crate::{
     context::{AsBaseAudioContext, AudioContextRegistration, AudioParamId},
@@ -22,14 +21,14 @@ use super::{
     SINETABLE, TABLE_LENGTH_BY_4_F32, TABLE_LENGTH_BY_4_USIZE,
 };
 
-/// `StereoPannerOptions` is used to pass options
-/// during the construction of `StereoPannerNode` using its
-/// constructor method `new`
-// the naming comes from the web audio specfication
-#[allow(clippy::module_name_repetitions)]
+/// Options for constructing a [`StereoPannerOptions`]
+// dictionary StereoPannerOptions : AudioNodeOptions {
+//   float pan = 0;
+// };
+#[derive(Clone, Debug)]
 pub struct StereoPannerOptions {
     /// initial value for the pan parameter
-    pan: Option<f32>,
+    pan: f32,
     /// audio node options
     pub channel_config: ChannelConfigOptions,
 }
@@ -37,7 +36,7 @@ pub struct StereoPannerOptions {
 impl Default for StereoPannerOptions {
     fn default() -> Self {
         Self {
-            pan: Some(0.),
+            pan: 0.,
             channel_config: ChannelConfigOptions {
                 count: 2,
                 mode: ChannelCountMode::ClampedMax,
@@ -48,8 +47,6 @@ impl Default for StereoPannerOptions {
 }
 
 /// `StereoPannerNode` positions an incoming audio stream in a stereo image
-// the naming comes from the web audio specfication
-#[allow(clippy::module_name_repetitions)]
 pub struct StereoPannerNode {
     /// Represents the node instance and its associated audio context
     registration: AudioContextRegistration,
@@ -105,10 +102,8 @@ impl StereoPannerNode {
     ///
     /// * `context` - audio context in which the audio node will live.
     /// * `options` - stereo panner options
-    pub fn new<C: AsBaseAudioContext>(context: &C, options: Option<StereoPannerOptions>) -> Self {
+    pub fn new<C: AsBaseAudioContext>(context: &C, options: StereoPannerOptions) -> Self {
         context.base().register(move |registration| {
-            let options = options.unwrap_or_default();
-
             assert!(
                 options.channel_config.count <= 2,
                 "NotSupportedError: channel count"
@@ -118,14 +113,12 @@ impl StereoPannerNode {
                 "NotSupportedError: count mode"
             );
 
-            let default_pan = 0.;
-
-            let pan_value = options.pan.unwrap_or(default_pan);
+            let pan_value = options.pan;
 
             let pan_param_opts = AudioParamOptions {
                 min_value: -1.,
                 max_value: 1.,
-                default_value: default_pan,
+                default_value: 0.,
                 automation_rate: crate::param::AutomationRate::A,
             };
             let (pan_param, pan_proc) = context
@@ -271,13 +264,13 @@ mod test {
         SampleRate,
     };
 
-    use super::{StereoPannerNode, StereoPannerRenderer};
+    use super::{StereoPannerNode, StereoPannerOptions, StereoPannerRenderer};
     const LENGTH: usize = 555;
 
     #[test]
     fn build_with_new() {
         let context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
-        let _panner = StereoPannerNode::new(&context, None);
+        let _panner = StereoPannerNode::new(&context, StereoPannerOptions::default());
     }
 
     #[test]
@@ -292,7 +285,7 @@ mod test {
 
         let mut context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
 
-        let panner = StereoPannerNode::new(&context, None);
+        let panner = StereoPannerNode::new(&context, StereoPannerOptions::default());
 
         context.start_rendering();
 
@@ -307,7 +300,7 @@ mod test {
 
         let mut context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
 
-        let panner = StereoPannerNode::new(&context, None);
+        let panner = StereoPannerNode::new(&context, StereoPannerOptions::default());
 
         let pan = panner.pan.value();
         assert_float_eq!(pan, default_pan, abs_all <= 0.);
@@ -364,7 +357,7 @@ mod test {
 
         let mut context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
 
-        let panner = StereoPannerNode::new(&context, None);
+        let panner = StereoPannerNode::new(&context, StereoPannerOptions::default());
 
         let pan = panner.pan.value();
         assert_float_eq!(pan, default_pan, abs_all <= 0.);
@@ -384,7 +377,7 @@ mod test {
 
         let mut context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
 
-        let panner = StereoPannerNode::new(&context, None);
+        let panner = StereoPannerNode::new(&context, StereoPannerOptions::default());
 
         let pan = panner.pan.value();
         assert_float_eq!(pan, default_pan, abs_all <= 0.);

--- a/src/periodic_wave.rs
+++ b/src/periodic_wave.rs
@@ -6,7 +6,8 @@ use crate::context::AsBaseAudioContext;
 
 use crate::node::TABLE_LENGTH_USIZE;
 
-/// Options for constructing an `PeriodicWave`
+/// Options for constructing a [`PeriodicWave`]
+#[derive(Debug, Default, Clone)]
 pub struct PeriodicWaveOptions {
     /// The real parameter represents an array of cosine terms of Fourrier series.
     ///
@@ -28,7 +29,7 @@ pub struct PeriodicWaveOptions {
     ///
     /// If disable_normalization is enabled (disable_normalization = true), the normalization is
     /// defined by the periodic waveform characteristics (img, and real fields).
-    pub disable_normalization: Option<bool>,
+    pub disable_normalization: bool,
 }
 
 /// `PeriodicWave` represents an arbitrary periodic waveform to be used with an `OscillatorNode`.
@@ -51,10 +52,10 @@ pub struct PeriodicWaveOptions {
 /// let options = PeriodicWaveOptions {
 ///   real: Some(vec![0., 0., 0.]),
 ///   imag: Some(vec![0., 0.5, 0.5]),
-///   disable_normalization: Some(false),
+///   disable_normalization: false,
 /// };
 ///
-/// let periodic_wave = PeriodicWave::new(&context, Some(options));
+/// let periodic_wave = PeriodicWave::new(&context, options);
 ///
 /// let osc = context.create_oscillator();
 /// osc.set_periodic_wave(periodic_wave);
@@ -65,7 +66,7 @@ pub struct PeriodicWaveOptions {
 ///
 /// - `cargo run --release --example oscillators`
 ///
-// Basically a wrapper around Arc<Vec<f32>>, so `PeriodicWave` are cheap to clone
+// Basically a wrapper around Arc<Vec<f32>>, so `PeriodicWave`s are cheap to clone
 #[derive(Debug, Clone)]
 pub struct PeriodicWave {
     wavetable: Arc<Vec<f32>>,
@@ -88,73 +89,79 @@ impl PeriodicWave {
     /// * `imag` is defined and its length is less than 2
     /// * `real` and `imag` are defined and theirs lengths are not equal
     /// * `PeriodicWave` is more than 8192 components
-    pub fn new<C: AsBaseAudioContext>(_context: &C, options: Option<PeriodicWaveOptions>) -> Self {
-        let (real, imag, normalize) = if let Some(PeriodicWaveOptions {
+    //
+    // @todo - review constructor, should check real and imag size consistency
+    // cf. https://webaudio.github.io/web-audio-api/#PeriodicWave-constructors
+    pub fn new<C: AsBaseAudioContext>(_context: &C, options: PeriodicWaveOptions) -> Self {
+        let PeriodicWaveOptions {
             real,
             imag,
             disable_normalization,
-        }) = options
-        {
-            let (real, imag) = match (real, imag) {
-                (Some(r), Some(i)) => {
-                    assert!(
-                        r.len() >= 2,
-                        "RangeError: Real field length should be at least 2"
-                    );
-                    assert!(
-                        i.len() >= 2,
-                        "RangeError: Imag field length should be at least 2",
-                    );
-                    assert!(
-                        // the specs gives this number as a lower bound
-                        // it is implemented here as a upper bound to enable required casting
-                        // without loss of precision
-                        r.len() <= 8192,
-                        "NotSupported: periodic wave of more than 8192 components"
-                    );
-                    assert!(
-                        r.len() == i.len(),
-                        "RangeError: Imag and real field length should be equal"
-                    );
-                    (r, i)
-                }
-                (Some(r), None) => {
-                    assert!(
-                        r.len() >= 2,
-                        "RangeError: Real field length should be at least 2"
-                    );
-                    assert!(
-                        // the specs gives this number as a lower bound
-                        // it is implemented here as a upper bound to enable required casting
-                        // without loss of precision
-                        r.len() <= 8192,
-                        "NotSupported: periodic wave of more than 8192 components"
-                    );
-                    let r_len = r.len();
-                    (r, vec![0.; r_len])
-                }
-                (None, Some(i)) => {
-                    assert!(
-                        i.len() >= 2,
-                        "RangeError: Real field length should be at least 2"
-                    );
-                    assert!(
-                        i.len() <= 8192,
-                        // the specs gives this number as a lower bound
-                        // it is implemented here as a upper bound to enable required casting
-                        // without loss of precision
-                        "NotSupported: periodic wave of more than 8192 components"
-                    );
-                    let i_len = i.len();
-                    (vec![0.; i_len], i)
-                }
-                _ => (vec![0., 0.], vec![0., 1.]),
-            };
+        } = options;
 
-            (real, imag, !disable_normalization.unwrap_or(false))
-        } else {
-            (vec![0., 0.], vec![0., 0.], true)
+        let (real, imag) = match (real, imag) {
+            (Some(r), Some(i)) => {
+                assert!(
+                    r.len() >= 2,
+                    "RangeError: Real field length should be at least 2"
+                );
+                assert!(
+                    i.len() >= 2,
+                    "RangeError: Imag field length should be at least 2",
+                );
+                assert!(
+                    // the specs gives this number as a lower bound
+                    // it is implemented here as a upper bound to enable required casting
+                    // without loss of precision
+                    // note: this seems to be wrong, the spec here seems to speak
+                    // about the wavetable length:
+                    // A conforming implementation MUST support PeriodicWave up to at least 8192 elements.
+                    r.len() <= 8192,
+                    "NotSupported: periodic wave of more than 8192 components"
+                );
+                assert!(
+                    r.len() == i.len(),
+                    "RangeError: Imag and real field length should be equal"
+                );
+                (r, i)
+            }
+            (Some(r), None) => {
+                assert!(
+                    r.len() >= 2,
+                    "RangeError: Real field length should be at least 2"
+                );
+                assert!(
+                    // the specs gives this number as a lower bound
+                    // it is implemented here as a upper bound to enable required casting
+                    // without loss of precision
+                    // note: this seems to be wrong, the spec here seems to speak
+                    // about the wavetable length:
+                    // A conforming implementation MUST support PeriodicWave up to at least 8192 elements.
+                    r.len() <= 8192,
+                    "NotSupported: periodic wave of more than 8192 components"
+                );
+                let r_len = r.len();
+                (r, vec![0.; r_len])
+            }
+            (None, Some(i)) => {
+                assert!(
+                    i.len() >= 2,
+                    "RangeError: Real field length should be at least 2"
+                );
+                assert!(
+                    i.len() <= 8192,
+                    // the specs gives this number as a lower bound
+                    // it is implemented here as a upper bound to enable required casting
+                    // without loss of precision
+                    "NotSupported: periodic wave of more than 8192 components"
+                );
+                let i_len = i.len();
+                (vec![0.; i_len], i)
+            }
+            _ => (vec![0., 0.], vec![0., 1.]),
         };
+
+        let normalize = !disable_normalization;
 
         let wavetable = Self::generate_wavetable(&real, &imag, normalize, TABLE_LENGTH_USIZE);
 
@@ -239,10 +246,10 @@ mod tests {
         let options = PeriodicWaveOptions {
             real: Some(vec![0.]),
             imag: Some(vec![0., 0., 0.]),
-            disable_normalization: Some(false),
+            disable_normalization: false,
         };
 
-        let _periodic_wave = PeriodicWave::new(&context, Some(options));
+        let _periodic_wave = PeriodicWave::new(&context, options);
     }
 
     #[test]
@@ -253,10 +260,10 @@ mod tests {
         let options = PeriodicWaveOptions {
             real: Some(vec![0.]),
             imag: None,
-            disable_normalization: Some(false),
+            disable_normalization: false,
         };
 
-        let _periodic_wave = PeriodicWave::new(&context, Some(options));
+        let _periodic_wave = PeriodicWave::new(&context, options);
     }
 
     #[test]
@@ -267,10 +274,10 @@ mod tests {
         let options = PeriodicWaveOptions {
             real: Some(vec![0., 0., 0.]),
             imag: Some(vec![0.]),
-            disable_normalization: Some(false),
+            disable_normalization: false,
         };
 
-        let _periodic_wave = PeriodicWave::new(&context, Some(options));
+        let _periodic_wave = PeriodicWave::new(&context, options);
     }
 
     #[test]
@@ -281,10 +288,10 @@ mod tests {
         let options = PeriodicWaveOptions {
             real: None,
             imag: Some(vec![0.]),
-            disable_normalization: Some(false),
+            disable_normalization: false,
         };
 
-        let _periodic_wave = PeriodicWave::new(&context, Some(options));
+        let _periodic_wave = PeriodicWave::new(&context, options);
     }
 
     #[test]
@@ -295,10 +302,10 @@ mod tests {
         let options = PeriodicWaveOptions {
             real: Some(vec![0., 0., 0.]),
             imag: Some(vec![0., 0.]),
-            disable_normalization: Some(false),
+            disable_normalization: false,
         };
 
-        let _periodic_wave = PeriodicWave::new(&context, Some(options));
+        let _periodic_wave = PeriodicWave::new(&context, options);
     }
 
     #[test]
@@ -309,10 +316,10 @@ mod tests {
         let options = PeriodicWaveOptions {
             real: Some(vec![0.; 8193]),
             imag: Some(vec![0.; 8193]),
-            disable_normalization: Some(false),
+            disable_normalization: false,
         };
 
-        let _periodic_wave = PeriodicWave::new(&context, Some(options));
+        let _periodic_wave = PeriodicWave::new(&context, options);
     }
 
     #[test]
@@ -323,10 +330,10 @@ mod tests {
         let options = PeriodicWaveOptions {
             real: Some(vec![0.; 8193]),
             imag: None,
-            disable_normalization: Some(false),
+            disable_normalization: false,
         };
 
-        let _periodic_wave = PeriodicWave::new(&context, Some(options));
+        let _periodic_wave = PeriodicWave::new(&context, options);
     }
 
     #[test]
@@ -337,10 +344,10 @@ mod tests {
         let options = PeriodicWaveOptions {
             real: None,
             imag: Some(vec![0.; 8193]),
-            disable_normalization: Some(false),
+            disable_normalization: false,
         };
 
-        let _periodic_wave = PeriodicWave::new(&context, Some(options));
+        let _periodic_wave = PeriodicWave::new(&context, options);
     }
 
     #[test]

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -18,3 +18,22 @@ pub fn read<P: AsRef<Path>>(path: P) -> Result<SnapShot, Box<dyn Error>> {
 
     Ok(SnapShot { data })
 }
+
+// keep that around, usefull to write data into files and plot long signals
+// @todo - `write`
+// use std::fs::File;
+// use std::io::Write;
+
+// let mut file = File::create("_signal-expected.txt").unwrap();
+// for i in expected.iter() {
+//     let mut tmp = String::from(i.to_string());
+//     tmp += ",\n";
+//     file.write(tmp.to_string().as_bytes()).unwrap();
+// }
+
+// let mut file = File::create("_signal-result.txt").unwrap();
+// for i in result.iter() {
+//     let mut tmp = String::from(i.to_string());
+//     tmp += ",\n";
+//     file.write(tmp.to_string().as_bytes()).unwrap();
+// }

--- a/tests/offline.rs
+++ b/tests/offline.rs
@@ -52,11 +52,11 @@ fn test_start_stop() {
 
     {
         let opts = OscillatorOptions {
-            type_: Some(OscillatorType::Square),
-            frequency: Some(0.), // constant signal
+            type_: OscillatorType::Square,
+            frequency: 0., // constant signal
             ..Default::default()
         };
-        let osc = OscillatorNode::new(&context, Some(opts));
+        let osc = OscillatorNode::new(&context, opts);
         osc.connect(&context.destination());
 
         osc.start_at(1.);


### PR DESCRIPTION
Hey, here is an attempt related to #73 

I tried to follow these rules:

- follow types given by the spec (few changes from `f32` to `f64`, and `usize` to `u32`)
- optional value -> defined in `Default`
- nullable value -> `Option` that defaults to `None`
- `option` in node constructor should always be given e.g.: 
```rs
OscillatorNode::new(context, Default::default());
// rather than
OscillatorNode::new(context, None);
```

I have the impression it's quite consistent and logical from a user perspective, but there is still an issue with the `required` parameters (e.g. for `IirFilter` or `AudioBuffer`), for which I see two possible solutions:

1. define required param as `Option` that defaults to `None` and `panic` in the constructor if `None`
2. do not provide `Default` whenever there is a required param

(for now its closer to 2. I guess, but only because I did nothing :)

I also cleaned a bit `context.rs` but mainly harmonizing factory methods and sorting them to alphabetical order.

Let me know what you think