### PR TITLE
Remove AudioNodeId from public interface

### DIFF
--- a/examples/worklet.rs
+++ b/examples/worklet.rs
@@ -50,9 +50,7 @@ impl WhiteNoiseNode {
                 default_value: 1.,
                 automation_rate: AutomationRate::A,
             };
-            let (param, proc) = context
-                .base()
-                .create_audio_param(param_opts, registration.id());
+            let (param, proc) = context.base().create_audio_param(param_opts, &registration);
 
             // setup the processor, this will run in the render thread
             let render = WhiteNoiseProcessor { amplitude: proc };

--- a/src/context/base.rs
+++ b/src/context/base.rs
@@ -215,7 +215,7 @@ pub trait BaseAudioContext {
     fn create_audio_param(
         &self,
         opts: AudioParamDescriptor,
-        dest: &AudioNodeId,
+        dest: &AudioContextRegistration,
     ) -> (crate::param::AudioParam, AudioParamId) {
         let param = self.base().register(move |registration| {
             let (node, proc) = crate::param::audio_param_pair(opts, registration);
@@ -224,9 +224,9 @@ pub trait BaseAudioContext {
         });
 
         // Connect the param to the node, once the node is registered inside the audio graph.
-        self.base().queue_audio_param_connect(&param, dest);
+        self.base().queue_audio_param_connect(&param, dest.id());
 
-        let proc_id = AudioParamId(param.id().0);
+        let proc_id = AudioParamId(param.registration().id().0);
         (param, proc_id)
     }
 

--- a/src/context/concrete_base.rs
+++ b/src/context/concrete_base.rs
@@ -300,7 +300,7 @@ impl ConcreteBaseAudioContext {
     /// It is not performed immediately as the `AudioNode` is not registered at this point.
     pub(super) fn queue_audio_param_connect(&self, param: &AudioParam, audio_node: &AudioNodeId) {
         let message = ControlMessage::ConnectNode {
-            from: param.id().0,
+            from: param.registration().id().0,
             to: audio_node.0,
             output: 0,
             input: u32::MAX, // audio params connect to the 'hidden' input port

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -35,7 +35,7 @@ const LISTENER_PARAM_IDS: Range<u64> = 2..11;
 ///
 /// Used for internal bookkeeping.
 #[derive(Debug)]
-pub struct AudioNodeId(u64);
+pub(crate) struct AudioNodeId(u64);
 
 /// Unique identifier for audio params.
 ///
@@ -66,14 +66,14 @@ impl AudioContextRegistration {
     // false positive: AudioContextRegistration is not const
     #[allow(clippy::missing_const_for_fn, clippy::unused_self)]
     #[must_use]
-    pub fn id(&self) -> &AudioNodeId {
+    pub(crate) fn id(&self) -> &AudioNodeId {
         &self.id
     }
     /// get the context of the registration
     // false positive: AudioContextRegistration is not const
     #[allow(clippy::missing_const_for_fn, clippy::unused_self)]
     #[must_use]
-    pub fn context(&self) -> &ConcreteBaseAudioContext {
+    pub(crate) fn context(&self) -> &ConcreteBaseAudioContext {
         &self.context
     }
 }

--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -154,7 +154,7 @@ impl AudioBufferSourceNode {
             };
             let (d_param, d_proc) = context
                 .base()
-                .create_audio_param(detune_param_options, registration.id());
+                .create_audio_param(detune_param_options, &registration);
 
             d_param.set_value(detune);
 
@@ -166,7 +166,7 @@ impl AudioBufferSourceNode {
             };
             let (pr_param, pr_proc) = context
                 .base()
-                .create_audio_param(playback_rate_param_options, registration.id());
+                .create_audio_param(playback_rate_param_options, &registration);
 
             pr_param.set_value(playback_rate);
 

--- a/src/node/biquad_filter.rs
+++ b/src/node/biquad_filter.rs
@@ -168,7 +168,7 @@ impl BiquadFilterNode {
             };
             let (q_param, q_proc) = context
                 .base()
-                .create_audio_param(q_param_opts, registration.id());
+                .create_audio_param(q_param_opts, &registration);
 
             q_param.set_value(q_value);
 
@@ -180,7 +180,7 @@ impl BiquadFilterNode {
             };
             let (d_param, d_proc) = context
                 .base()
-                .create_audio_param(d_param_opts, registration.id());
+                .create_audio_param(d_param_opts, &registration);
 
             d_param.set_value(d_value);
 
@@ -193,7 +193,7 @@ impl BiquadFilterNode {
             };
             let (f_param, f_proc) = context
                 .base()
-                .create_audio_param(f_param_opts, registration.id());
+                .create_audio_param(f_param_opts, &registration);
 
             f_param.set_value(f_value);
 
@@ -205,7 +205,7 @@ impl BiquadFilterNode {
             };
             let (g_param, g_proc) = context
                 .base()
-                .create_audio_param(g_param_opts, registration.id());
+                .create_audio_param(g_param_opts, &registration);
 
             g_param.set_value(g_value);
 

--- a/src/node/constant_source.rs
+++ b/src/node/constant_source.rs
@@ -109,9 +109,7 @@ impl ConstantSourceNode {
                 default_value: 1.,
                 automation_rate: AutomationRate::A,
             };
-            let (param, proc) = context
-                .base()
-                .create_audio_param(param_opts, registration.id());
+            let (param, proc) = context.base().create_audio_param(param_opts, &registration);
             param.set_value(options.offset);
 
             let scheduler = Scheduler::new();

--- a/src/node/delay.rs
+++ b/src/node/delay.rs
@@ -133,8 +133,12 @@ impl AudioNode for DelayNode {
             panic!("IndexSizeError: input port {} is out of bounds", input);
         }
 
-        self.context()
-            .connect(self.reader_registration.id(), dest.id(), output, input);
+        self.context().connect(
+            self.reader_registration.id(),
+            dest.registration().id(),
+            output,
+            input,
+        );
 
         dest
     }
@@ -146,7 +150,7 @@ impl AudioNode for DelayNode {
         }
 
         self.context()
-            .disconnect_from(self.reader_registration.id(), dest.id());
+            .disconnect_from(self.reader_registration.id(), dest.registration().id());
 
         dest
     }
@@ -210,7 +214,7 @@ impl DelayNode {
                 };
                 let (param, proc) = context
                     .base()
-                    .create_audio_param(param_opts, reader_registration.id());
+                    .create_audio_param(param_opts, &reader_registration);
 
                 param.set_value_at_time(options.delay_time as f32, 0.);
 

--- a/src/node/gain.rs
+++ b/src/node/gain.rs
@@ -58,9 +58,7 @@ impl GainNode {
                 default_value: 1.,
                 automation_rate: crate::param::AutomationRate::A,
             };
-            let (param, proc) = context
-                .base()
-                .create_audio_param(param_opts, registration.id());
+            let (param, proc) = context.base().create_audio_param(param_opts, &registration);
 
             param.set_value_at_time(options.gain, 0.);
 

--- a/src/node/oscillator.rs
+++ b/src/node/oscillator.rs
@@ -197,7 +197,7 @@ impl OscillatorNode {
             };
             let (f_param, f_proc) = context
                 .base()
-                .create_audio_param(freq_param_opts, registration.id());
+                .create_audio_param(freq_param_opts, &registration);
             f_param.set_value(frequency);
 
             // detune audio parameter
@@ -209,7 +209,7 @@ impl OscillatorNode {
             };
             let (det_param, det_proc) = context
                 .base()
-                .create_audio_param(det_param_opts, registration.id());
+                .create_audio_param(det_param_opts, &registration);
             det_param.set_value(detune);
 
             let type_ = Arc::new(AtomicU32::new(type_ as u32));

--- a/src/node/panner.rs
+++ b/src/node/panner.rs
@@ -182,13 +182,14 @@ impl AudioNode for PannerNode {
 impl PannerNode {
     pub fn new<C: BaseAudioContext>(context: &C, options: PannerOptions) -> Self {
         let node = context.base().register(move |registration| {
-            let id = registration.id();
-
             use crate::spatial::PARAM_OPTS;
             // position params
-            let (position_x, render_px) = context.base().create_audio_param(PARAM_OPTS, id);
-            let (position_y, render_py) = context.base().create_audio_param(PARAM_OPTS, id);
-            let (position_z, render_pz) = context.base().create_audio_param(PARAM_OPTS, id);
+            let (position_x, render_px) =
+                context.base().create_audio_param(PARAM_OPTS, &registration);
+            let (position_y, render_py) =
+                context.base().create_audio_param(PARAM_OPTS, &registration);
+            let (position_z, render_pz) =
+                context.base().create_audio_param(PARAM_OPTS, &registration);
             position_x.set_value_at_time(options.position_x, 0.);
             position_y.set_value_at_time(options.position_y, 0.);
             position_z.set_value_at_time(options.position_z, 0.);
@@ -198,10 +199,13 @@ impl PannerNode {
                 default_value: 1.0,
                 ..PARAM_OPTS
             };
-            let (orientation_x, render_ox) =
-                context.base().create_audio_param(orientation_x_opts, id);
-            let (orientation_y, render_oy) = context.base().create_audio_param(PARAM_OPTS, id);
-            let (orientation_z, render_oz) = context.base().create_audio_param(PARAM_OPTS, id);
+            let (orientation_x, render_ox) = context
+                .base()
+                .create_audio_param(orientation_x_opts, &registration);
+            let (orientation_y, render_oy) =
+                context.base().create_audio_param(PARAM_OPTS, &registration);
+            let (orientation_z, render_oz) =
+                context.base().create_audio_param(PARAM_OPTS, &registration);
             orientation_x.set_value_at_time(options.orientation_x, 0.);
             orientation_y.set_value_at_time(options.orientation_y, 0.);
             orientation_z.set_value_at_time(options.orientation_z, 0.);
@@ -249,7 +253,9 @@ impl PannerNode {
         });
 
         // after the node is registered, connect the AudioListener
-        context.base().connect_listener_to_panner(node.id());
+        context
+            .base()
+            .connect_listener_to_panner(node.registration().id());
 
         node
     }

--- a/src/node/stereo_panner.rs
+++ b/src/node/stereo_panner.rs
@@ -127,7 +127,7 @@ impl StereoPannerNode {
             };
             let (pan_param, pan_proc) = context
                 .base()
-                .create_audio_param(pan_param_opts, registration.id());
+                .create_audio_param(pan_param_opts, &registration);
 
             pan_param.set_value(pan_value);
 

--- a/src/spatial.rs
+++ b/src/spatial.rs
@@ -122,7 +122,6 @@ impl AudioNode for AudioListenerNode {
 impl AudioListenerNode {
     pub fn new<C: BaseAudioContext>(context: &C) -> Self {
         context.base().register(move |registration| {
-            let reg_id = registration.id();
             let base = context.base();
 
             let forward_z_opts = AudioParamDescriptor {
@@ -134,15 +133,15 @@ impl AudioListenerNode {
                 ..PARAM_OPTS
             };
 
-            let (p1, v1) = base.create_audio_param(PARAM_OPTS, reg_id);
-            let (p2, v2) = base.create_audio_param(PARAM_OPTS, reg_id);
-            let (p3, v3) = base.create_audio_param(PARAM_OPTS, reg_id);
-            let (p4, v4) = base.create_audio_param(PARAM_OPTS, reg_id);
-            let (p5, v5) = base.create_audio_param(PARAM_OPTS, reg_id);
-            let (p6, v6) = base.create_audio_param(forward_z_opts, reg_id);
-            let (p7, v7) = base.create_audio_param(PARAM_OPTS, reg_id);
-            let (p8, v8) = base.create_audio_param(up_y_opts, reg_id);
-            let (p9, v9) = base.create_audio_param(PARAM_OPTS, reg_id);
+            let (p1, v1) = base.create_audio_param(PARAM_OPTS, &registration);
+            let (p2, v2) = base.create_audio_param(PARAM_OPTS, &registration);
+            let (p3, v3) = base.create_audio_param(PARAM_OPTS, &registration);
+            let (p4, v4) = base.create_audio_param(PARAM_OPTS, &registration);
+            let (p5, v5) = base.create_audio_param(PARAM_OPTS, &registration);
+            let (p6, v6) = base.create_audio_param(forward_z_opts, &registration);
+            let (p7, v7) = base.create_audio_param(PARAM_OPTS, &registration);
+            let (p8, v8) = base.create_audio_param(up_y_opts, &registration);
+            let (p9, v9) = base.create_audio_param(PARAM_OPTS, &registration);
 
             let node = Self {
                 registration,


### PR DESCRIPTION
Delegate all access via the AudioContextRegistration.

While working on #76 I realized we don't need to expose the `AudioNodeId` in the public interface.
Now, there's only `AudioParamId` and `AudioContextRegistration` inside the context mod that are not part of the API. These two however cannot be dropped because we need them for manual AudioNode construction (audio worklets)