### PR TITLE
Proof of concept: do not sort the audio graph when nodes are dropped

### DIFF
--- a/src/render/graph.rs
+++ b/src/render/graph.rs
@@ -341,9 +341,16 @@ impl Graph {
             }
         });
 
-        // If there were any nodes decomissioned, clear current graph order
+        // If there were any nodes decomissioned, remove from graph order
         if nodes_dropped {
-            self.ordered.clear();
+            let mut i = 0;
+            while i < self.ordered.len() {
+                if !nodes.contains_key(&self.ordered[i]) {
+                    self.ordered.remove(i);
+                } else {
+                    i += 1;
+                }
+            }
         }
 
         // Return the output buffer of destination node


### PR DESCRIPTION
Relates to #129

This improves benchmark performance x10:
- 13 | Granular synthesis | 3299 | 2.3x | 7.5
Old speedup was 0.6

Work in progress because we can update the ordering while we are
iterating it, instead of doing it after the main loop.