### PR TITLE
Add `base_latency` and `output_latency`

### DIFF
--- a/examples/latency_attributes.rs
+++ b/examples/latency_attributes.rs
@@ -14,7 +14,11 @@ fn main() {
     println!("- BaseLatency: {:?}", context.base_latency());
 
     loop {
+        println!("-------------------------------------------------");
+        println!("+ currentTime {:?}", context.current_time());
         println!("+ OutputLatency: {:?}", context.output_latency());
+        println!("+ AudioTimestamp {:?}", context.get_output_timestamp());
+
         std::thread::sleep(std::time::Duration::from_secs(1));
     }
 }

--- a/examples/latency_attributes.rs
+++ b/examples/latency_attributes.rs
@@ -12,11 +12,9 @@ fn main() {
     sine.start();
 
     println!("- BaseLatency: {:?}", context.base_latency());
-    println!("+ OutputLatency: {:?}", context.output_latency());
 
-    std::thread::sleep(std::time::Duration::from_secs(1));
-    println!("+ OutputLatency: {:?}", context.output_latency());
-
-    std::thread::sleep(std::time::Duration::from_secs(1));
-    println!("+ OutputLatency: {:?}", context.output_latency());
+    loop {
+        println!("+ OutputLatency: {:?}", context.output_latency());
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    }
 }

--- a/examples/latency_attributes.rs
+++ b/examples/latency_attributes.rs
@@ -17,7 +17,6 @@ fn main() {
         println!("-------------------------------------------------");
         println!("+ currentTime {:?}", context.current_time());
         println!("+ OutputLatency: {:?}", context.output_latency());
-        println!("+ AudioTimestamp {:?}", context.get_output_timestamp());
 
         std::thread::sleep(std::time::Duration::from_secs(1));
     }

--- a/examples/latency_attributes.rs
+++ b/examples/latency_attributes.rs
@@ -1,0 +1,22 @@
+use web_audio_api::context::{AudioContext, BaseAudioContext};
+use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
+
+fn main() {
+    println!("AudioContextLatencyCategory::Interactive");
+    let context = AudioContext::new(Default::default());
+
+    let sine = context.create_oscillator();
+    sine.frequency().set_value(200.);
+    sine.connect(&context.destination());
+
+    sine.start();
+
+    println!("- BaseLatency: {:?}", context.base_latency());
+    println!("+ OutputLatency: {:?}", context.output_latency());
+
+    std::thread::sleep(std::time::Duration::from_secs(1));
+    println!("+ OutputLatency: {:?}", context.output_latency());
+
+    std::thread::sleep(std::time::Duration::from_secs(1));
+    println!("+ OutputLatency: {:?}", context.output_latency());
+}

--- a/src/context/base.rs
+++ b/src/context/base.rs
@@ -254,25 +254,6 @@ pub trait BaseAudioContext {
         self.base().current_time()
     }
 
-    /// This represents the number of seconds of processing latency incurred by
-    /// the `AudioContext` passing the audio from the `AudioDestinationNode`
-    /// to the audio subsystem.
-    // We don't do any buffering between rendering the audio and sending
-    // it to the audio subsystem, so this value is zero. (see Gecko)
-    #[must_use]
-    fn base_latency(&self) -> f64 {
-        self.base().base_latency()
-    }
-
-    /// The estimation in seconds of audio output latency, i.e., the interval
-    /// between the time the UA requests the host system to play a buffer and
-    /// the time at which the first sample in the buffer is actually processed
-    /// by the audio output device.
-    #[must_use]
-    fn output_latency(&self) -> f64 {
-        self.base().output_latency()
-    }
-
     /// Create an `AudioParam`.
     ///
     /// Call this inside the `register` closure when setting up your `AudioNode`

--- a/src/context/concrete_base.rs
+++ b/src/context/concrete_base.rs
@@ -225,17 +225,6 @@ impl ConcreteBaseAudioContext {
         self.inner.sample_rate
     }
 
-    /// This represents the number of seconds of processing latency incurred by
-    /// the `AudioContext` passing the audio from the `AudioDestinationNode`
-    /// to the audio subsystem.
-    // We don't do any buffering between rendering the audio and sending
-    // it to the audio subsystem, so this value is zero. (see Gecko)
-    #[allow(clippy::unused_self)]
-    #[must_use]
-    pub(super) const fn base_latency(&self) -> f64 {
-        0.
-    }
-
     /// The estimation in seconds of audio output latency, i.e., the interval
     /// between the time the UA requests the host system to play a buffer and
     /// the time at which the first sample in the buffer is actually processed

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -1,12 +1,4 @@
 //! The `BaseAudioContext` interface and the `AudioContext` and `OfflineAudioContext` types
-#![warn(
-    clippy::all,
-    clippy::pedantic,
-    clippy::nursery,
-    clippy::perf,
-    clippy::missing_docs_in_private_items
-)]
-
 use std::ops::Range;
 
 mod base;

--- a/src/context/offline.rs
+++ b/src/context/offline.rs
@@ -43,7 +43,7 @@ impl OfflineAudioContext {
         let frames_played = Arc::new(AtomicU64::new(0));
         let frames_played_clone = frames_played.clone();
 
-        // this is irrelevant for offline context, so we put 0.
+        // this is irrelevant for offline context, so we just put 0.
         let output_latency = Arc::new(AtomicF64::new(0.));
         let output_latency_clone = output_latency.clone();
 
@@ -53,7 +53,7 @@ impl OfflineAudioContext {
             number_of_channels,
             receiver,
             frames_played_clone,
-            output_latency_clone,
+            output_latency_clones,
         );
 
         // first, setup the base audio context

--- a/src/context/offline.rs
+++ b/src/context/offline.rs
@@ -43,9 +43,9 @@ impl OfflineAudioContext {
         let frames_played = Arc::new(AtomicU64::new(0));
         let frames_played_clone = frames_played.clone();
 
-        // this is irrelevant for offline context, so we just put 0.
+        // output_latency is irrelevant for offline context, but it needs to
+        // be passed to the `RenderThread` constructor
         let output_latency = Arc::new(AtomicF64::new(0.));
-        let output_latency_clone = output_latency.clone();
 
         // setup the render 'thread', which will run inside the control thread
         let renderer = RenderThread::new(
@@ -53,7 +53,7 @@ impl OfflineAudioContext {
             number_of_channels,
             receiver,
             frames_played_clone,
-            output_latency_clone,
+            output_latency,
         );
 
         // first, setup the base audio context
@@ -61,7 +61,6 @@ impl OfflineAudioContext {
             sample_rate,
             number_of_channels,
             frames_played,
-            output_latency,
             sender,
             true,
         );

--- a/src/context/offline.rs
+++ b/src/context/offline.rs
@@ -53,7 +53,7 @@ impl OfflineAudioContext {
             number_of_channels,
             receiver,
             frames_played_clone,
-            output_latency_clones,
+            output_latency_clone,
         );
 
         // first, setup the base audio context

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -57,12 +57,12 @@ pub struct AudioContextOptions {
 
 /// Struct returned by `get_output_timestamp` that associate estimated playback
 /// context time (i.e. `current_time - output_latency`) to a monotonic global clock
-/// (i.e. https://doc.rust-lang.org/std/time/struct.Instant.html)
+/// (i.e. <https://doc.rust-lang.org/std/time/struct.Instant.html>)
 #[derive(Clone, Debug, Default)]
 pub struct AudioTimestamp {
-    // Represents a point in the time coordinate system of BaseAudioContext’s currentTime.
+    /// Represents a point in the time coordinate system of BaseAudioContext’s currentTime.
     pub context_time: f64,
-    // Represents a point in the time coordinate system of a Performance interface implementation
+    /// Represents a point in the time coordinate system of a Performance interface implementation
     pub performance_time: f64,
 }
 
@@ -168,7 +168,6 @@ impl AudioContext {
         Self { base }
     }
 
-
     /// This represents the number of seconds of processing latency incurred by
     /// the `AudioContext` passing the audio from the `AudioDestinationNode`
     /// to the audio subsystem.
@@ -188,14 +187,14 @@ impl AudioContext {
         self.base().output_latency()
     }
 
-    /// Returns a new AudioTimestamp instance containing two related audio stream
-    /// position values for the context: the contextTime member contains the time of
+    /// Returns a new `AudioTimestamp` instance containing two related audio stream
+    /// position values for the context: the `context_time` member contains the time of
     /// the sample frame which is currently being rendered by the audio output device
     /// (i.e. output audio stream position), in the same units and origin as context’s
-    /// currentTime; the performanceTime member contains the time estimating the
-    /// moment when the sample frame corresponding to the stored contextTime value was
-    /// rendered by the audio output device, in the same units and origin as
-    /// performance.now()
+    /// `current_time`; the `performance_time` member contains the time estimating the
+    /// moment when the sample frame corresponding to the stored `context_time` value was
+    /// rendered by the audio output device, in milliseconds using `TIME_ORIGIN` as
+    /// the origin.
     #[must_use]
     pub fn get_output_timestamp(&self) -> AudioTimestamp {
         // @todo - [spec] If the context’s rendering graph has not yet processed a block
@@ -212,7 +211,10 @@ impl AudioContext {
         // performance time is in ms
         let performance_time = (performance_time_sec * 1000.).max(0.);
 
-        AudioTimestamp { context_time, performance_time }
+        AudioTimestamp {
+            context_time,
+            performance_time,
+        }
     }
 
     /// Suspends the progression of time in the audio context.

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -165,7 +165,10 @@ impl AudioContext {
         );
         base.set_state(AudioContextState::Running);
 
-        Self { base, output_latency }
+        Self {
+            base,
+            output_latency,
+        }
     }
 
     /// This represents the number of seconds of processing latency incurred by

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -55,17 +55,6 @@ pub struct AudioContextOptions {
     pub sample_rate: Option<u32>,
 }
 
-/// Struct returned by `get_output_timestamp` that associate estimated playback
-/// context time (i.e. `current_time - output_latency`) to a monotonic global clock
-/// (i.e. <https://doc.rust-lang.org/std/time/struct.Instant.html>)
-#[derive(Clone, Debug, Default)]
-pub struct AudioTimestamp {
-    /// Represents a point in the time coordinate system of BaseAudioContext’s currentTime.
-    pub context_time: f64,
-    /// Represents a point in the time coordinate system of a Performance interface implementation
-    pub performance_time: f64,
-}
-
 /// This interface represents an audio graph whose `AudioDestinationNode` is routed to a real-time
 /// output device that produces a signal directed at the user.
 // the naming comes from the web audio specfication

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -157,6 +157,26 @@ impl AudioContext {
         Self { base }
     }
 
+
+    /// This represents the number of seconds of processing latency incurred by
+    /// the `AudioContext` passing the audio from the `AudioDestinationNode`
+    /// to the audio subsystem.
+    // We don't do any buffering between rendering the audio and sending
+    // it to the audio subsystem, so this value is zero. (see Gecko)
+    #[must_use]
+    fn base_latency(&self) -> f64 {
+        self.base().base_latency()
+    }
+
+    /// The estimation in seconds of audio output latency, i.e., the interval
+    /// between the time the UA requests the host system to play a buffer and
+    /// the time at which the first sample in the buffer is actually processed
+    /// by the audio output device.
+    #[must_use]
+    fn output_latency(&self) -> f64 {
+        self.base().output_latency()
+    }
+
     /// Suspends the progression of time in the audio context.
     ///
     /// This will temporarily halt audio hardware access and reducing CPU/battery usage in the
@@ -179,7 +199,7 @@ impl AudioContext {
             if let Err(e) = s.pause() {
                 panic!("Error suspending cpal stream: {:?}", e);
             }
-            self.base.set_state(AudioContextState::Suspended);
+            self.base().set_state(AudioContextState::Suspended);
         }
     }
 
@@ -203,7 +223,7 @@ impl AudioContext {
             if let Err(e) = s.play() {
                 panic!("Error resuming cpal stream: {:?}", e);
             }
-            self.base.set_state(AudioContextState::Running);
+            self.base().set_state(AudioContextState::Running);
         }
     }
 
@@ -223,7 +243,7 @@ impl AudioContext {
     pub fn close_sync(&self) {
         #[cfg(not(test))] // in tests, do not set up a cpal Stream
         self.stream.lock().unwrap().take(); // will Drop
-        self.base.set_state(AudioContextState::Closed);
+        self.base().set_state(AudioContextState::Closed);
     }
 
     /// Creates a `MediaStreamAudioSourceNode` from a [`MediaStream`]

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,13 +1,4 @@
 //! Audio IO management API
-#![warn(
-    clippy::all,
-    clippy::pedantic,
-    clippy::nursery,
-    clippy::perf,
-    clippy::missing_docs_in_private_items
-)]
-#![allow(clippy::missing_const_for_fn)]
-
 use std::convert::TryFrom;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
@@ -237,7 +228,7 @@ struct OutputStreamer {
     configs: StreamConfigs,
     /// `frames_played` act as a time reference when processing
     frames_played: Arc<AtomicU64>,
-    /// latency between render and actually audio output
+    /// delay between render and actual system audio output
     output_latency: Arc<AtomicF64>,
     /// communication channel between control and render thread (sender part)
     sender: Option<Sender<ControlMessage>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,9 @@
 #![deny(trivial_numeric_casts)]
 
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::time::Instant;
+
+use once_cell::sync::Lazy;
 
 /// Render quantum size, the audio graph is rendered in blocks of RENDER_QUANTUM_SIZE samples
 /// see. <https://webaudio.github.io/web-audio-api/#render-quantum>
@@ -45,6 +48,12 @@ pub const RENDER_QUANTUM_SIZE: usize = 128;
 
 /// Maximum number of channels for audio processing
 pub const MAX_CHANNELS: usize = 32;
+
+/// Global `Instant` to create `AudioTimestamp` returned by `AudioContext::getOutputTimestamp`
+/// on a timeline shared by all contexts. This can be usefull to tightly synchronise
+/// audio rendering with other processes (e.g. graphics)
+// @note: naming inspired by https://www.w3.org/TR/hr-time-3/#dfn-time-origin
+pub(crate) static TIME_ORIGIN: Lazy<Instant> = Lazy::new(Instant::now);
 
 pub mod buffer;
 pub mod context;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,9 +38,6 @@
 #![deny(trivial_numeric_casts)]
 
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
-use std::time::Instant;
-
-use once_cell::sync::Lazy;
 
 /// Render quantum size, the audio graph is rendered in blocks of RENDER_QUANTUM_SIZE samples
 /// see. <https://webaudio.github.io/web-audio-api/#render-quantum>
@@ -48,12 +45,6 @@ pub const RENDER_QUANTUM_SIZE: usize = 128;
 
 /// Maximum number of channels for audio processing
 pub const MAX_CHANNELS: usize = 32;
-
-/// Global `Instant` to create `AudioTimestamp` returned by `AudioContext::getOutputTimestamp`
-/// on a timeline shared by all contexts. This can be usefull to tightly synchronise
-/// audio rendering with other processes (e.g. graphics)
-// @note: naming inspired by https://www.w3.org/TR/hr-time-3/#dfn-time-origin
-pub(crate) static TIME_ORIGIN: Lazy<Instant> = Lazy::new(Instant::now);
 
 pub mod buffer;
 pub mod context;


### PR DESCRIPTION
Fixes #138

In the same vein, there is `getOutputTimestamp` (https://webaudio.github.io/web-audio-api/#dom-audiocontext-getoutputtimestamp), maybe I can have a shot in this PR as you prefer