### PR TITLE
Small improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ rubato = "0.10"
 float_eq = "0.7"
 smallvec = "1.7.0"
 once_cell = "1.9.0"
-symphonia = { version = "0.4.0", default-features = false }
+symphonia = { version = "0.5.0", default-features = false }
 
 [dev-dependencies]
 rand = "0.8.*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/orottier/web-audio-api-rs"
 keywords = ["web-audio-api", "audio", "sound"]
 license = "MIT"
 categories = ["multimedia::audio"]
+exclude = ["/samples", "/snapshots"]
 
 [dependencies]
 cpal = "0.13.1"

--- a/src/context.rs
+++ b/src/context.rs
@@ -126,7 +126,7 @@ pub trait BaseAudioContext {
     /// // await result from the decoder thread
     /// let decode_buffer_result = handle.join();
     /// ```
-    fn decode_audio_data_sync<R: std::io::Read + Send + 'static>(
+    fn decode_audio_data_sync<R: std::io::Read + Send + Sync + 'static>(
         &self,
         input: R,
     ) -> Result<AudioBuffer, Box<dyn std::error::Error + Send + Sync>> {

--- a/src/context.rs
+++ b/src/context.rs
@@ -950,4 +950,18 @@ mod tests {
         let file = std::fs::File::open("samples/corrupt.wav").unwrap();
         assert!(context.decode_audio_data_sync(file).is_err());
     }
+
+    #[test]
+    fn test_create_buffer() {
+        let number_of_channels = 3;
+        let length = 2000;
+        let sample_rate = SampleRate(96_000);
+
+        let context = OfflineAudioContext::new(1, 0, SampleRate(44100));
+        let buffer = context.create_buffer(number_of_channels, length, sample_rate);
+
+        assert_eq!(buffer.number_of_channels(), 3);
+        assert_eq!(buffer.length(), 2000);
+        assert_float_eq!(buffer.sample_rate(), 96000., abs_all <= 0.);
+    }
 }

--- a/src/media/decoding.rs
+++ b/src/media/decoding.rs
@@ -39,7 +39,7 @@ impl<R> Seek for MediaInput<R> {
     }
 }
 
-impl<R: Read + Send> symphonia::core::io::MediaSource for MediaInput<R> {
+impl<R: Read + Send + Sync> symphonia::core::io::MediaSource for MediaInput<R> {
     fn is_seekable(&self) -> bool {
         false
     }
@@ -105,7 +105,7 @@ impl MediaDecoder {
     /// let media = MediaDecoder::try_new(input);
     ///
     /// assert!(media.is_err()); // the input was not a valid MIME type
-    pub fn try_new<R: std::io::Read + Send + 'static>(
+    pub fn try_new<R: std::io::Read + Send + Sync + 'static>(
         input: R,
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         // Symfonia lib needs a Box<dyn MediaSource> - use our own MediaInput

--- a/src/periodic_wave.rs
+++ b/src/periodic_wave.rs
@@ -281,7 +281,7 @@ mod tests {
             expected.push(sample);
         }
 
-        assert_float_eq!(result[..], expected[..], abs_all <= 0.);
+        assert_float_eq!(result[..], expected[..], abs_all <= 1e-6);
     }
 
     #[test]
@@ -302,7 +302,7 @@ mod tests {
             expected.push(sample);
         }
 
-        assert_float_eq!(result[..], expected[..], abs_all <= 0.);
+        assert_float_eq!(result[..], expected[..], abs_all <= 1e-6);
     }
 
     #[test]
@@ -344,6 +344,6 @@ mod tests {
 
         PeriodicWave::normalize(&mut expected);
 
-        assert_float_eq!(result[..], expected[..], abs_all <= 0.);
+        assert_float_eq!(result[..], expected[..], abs_all <= 1e-6);
     }
 }


### PR DESCRIPTION
Hey @b-ma could you check for me your output for
`cargo test -- test_audio_buffer_resampling`

For me it returns an error consistently, but it works in `--release` mode.
Very strange because the test looks sound to me.
It appears to me that in debug mode the node stops returning samples prematurely. So the left hand side of the assert contains many zeroes..