### PR TITLE
Feature/resampling

### DIFF
--- a/examples/audio_buffer.rs
+++ b/examples/audio_buffer.rs
@@ -1,0 +1,44 @@
+use std::f32::consts::PI;
+
+use web_audio_api::context::{AudioContext, BaseAudioContext};
+use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
+
+fn main() {
+    let context = AudioContext::new(None);
+
+    // create a 1 second buffer filled with a sine at 200Hz
+    println!("> Play sine at 200Hz created manually in an AudioBuffer");
+
+    let length = context.sample_rate() as usize;
+    let sample_rate = context.sample_rate_raw();
+    let mut buffer = context.create_buffer(1, length, sample_rate);
+    let mut sine = vec![];
+
+    for i in 0..length {
+        let phase = i as f32 / length as f32 * 2. * PI * 200.;
+        sine.push(phase.sin());
+    }
+
+    buffer.copy_to_channel(&sine, 0);
+
+    // play the buffer in a loop
+    let src = context.create_buffer_source();
+    src.set_buffer(buffer.clone());
+    src.set_loop(true);
+    src.connect(&context.destination());
+    src.start_at(context.current_time());
+    src.stop_at(context.current_time() + 3.);
+
+    std::thread::sleep(std::time::Duration::from_millis(3500));
+
+    // play a sine at 200Hz
+    println!("> Play sine at 200Hz from an OscillatorNode");
+
+    let osc = context.create_oscillator();
+    osc.frequency().set_value(200.);
+    osc.connect(&context.destination());
+    osc.start_at(context.current_time());
+    osc.stop_at(context.current_time() + 3.);
+
+    std::thread::sleep(std::time::Duration::from_millis(3500));
+}

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -542,6 +542,31 @@ mod tests {
     }
 
     #[test]
+    fn test_resample_to_zero_hertz() {
+        let channel = ChannelData::from(vec![1., 2., 3., 4., 5.]);
+        let mut buffer = AudioBuffer::from_channels(vec![channel], SampleRate(100));
+        buffer.resample(SampleRate(0));
+    }
+
+    #[test]
+    fn test_resample_from_zero_hertz() {
+        let channel = ChannelData::from(vec![1., 2., 3., 4., 5.]);
+        let mut buffer = AudioBuffer::from_channels(vec![channel], SampleRate(0));
+        buffer.resample(SampleRate(100));
+    }
+
+    #[test]
+    fn test_resample_from_empty() {
+        let options = AudioBufferOptions {
+            number_of_channels: 1,
+            length: 0,
+            sample_rate: SampleRate(100),
+        };
+        let mut buffer = AudioBuffer::new(options);
+        buffer.resample(SampleRate(200));
+    }
+
+    #[test]
     fn test_upsample() {
         let channel = ChannelData::from(vec![1., 2., 3., 4., 5.]);
         let mut buffer = AudioBuffer::from_channels(vec![channel], SampleRate(100));

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -144,6 +144,11 @@ impl AudioBuffer {
     }
 
     /// Copy data from a given channel to the given `Vec`
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `channel_number` is greater or equal to
+    /// `AudioBuffer::number_of_channels()`
     pub fn copy_from_channel(&self, destination: &mut [f32], channel_number: usize) {
         assert_is_valid_channel_number(channel_number, self.number_of_channels());
 
@@ -151,6 +156,11 @@ impl AudioBuffer {
     }
 
     /// Copy data from a given channel to the given `Vec` starting at `offset`
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `channel_number` is greater or equal to
+    /// `AudioBuffer::number_of_channels()`
     pub fn copy_from_channel_with_offset(
         &self,
         destination: &mut [f32],
@@ -171,6 +181,11 @@ impl AudioBuffer {
     }
 
     /// Copy data from a given source to the given channel.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `channel_number` is greater or equal to
+    /// `AudioBuffer::number_of_channels()`
     pub fn copy_to_channel(&mut self, source: &[f32], channel_number: usize) {
         assert_is_valid_channel_number(channel_number, self.number_of_channels());
 
@@ -178,6 +193,11 @@ impl AudioBuffer {
     }
 
     /// Copy data from a given source to the given channel starting at `offset`.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `channel_number` is greater or equal to
+    /// `AudioBuffer::number_of_channels()`
     pub fn copy_to_channel_with_offset(
         &mut self,
         source: &[f32],
@@ -198,6 +218,11 @@ impl AudioBuffer {
     }
 
     /// Return a read-only copy of the underlying data of the channel
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `channel_number` is greater or equal to
+    /// `AudioBuffer::number_of_channels()`
     pub fn get_channel_data(&self, channel_number: usize) -> &[f32] {
         assert_is_valid_channel_number(channel_number, self.number_of_channels());
         // [spec] According to the rules described in acquire the content either allow writing

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -30,6 +30,42 @@ pub struct AudioBufferOptions {
 /// - MDN documentation: <https://developer.mozilla.org/en-US/docs/Web/API/AudioBuffer>
 /// - specification: <https://webaudio.github.io/web-audio-api/#AudioBuffer>
 /// - see also: [`BaseAudioContext::create_buffer`](crate::context::BaseAudioContext::create_buffer)
+///
+/// # Usage
+///
+/// ```no_run
+/// use std::f32::consts::PI;
+/// use web_audio_api::context::{AudioContext, BaseAudioContext};
+/// use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
+///
+/// let context = AudioContext::new(None);
+///
+/// let length = context.sample_rate() as usize;
+/// let sample_rate = context.sample_rate_raw();
+/// let mut buffer = context.create_buffer(1, length, sample_rate);
+///
+/// // fill buffer with a sine wave
+/// let mut sine = vec![];
+///
+/// for i in 0..length {
+///     let phase = i as f32 / length as f32 * 2. * PI * 200.;
+///     sine.push(phase.sin());
+/// }
+///
+/// buffer.copy_to_channel(&sine, 0);
+///
+/// // play the buffer in a loop
+/// let src = context.create_buffer_source();
+/// src.set_buffer(buffer.clone());
+/// src.set_loop(true);
+/// src.connect(&context.destination());
+/// src.start();
+/// ```
+///
+/// # Example
+///
+/// - `cargo run --release --example audio_buffer`
+///
 #[derive(Clone, Debug)]
 pub struct AudioBuffer {
     channels: Vec<ChannelData>,

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -147,7 +147,7 @@ impl AudioBuffer {
     ///
     /// # Panics
     ///
-    /// This function will panic if `channel_number` is greater or equal to
+    /// This function will panic if `channel_number` is greater or equal than
     /// `AudioBuffer::number_of_channels()`
     pub fn copy_from_channel(&self, destination: &mut [f32], channel_number: usize) {
         assert_is_valid_channel_number(channel_number, self.number_of_channels());
@@ -159,7 +159,7 @@ impl AudioBuffer {
     ///
     /// # Panics
     ///
-    /// This function will panic if `channel_number` is greater or equal to
+    /// This function will panic if `channel_number` is greater or equal than
     /// `AudioBuffer::number_of_channels()`
     pub fn copy_from_channel_with_offset(
         &self,
@@ -184,7 +184,7 @@ impl AudioBuffer {
     ///
     /// # Panics
     ///
-    /// This function will panic if `channel_number` is greater or equal to
+    /// This function will panic if `channel_number` is greater or equal than
     /// `AudioBuffer::number_of_channels()`
     pub fn copy_to_channel(&mut self, source: &[f32], channel_number: usize) {
         assert_is_valid_channel_number(channel_number, self.number_of_channels());
@@ -196,7 +196,7 @@ impl AudioBuffer {
     ///
     /// # Panics
     ///
-    /// This function will panic if `channel_number` is greater or equal to
+    /// This function will panic if `channel_number` is greater or equal than
     /// `AudioBuffer::number_of_channels()`
     pub fn copy_to_channel_with_offset(
         &mut self,
@@ -221,7 +221,7 @@ impl AudioBuffer {
     ///
     /// # Panics
     ///
-    /// This function will panic if `channel_number` is greater or equal to
+    /// This function will panic if `channel_number` is greater or equal than
     /// `AudioBuffer::number_of_channels()`
     pub fn get_channel_data(&self, channel_number: usize) -> &[f32] {
         assert_is_valid_channel_number(channel_number, self.number_of_channels());

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -335,6 +335,7 @@ impl ChannelData {
 #[cfg(test)]
 mod tests {
     use float_eq::assert_float_eq;
+    use std::convert::TryFrom;
     use std::f32::consts::PI;
 
     use super::*;
@@ -596,7 +597,7 @@ mod tests {
             let right_chan = ChannelData::from(right);
             let mut buffer = AudioBuffer::from_channels(
                 vec![left_chan, right_chan],
-                SampleRate(source_sr as u32),
+                SampleRate(u32::try_from(source_sr).unwrap()),
             );
             buffer.resample(SampleRate(target_sr as u32));
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -224,14 +224,14 @@ impl AudioBuffer {
         AudioBuffer::from_channels(channels, sample_rate)
     }
 
-    /// Resample to the desired sample rate. The method performs a simple linear
-    /// interpolation an keep the first and last sample intacts. The new number
-    /// of samples is always ceiled according the ratio defined by old and new
-    /// sample rates.
+    // Resample to the desired sample rate. The method performs a simple linear
+    // interpolation an keep the first and last sample intacts. The new number
+    // of samples is always ceiled according the ratio defined by old and new
+    // sample rates.
     //
     // ```
-    // use web_audio_api::SampleRate;
-    // use web_audio_api::buffer::{ChannelData, AudioBuffer};
+    // use crate::SampleRate;
+    // use crate::buffer::{ChannelData, AudioBuffer};
     //
     // let channel = ChannelData::from(vec![1., 2., 3., 4., 5.]);
     // let mut buffer = AudioBuffer::from_channels(vec![channel], SampleRate(48_000));

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,7 +1,6 @@
 //! General purpose audio signal data structures
 use std::sync::Arc;
 
-use crate::media::MediaStream;
 use crate::render::AudioRenderQuantum;
 use crate::SampleRate;
 
@@ -28,8 +27,6 @@ pub struct AudioBuffer {
     channels: Vec<ChannelData>,
     sample_rate: SampleRate,
 }
-
-use std::error::Error;
 
 impl AudioBuffer {
     /// Allocate a silent audiobuffer with [`AudioBufferOptions`]
@@ -321,112 +318,6 @@ impl ChannelData {
     }
 }
 
-/// Sample rate converter and buffer chunk splitter.
-///
-/// A `MediaElement` can be wrapped inside a `Resampler` to yield AudioBuffers of the desired sample_rate and length
-///
-/// ```
-/// use web_audio_api::SampleRate;
-/// use web_audio_api::buffer::{AudioBuffer, Resampler};
-///
-/// // construct an input of 3 chunks of 5 samples
-/// let samples = vec![vec![1., 2., 3., 4., 5.]];
-/// let input_buf = AudioBuffer::from(samples, SampleRate(44_100));
-/// let input = vec![input_buf; 3].into_iter().map(|b| Ok(b));
-///
-/// // resample to chunks of 10 samples
-/// let mut resampler = Resampler::new(SampleRate(44_100), 10, input);
-///
-/// // first chunk contains 10 samples
-/// let next = resampler.next().unwrap().unwrap();
-/// assert_eq!(next.length(), 10);
-/// assert_eq!(next.get_channel_data(0)[..], vec![
-///     1., 2., 3., 4., 5.,
-///     1., 2., 3., 4., 5.,
-/// ][..]);
-///
-/// // second chunk contains 5 samples of signal, and 5 silent
-/// let next = resampler.next().unwrap().unwrap();
-/// assert_eq!(next.length(), 10);
-/// assert_eq!(next.get_channel_data(0)[..], vec![
-///     1., 2., 3., 4., 5.,
-///     0., 0., 0., 0., 0.,
-/// ][..]);
-///
-/// // no further chunks
-/// assert!(resampler.next().is_none());
-/// ```
-pub struct Resampler<I> {
-    /// desired sample rate
-    sample_rate: SampleRate,
-    /// desired sample length
-    sample_len: usize,
-    /// input stream
-    input: I,
-    /// internal buffer
-    buffer: Option<AudioBuffer>,
-}
-
-impl<M: MediaStream> Resampler<M> {
-    pub fn new(sample_rate: SampleRate, sample_len: usize, input: M) -> Self {
-        Self {
-            sample_rate,
-            sample_len,
-            input,
-            buffer: None,
-        }
-    }
-}
-
-impl<M: MediaStream> Iterator for Resampler<M> {
-    type Item = Result<AudioBuffer, Box<dyn Error + Send + Sync>>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let mut buffer = match self.buffer.take() {
-            None => match self.input.next() {
-                None => return None,
-                Some(Err(e)) => return Some(Err(e)),
-                Some(Ok(mut data)) => {
-                    data.resample(self.sample_rate);
-                    data
-                }
-            },
-            Some(data) => data,
-        };
-
-        while buffer.length() < self.sample_len {
-            // buffer is smaller than desired len
-            match self.input.next() {
-                None => {
-                    let options = AudioBufferOptions {
-                        number_of_channels: buffer.number_of_channels(),
-                        length: self.sample_len - buffer.length(),
-                        sample_rate: self.sample_rate,
-                    };
-
-                    let padding = AudioBuffer::new(options);
-                    buffer.extend(&padding);
-
-                    return Some(Ok(buffer));
-                }
-                Some(Err(e)) => return Some(Err(e)),
-                Some(Ok(mut data)) => {
-                    data.resample(self.sample_rate);
-                    buffer.extend(&data)
-                }
-            }
-        }
-
-        if buffer.length() == self.sample_len {
-            return Some(Ok(buffer));
-        }
-
-        self.buffer = Some(buffer.split_off(self.sample_len));
-
-        Some(Ok(buffer))
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use float_eq::assert_float_eq;
@@ -658,60 +549,5 @@ mod tests {
             abs_all <= 0.
         );
         assert_eq!(buffer.sample_rate_raw().0, 100);
-    }
-
-    #[test]
-    fn test_resampler_concat() {
-        let channel = ChannelData::from(vec![1., 2., 3., 4., 5.]);
-        let input_buf = AudioBuffer::from_channels(vec![channel], SampleRate(44_100));
-        let input = vec![input_buf; 3].into_iter().map(Ok);
-        let mut resampler = Resampler::new(SampleRate(44_100), 10, input);
-
-        let next = resampler.next().unwrap().unwrap();
-        assert_eq!(next.length(), 10);
-        assert_float_eq!(
-            next.channel_data(0).as_slice(),
-            &[1., 2., 3., 4., 5., 1., 2., 3., 4., 5.,][..],
-            abs_all <= 0.
-        );
-
-        let next = resampler.next().unwrap().unwrap();
-        assert_eq!(next.length(), 10);
-        assert_float_eq!(
-            next.channel_data(0).as_slice(),
-            &[1., 2., 3., 4., 5., 0., 0., 0., 0., 0.][..],
-            abs_all <= 0.
-        );
-
-        assert!(resampler.next().is_none());
-    }
-
-    #[test]
-    fn test_resampler_split() {
-        let channel = ChannelData::from(vec![1., 2., 3., 4., 5., 6., 7., 8., 9., 10.]);
-        let input_buf = Ok(AudioBuffer::from_channels(
-            vec![channel],
-            SampleRate(44_100),
-        ));
-        let input = vec![input_buf].into_iter();
-        let mut resampler = Resampler::new(SampleRate(44_100), 5, input);
-
-        let next = resampler.next().unwrap().unwrap();
-        assert_eq!(next.length(), 5);
-        assert_float_eq!(
-            next.channel_data(0).as_slice(),
-            &[1., 2., 3., 4., 5.][..],
-            abs_all <= 0.
-        );
-
-        let next = resampler.next().unwrap().unwrap();
-        assert_eq!(next.length(), 5);
-        assert_float_eq!(
-            next.channel_data(0).as_slice(),
-            &[6., 7., 8., 9., 10.][..],
-            abs_all <= 0.
-        );
-
-        assert!(resampler.next().is_none());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,8 +140,8 @@ impl AtomicF64 {
 /// Assert that the given sample rate is valid.
 ///
 /// Note that in practice sample rates should stand between 8000Hz (lower bound for
-/// voice based applications, i.e. phone bandwidth) and 96000Hz (for very high quality
-/// audio applications and spectrum manipulation).
+/// voice based applications, e.g. see phone bandwidth) and 96000Hz (for very high
+/// quality audio applications and spectrum manipulation).
 /// Most common sample rates for musical applications are 44100 and 48000.
 /// - see <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createbuffer-samplerate>
 ///
@@ -177,7 +177,7 @@ pub(crate) fn assert_valid_number_of_channels(number_of_channels: usize) {
 }
 
 /// Assert that the given channel number is valid according the number of channel
-/// of an Audio asset (e.g. [`AudioBuffer`])
+/// of an Audio asset (e.g. [`AudioBuffer`](crate::buffer::AudioBuffer))
 ///
 /// # Panics
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@
 //! std::thread::sleep(std::time::Duration::from_secs(4));
 //! ```
 
+use std::convert::TryFrom;
 use std::fmt;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 
@@ -137,6 +138,39 @@ impl AtomicF64 {
     }
 }
 
+/// Utility functions for arguments sanity check
+pub(crate) fn assert_is_valid_sample_rate(sample_rate: SampleRate) {
+    let sample_rate = sample_rate.0;
+    // allow arbitrary sample rates in tests
+    if cfg!(test) {
+        if sample_rate == 0 {
+            panic!(
+                "Invalid sample rate: {:?} is negative or zero (test mode)",
+                sample_rate
+            );
+        }
+    } else {
+        // An implementation MUST support sample rates in at least the range 8000 to 96000
+        // @note - `test/media.rs` relies on `RENDER_QUANTUM_SIZE` this should be
+        // cleaned together with the MediaElement, see pull #106
+        if sample_rate < u32::try_from(RENDER_QUANTUM_SIZE).unwrap() || sample_rate > 96000 {
+            panic!(
+                "Invalid sample rate: {:?} is outside range [8000, 96000]",
+                sample_rate
+            );
+        }
+    }
+}
+
+pub(crate) fn assert_is_valid_number_of_channels(number_of_channels: usize) {
+    if number_of_channels == 0 || number_of_channels > MAX_CHANNELS {
+        panic!(
+            "Invalid number of channels: {:?} is outside range [1, 32]",
+            number_of_channels
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use float_eq::assert_float_eq;
@@ -154,5 +188,36 @@ mod tests {
         let prev = f.swap(4.0);
         assert_float_eq!(prev, 3.0, abs <= 0.);
         assert_float_eq!(f.load(), 4.0, abs <= 0.);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_sample_rate() {
+        let sample_rate = SampleRate(0);
+        assert_is_valid_sample_rate(sample_rate);
+    }
+
+    #[test]
+    fn test_valid_sample_rate() {
+        let sample_rate = SampleRate(1);
+        assert_is_valid_sample_rate(sample_rate);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_number_of_channels_min() {
+        assert_is_valid_number_of_channels(0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_number_of_channels_max() {
+        assert_is_valid_number_of_channels(33);
+    }
+
+    #[test]
+    fn test_valid_number_of_channels() {
+        assert_is_valid_number_of_channels(1);
+        assert_is_valid_number_of_channels(32);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ pub(crate) fn assert_is_valid_sample_rate(sample_rate: SampleRate) {
     if cfg!(test) {
         if sample_rate == 0 {
             panic!(
-                "Invalid sample rate: {:?} is negative or zero (test mode)",
+                "NotSupportedError - Invalid sample rate: {:?} is negative or zero (test mode)",
                 sample_rate
             );
         }
@@ -155,7 +155,7 @@ pub(crate) fn assert_is_valid_sample_rate(sample_rate: SampleRate) {
         // cleaned together with the MediaElement, see pull #106
         if sample_rate < u32::try_from(RENDER_QUANTUM_SIZE).unwrap() || sample_rate > 96000 {
             panic!(
-                "Invalid sample rate: {:?} is outside range [8000, 96000]",
+                "NotSupportedError - Invalid sample rate: {:?} is outside range [8000, 96000]",
                 sample_rate
             );
         }
@@ -165,8 +165,17 @@ pub(crate) fn assert_is_valid_sample_rate(sample_rate: SampleRate) {
 pub(crate) fn assert_is_valid_number_of_channels(number_of_channels: usize) {
     if number_of_channels == 0 || number_of_channels > MAX_CHANNELS {
         panic!(
-            "Invalid number of channels: {:?} is outside range [1, 32]",
+            "NotSupportedError - Invalid number of channels: {:?} is outside range [1, 32]",
             number_of_channels
+        );
+    }
+}
+
+pub(crate) fn assert_is_valid_channel_number(channel_number: usize, number_of_channels: usize) {
+    if channel_number >= number_of_channels {
+        panic!(
+            "IndexSizeError - invalid channel number {:?} (number of channels: {:?})",
+            channel_number, number_of_channels
         );
     }
 }

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -6,6 +6,9 @@ pub use decoding::MediaDecoder;
 mod mic;
 pub use mic::Microphone;
 
+mod resampling;
+pub(crate) use resampling::Resampler;
+
 #[cfg(not(test))]
 pub(crate) use mic::MicrophoneRender;
 

--- a/src/media/resampling.rs
+++ b/src/media/resampling.rs
@@ -1,0 +1,141 @@
+use std::error::Error;
+
+use crate::buffer::{AudioBuffer, AudioBufferOptions};
+use crate::media::MediaStream;
+use crate::SampleRate;
+
+/// Sample rate converter and buffer chunk splitter.
+pub struct Resampler<I> {
+    /// desired sample rate
+    sample_rate: SampleRate,
+    /// desired sample length
+    sample_len: usize,
+    /// input stream
+    input: I,
+    /// internal buffer
+    buffer: Option<AudioBuffer>,
+}
+
+impl<M: MediaStream> Resampler<M> {
+    pub fn new(sample_rate: SampleRate, sample_len: usize, input: M) -> Self {
+        Self {
+            sample_rate,
+            sample_len,
+            input,
+            buffer: None,
+        }
+    }
+}
+
+impl<M: MediaStream> Iterator for Resampler<M> {
+    type Item = Result<AudioBuffer, Box<dyn Error + Send + Sync>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut buffer = match self.buffer.take() {
+            None => match self.input.next() {
+                None => return None,
+                Some(Err(e)) => return Some(Err(e)),
+                Some(Ok(mut data)) => {
+                    data.resample(self.sample_rate);
+                    data
+                }
+            },
+            Some(data) => data,
+        };
+
+        while buffer.length() < self.sample_len {
+            // buffer is smaller than desired len
+            match self.input.next() {
+                None => {
+                    let options = AudioBufferOptions {
+                        number_of_channels: buffer.number_of_channels(),
+                        length: self.sample_len - buffer.length(),
+                        sample_rate: self.sample_rate,
+                    };
+
+                    let padding = AudioBuffer::new(options);
+                    buffer.extend(&padding);
+
+                    return Some(Ok(buffer));
+                }
+                Some(Err(e)) => return Some(Err(e)),
+                Some(Ok(mut data)) => {
+                    data.resample(self.sample_rate);
+                    buffer.extend(&data)
+                }
+            }
+        }
+
+        if buffer.length() == self.sample_len {
+            return Some(Ok(buffer));
+        }
+
+        self.buffer = Some(buffer.split_off(self.sample_len));
+
+        Some(Ok(buffer))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use float_eq::assert_float_eq;
+
+    use super::*;
+    use crate::buffer::{AudioBuffer, ChannelData};
+    use crate::SampleRate;
+
+    #[test]
+    fn test_resampler_concat() {
+        let channel = ChannelData::from(vec![1., 2., 3., 4., 5.]);
+        let input_buf = AudioBuffer::from_channels(vec![channel], SampleRate(44_100));
+        let input = vec![input_buf; 3].into_iter().map(Ok);
+        let mut resampler = Resampler::new(SampleRate(44_100), 10, input);
+
+        let next = resampler.next().unwrap().unwrap();
+        assert_eq!(next.length(), 10);
+        assert_float_eq!(
+            next.channel_data(0).as_slice(),
+            &[1., 2., 3., 4., 5., 1., 2., 3., 4., 5.,][..],
+            abs_all <= 0.
+        );
+
+        let next = resampler.next().unwrap().unwrap();
+        assert_eq!(next.length(), 10);
+        assert_float_eq!(
+            next.channel_data(0).as_slice(),
+            &[1., 2., 3., 4., 5., 0., 0., 0., 0., 0.][..],
+            abs_all <= 0.
+        );
+
+        assert!(resampler.next().is_none());
+    }
+
+    #[test]
+    fn test_resampler_split() {
+        let channel = ChannelData::from(vec![1., 2., 3., 4., 5., 6., 7., 8., 9., 10.]);
+        let input_buf = Ok(AudioBuffer::from_channels(
+            vec![channel],
+            SampleRate(44_100),
+        ));
+        let input = vec![input_buf].into_iter();
+        let mut resampler = Resampler::new(SampleRate(44_100), 5, input);
+
+        let next = resampler.next().unwrap().unwrap();
+        assert_eq!(next.length(), 5);
+        assert_float_eq!(
+            next.channel_data(0).as_slice(),
+            &[1., 2., 3., 4., 5.][..],
+            abs_all <= 0.
+        );
+
+        let next = resampler.next().unwrap().unwrap();
+        assert_eq!(next.length(), 5);
+        assert_float_eq!(
+            next.channel_data(0).as_slice(),
+            &[6., 7., 8., 9., 10.][..],
+            abs_all <= 0.
+        );
+
+        assert!(resampler.next().is_none());
+    }
+}

--- a/src/media/resampling.rs
+++ b/src/media/resampling.rs
@@ -5,6 +5,41 @@ use crate::media::MediaStream;
 use crate::SampleRate;
 
 /// Sample rate converter and buffer chunk splitter.
+///
+/// A stream can be wrapped inside a `Resampler` to yield `AudioBuffer`s
+/// of the desired sample_rate and length
+///
+/// ```ignore
+/// use crate::SampleRate;
+/// use crate::buffer::{AudioBuffer, Resampler};
+///
+/// // construct an input of 3 chunks of 5 samples
+/// let samples = vec![vec![1., 2., 3., 4., 5.]];
+/// let input_buf = AudioBuffer::from(samples, SampleRate(44_100));
+/// let input = vec![input_buf; 3].into_iter().map(|b| Ok(b));
+///
+/// // resample to chunks of 10 samples
+/// let mut resampler = Resampler::new(SampleRate(44_100), 10, input);
+///
+/// // first chunk contains 10 samples
+/// let next = resampler.next().unwrap().unwrap();
+/// assert_eq!(next.length(), 10);
+/// assert_eq!(next.get_channel_data(0)[..], vec![
+///     1., 2., 3., 4., 5.,
+///     1., 2., 3., 4., 5.,
+/// ][..]);
+///
+/// // second chunk contains 5 samples of signal, and 5 silent
+/// let next = resampler.next().unwrap().unwrap();
+/// assert_eq!(next.length(), 10);
+/// assert_eq!(next.get_channel_data(0)[..], vec![
+///     1., 2., 3., 4., 5.,
+///     0., 0., 0., 0., 0.,
+/// ][..]);
+///
+/// // no further chunks
+/// assert!(resampler.next().is_none());
+/// ```
 pub struct Resampler<I> {
     /// desired sample rate
     sample_rate: SampleRate,

--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -708,7 +708,9 @@ mod tests {
         let sr = SampleRate(sample_rate as u32);
         let mut context = OfflineAudioContext::new(1, sample_rate, sr);
 
+        println!("create dirac");
         let mut dirac = context.create_buffer(1, 1, sr);
+        println!("created dirac");
         dirac.copy_to_channel(&[1.], 0);
 
         let src = context.create_buffer_source();
@@ -716,7 +718,9 @@ mod tests {
         src.set_buffer(dirac);
         src.start_at(-1.);
 
+        println!("start rendering");
         let result = context.start_rendering_sync();
+        println!("stopped rendering");
         let channel = result.get_channel_data(0);
 
         let mut expected = vec![0.; sample_rate];

--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -708,9 +708,7 @@ mod tests {
         let sr = SampleRate(sample_rate as u32);
         let mut context = OfflineAudioContext::new(1, sample_rate, sr);
 
-        println!("create dirac");
         let mut dirac = context.create_buffer(1, 1, sr);
-        println!("created dirac");
         dirac.copy_to_channel(&[1.], 0);
 
         let src = context.create_buffer_source();
@@ -718,9 +716,7 @@ mod tests {
         src.set_buffer(dirac);
         src.start_at(-1.);
 
-        println!("start rendering");
         let result = context.start_rendering_sync();
-        println!("stopped rendering");
         let channel = result.get_channel_data(0);
 
         let mut expected = vec![0.; sample_rate];

--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -735,8 +735,6 @@ mod tests {
             let mut buffer = context.create_buffer(1, buf_sr, SampleRate(buf_sr as u32));
             let mut sine = vec![];
 
-            println!("{:?}", buffer.sample_rate_raw());
-
             for i in 0..buf_sr {
                 let phase = i as f32 / buf_sr as f32 * 2. * PI;
                 let sample = phase.sin();

--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -374,7 +374,6 @@ impl AudioProcessor for AudioBufferSourceRenderer {
         }
 
         // If the buffer has not been set wait for it.
-        // @see - `set_buffer` tries to acquire the buffer if the source already started
         let buffer = match &self.buffer {
             None => {
                 output.make_silent();
@@ -735,6 +734,8 @@ mod tests {
             let buf_sr = *sr;
             let mut buffer = context.create_buffer(1, buf_sr, SampleRate(buf_sr as u32));
             let mut sine = vec![];
+
+            println!("{:?}", buffer.sample_rate_raw());
 
             for i in 0..buf_sr {
                 let phase = i as f32 / buf_sr as f32 * 2. * PI;

--- a/src/node/media_element.rs
+++ b/src/node/media_element.rs
@@ -1,7 +1,7 @@
-use crate::buffer::Resampler;
 use crate::context::{AudioContextRegistration, BaseAudioContext};
 use crate::control::{Controller, Scheduler};
 use crate::media::MediaElement;
+use crate::media::Resampler;
 use crate::RENDER_QUANTUM_SIZE;
 
 use super::{

--- a/src/node/media_element.rs
+++ b/src/node/media_element.rs
@@ -1,7 +1,6 @@
 use crate::context::{AudioContextRegistration, BaseAudioContext};
 use crate::control::{Controller, Scheduler};
-use crate::media::MediaElement;
-use crate::media::Resampler;
+use crate::media::{MediaElement, Resampler};
 use crate::RENDER_QUANTUM_SIZE;
 
 use super::{

--- a/src/node/media_stream.rs
+++ b/src/node/media_stream.rs
@@ -1,8 +1,6 @@
 use crate::context::{AudioContextRegistration, BaseAudioContext};
 use crate::control::Scheduler;
-use crate::media::MediaStream;
-use crate::media::Resampler;
-
+use crate::media::{MediaStream, Resampler};
 use crate::RENDER_QUANTUM_SIZE;
 
 use super::{AudioNode, ChannelConfig, ChannelConfigOptions, MediaStreamRenderer};

--- a/src/node/media_stream.rs
+++ b/src/node/media_stream.rs
@@ -1,7 +1,7 @@
-use crate::buffer::Resampler;
 use crate::context::{AudioContextRegistration, BaseAudioContext};
 use crate::control::Scheduler;
 use crate::media::MediaStream;
+use crate::media::Resampler;
 
 use crate::RENDER_QUANTUM_SIZE;
 

--- a/src/node/oscillator.rs
+++ b/src/node/oscillator.rs
@@ -94,7 +94,6 @@ impl From<u32> for OscillatorType {
 /// # Usage
 ///
 /// ```no_run
-/// use std::fs::File;
 /// use web_audio_api::context::{BaseAudioContext, AudioContext};
 /// use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 ///


### PR DESCRIPTION
Hey, 

related to #112 
- `Resampler` now lives in its own file in `media`
- `Buffer::resample` does a linear interpolation

The example `cargo run --example resampling` now sounds better with `decode_audio_data`

Between, I have made a rapid test with the `speex_resample` crate, that seems very slow for us I think and I have a strange bug on the right channel which just disappears. 

To be continued... (seems we will have to dig more on the `rubato` side)