### PR TITLE
Fix : accumulate and mix inputs according to the node channel config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ textplots = "0.8"
 
 # Uncomment the following lines to enable debug symbols
 # during CPU profiling
-[profile.release]
-debug = true
+# [profile.release]
+# debug = true
 
 [features]
 default = ["mp3", "ogg", "flac", "wav"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ textplots = "0.8"
 
 # Uncomment the following lines to enable debug symbols
 # during CPU profiling
-# [profile.release]
-# debug = true
+[profile.release]
+debug = true
 
 [features]
 default = ["mp3", "ogg", "flac", "wav"]

--- a/src/context/offline.rs
+++ b/src/context/offline.rs
@@ -96,3 +96,18 @@ impl OfflineAudioContext {
         self.length
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::SampleRate;
+
+    #[test]
+    fn render_empty_graph() {
+        let mut context = OfflineAudioContext::new(2, 555, SampleRate(44_100));
+        let buffer = context.start_rendering_sync();
+
+        assert_eq!(buffer.number_of_channels(), 2);
+        assert_eq!(buffer.length(), 555);
+    }
+}

--- a/src/node/gain.rs
+++ b/src/node/gain.rs
@@ -94,16 +94,18 @@ impl AudioProcessor for GainRenderer {
         let input = &inputs[0];
         let output = &mut outputs[0];
 
-        let gain_values = params.get(&self.gain);
-
         *output = input.clone();
 
-        output.modify_channels(|channel| {
-            channel
-                .iter_mut()
-                .zip(gain_values.iter())
-                .for_each(|(value, g)| *value *= g)
-        });
+        if !input.is_silent() {
+            let gain_values = params.get(&self.gain);
+
+            output.modify_channels(|channel| {
+                channel
+                    .iter_mut()
+                    .zip(gain_values.iter())
+                    .for_each(|(value, g)| *value *= g)
+            });
+        }
 
         false
     }

--- a/src/param.rs
+++ b/src/param.rs
@@ -568,20 +568,24 @@ impl AudioProcessor for AudioParamProcessor {
         let period = 1. / scope.sample_rate.0 as f64;
         let param_intrisic_values = self.tick(scope.current_time, period, RENDER_QUANTUM_SIZE);
 
-        let input = &inputs[0]; // single input mode
         let param_computed_values = &mut outputs[0];
 
         param_computed_values
             .channel_data_mut(0)
             .copy_from_slice(param_intrisic_values);
 
-        param_computed_values.add(input, ChannelInterpretation::Discrete);
+        let input = &inputs[0]; // single input mode
+        if !input.is_silent() {
+            param_computed_values.add(input, ChannelInterpretation::Discrete);
+        }
 
         true // has intrinsic value
     }
 }
 
 impl AudioParamProcessor {
+    // [spec] intrinsic parameter value [is the] the value the AudioParam would
+    // normally have without any audio connections
     pub fn intrisic_value(&self) -> f32 {
         if self.intrisic_value.is_nan() {
             self.default_value

--- a/src/param.rs
+++ b/src/param.rs
@@ -574,7 +574,11 @@ impl AudioProcessor for AudioParamProcessor {
             .channel_data_mut(0)
             .copy_from_slice(param_intrisic_values);
 
+        // add input signal to param computed values
+        // @note - maybe we should clamp after that too? not very clear in spec
+        // but it would appear logical
         let input = &inputs[0]; // single input mode
+
         if !input.is_silent() {
             param_computed_values.add(input, ChannelInterpretation::Discrete);
         }

--- a/src/param.rs
+++ b/src/param.rs
@@ -574,12 +574,12 @@ impl AudioProcessor for AudioParamProcessor {
             .channel_data_mut(0)
             .copy_from_slice(param_intrisic_values);
 
-        // add input signal to param computed values
-        // @note - maybe we should clamp after that too? not very clear in spec
-        // but it would appear logical
-        let input = &inputs[0]; // single input mode
+        // add input signal to param computed values if not silent
+        let input = &inputs[0];
 
         if !input.is_silent() {
+            // @note/todo - maybe we should clamp after that too? this is not
+            // very clear in the spec but it would appear quite logical
             param_computed_values.add(input, 1, ChannelInterpretation::Discrete);
         }
 
@@ -588,7 +588,7 @@ impl AudioProcessor for AudioParamProcessor {
 }
 
 impl AudioParamProcessor {
-    // [spec] intrinsic parameter value [is the] the value the AudioParam would
+    // [spec] intrinsic parameter value [is] the value the AudioParam would
     // normally have without any audio connections
     pub fn intrisic_value(&self) -> f32 {
         if self.intrisic_value.is_nan() {

--- a/src/param.rs
+++ b/src/param.rs
@@ -580,7 +580,7 @@ impl AudioProcessor for AudioParamProcessor {
         let input = &inputs[0]; // single input mode
 
         if !input.is_silent() {
-            param_computed_values.add(input, ChannelInterpretation::Discrete);
+            param_computed_values.add(input, 1, ChannelInterpretation::Discrete);
         }
 
         true // has intrinsic value

--- a/src/render/graph.rs
+++ b/src/render/graph.rs
@@ -587,10 +587,10 @@ mod tests {
 
     #[test]
     fn test_connection_mixing() {
-        // run mutliple time as the issue should appear depending of graph ordering
-        // - if discrete is run before speaker we should have two channels of [2.; 128]
+        // run mutliple time as the issue was appearing depending of graph ordering
+        // - if discrete was run before speaker we had two channels of [3.; 128]
         //   which is expected
-        // - if discrete is run after speaker we should have [2.; 128] and [1.; 128]
+        // - if discrete was run after speaker we had [3.; 128] and [2.; 128]
         //   which is wrong
         for _ in 0..10 {
             let mut graph = Graph::new();
@@ -610,7 +610,8 @@ mod tests {
             );
 
             // this one should be present in both `output_node` channels, because it
-            // should be mixed in input according to `output_node` channel config, i.e. Speaker
+            // should be mixed in `output_nodeinput` according to `output_node`
+            // channel config, i.e. Speaker
             let discrete_node = Box::new(DiscreteNode {});
             graph.add_node(
                 NodeIndex(2),
@@ -649,11 +650,6 @@ mod tests {
                 current_time: 0.,
                 sample_rate: crate::SampleRate(1),
             });
-
-            // println!("----------------------------------------------------");
-            // println!("num channels: {:?}", &output.number_of_channels());
-            // println!("{:?}", &output.channel_data(0)[..]);
-            // println!("{:?}", &output.channel_data(1)[..]);
 
             assert_float_eq!(&output.channel_data(0)[..], &[3.; 128][..], abs_all <= 0.);
             assert_float_eq!(&output.channel_data(1)[..], &[3.; 128][..], abs_all <= 0.);

--- a/src/render/graph.rs
+++ b/src/render/graph.rs
@@ -587,7 +587,7 @@ mod tests {
 
     #[test]
     fn test_connection_mixing() {
-        // run mutliple time as the issue was appearing depending of graph ordering
+        // run mutliple time as the issue was appearing depending of graph ordering:
         // - if discrete was run before speaker we had two channels of [3.; 128]
         //   which is expected
         // - if discrete was run after speaker we had [3.; 128] and [2.; 128]
@@ -610,7 +610,7 @@ mod tests {
             );
 
             // this one should be present in both `output_node` channels, because it
-            // should be mixed in `output_nodeinput` according to `output_node`
+            // should be mixed in `output_node.inputs` according to `output_node`
             // channel config, i.e. Speaker
             let discrete_node = Box::new(DiscreteNode {});
             graph.add_node(
@@ -644,7 +644,6 @@ mod tests {
             graph.add_edge((NodeIndex(1), 0), (NodeIndex(0), 0));
             graph.add_edge((NodeIndex(2), 0), (NodeIndex(0), 0));
 
-            // connect both nodes to output
             let output = graph.render(&RenderScope {
                 current_frame: 0,
                 current_time: 0.,

--- a/src/render/render_quantum.rs
+++ b/src/render/render_quantum.rs
@@ -453,6 +453,7 @@ impl AudioRenderQuantum {
         self.channels.truncate(1);
     }
 
+    /// Check if this `RenderQuantum` contains a single channel of silence
     #[must_use]
     pub fn is_silent(&self) -> bool {
         self.number_of_channels() == 1 && self.channels[0].is_silent()
@@ -473,6 +474,9 @@ impl AudioRenderQuantum {
     ///
     /// If the channel counts differ, the buffer with lower count will be upmixed.
     pub fn add(&mut self, other: &Self, interpretation: ChannelInterpretation) {
+        if other.is_silent() {
+            return;
+        }
         // mix buffers to the max channel count
         let channels_self = self.number_of_channels();
         let channels_other = other.number_of_channels();

--- a/src/render/render_quantum.rs
+++ b/src/render/render_quantum.rs
@@ -470,7 +470,7 @@ impl AudioRenderQuantum {
         self.channels.iter_mut().for_each(fun)
     }
 
-    /// Sum two `AudioRenderQuantum`s, both quantum will be up/down mix according
+    /// Sum two `AudioRenderQuantum`s, both quantums will be up/down mix according
     /// to given number of channels and channel interpretation.
     /// see <https://webaudio.github.io/web-audio-api/#channel-up-mixing-and-down-mixing>
     pub fn add(&mut self, other: &Self, channels: usize, interpretation: ChannelInterpretation) {

--- a/src/render/render_quantum.rs
+++ b/src/render/render_quantum.rs
@@ -453,6 +453,11 @@ impl AudioRenderQuantum {
         self.channels.truncate(1);
     }
 
+    #[must_use]
+    pub fn is_silent(&self) -> bool {
+        self.number_of_channels() == 1 && self.channels[0].is_silent()
+    }
+
     /// Convert to a single channel buffer, dropping excess channels
     pub fn force_mono(&mut self) {
         self.channels.truncate(1);

--- a/src/render/render_quantum.rs
+++ b/src/render/render_quantum.rs
@@ -470,18 +470,10 @@ impl AudioRenderQuantum {
         self.channels.iter_mut().for_each(fun)
     }
 
-    /// Sum two `AudioRenderQuantum`s
-    ///
-    /// If the channel counts differ, the buffer with lower count will be upmixed.
-    pub fn add(&mut self, other: &Self, interpretation: ChannelInterpretation) {
-        if other.is_silent() {
-            return;
-        }
-        // mix buffers to the max channel count
-        let channels_self = self.number_of_channels();
-        let channels_other = other.number_of_channels();
-        let channels = channels_self.max(channels_other);
-
+    /// Sum two `AudioRenderQuantum`s, both quantum will be up/down mix according
+    /// to given number of channels and channel interpretation.
+    /// see <https://webaudio.github.io/web-audio-api/#channel-up-mixing-and-down-mixing>
+    pub fn add(&mut self, other: &Self, channels: usize, interpretation: ChannelInterpretation) {
         self.mix(channels, interpretation);
 
         let mut other_mixed = other.clone();
@@ -1352,7 +1344,7 @@ mod tests {
         signal2.copy_from_slice(&[2.; RENDER_QUANTUM_SIZE]);
         let buffer2 = AudioRenderQuantum::new(signal2);
 
-        buffer.add(&buffer2, ChannelInterpretation::Discrete);
+        buffer.add(&buffer2, 2, ChannelInterpretation::Discrete);
 
         assert_eq!(buffer.number_of_channels(), 2);
         assert_float_eq!(


### PR DESCRIPTION
A first draft in the direction of #147, let me know what you think. 

For the record here are my flamegraphs for the granular bench example:

before
![164681860-ec4dcab3-d746-4825-a75b-a15e40a8ee5d (1)](https://user-images.githubusercontent.com/1013757/165070578-fbb7f0c5-bf6c-4f10-9152-6d4a48f5a0e3.svg)

after
![_flame_offline_granular](https://user-images.githubusercontent.com/1013757/165070640-e1ac8753-7620-497d-b5b0-daf9b41c4cfc.svg)

The code I use for the flamegraphs (I did not manage to make something simply work with a `benches` directory)

```rs
use std::fs::File;
use std::time::Instant;

use rand::Rng;
 
use web_audio_api::context::{BaseAudioContext, OfflineAudioContext};
use web_audio_api::node::AudioNode;
use web_audio_api::SampleRate;

fn main() {
    let duration = 120. / 16.;
    let sample_rate = SampleRate(48000);

    let length = (duration * sample_rate.0 as f64) as usize;
    let mut context = OfflineAudioContext::new(1, length, sample_rate);
    // let mut context = OfflineAudioContext::new(1, 256, sample_rate);

    let file = File::open("samples/think-mono-48000.wav").unwrap();
    let buffer = context.decode_audio_data_sync(file).unwrap();

    let mut offset = 0.;
    let mut rng = rand::thread_rng();

    // this 1500 sources...
    while offset < duration {
        let env = context.create_gain();
        env.connect(&context.destination());

        let src = context.create_buffer_source();
        src.connect(&env);
        src.set_buffer(buffer.clone());

        let rand_start = rng.gen_range(0..1000) as f64 / 1000. * 0.5;
        let rand_duration = rng.gen_range(0..1000) as f64 / 1000. * 0.999;
        let start = offset * rand_start;
        let end = start + 0.005 * rand_duration;
        let start_release = (offset + end - start).max(0.);

        env.gain().set_value_at_time(0., offset);
        env.gain().linear_ramp_to_value_at_time(0.5, offset + 0.005);
        env.gain().set_value_at_time(0.5, start_release);
        env.gain()
            .linear_ramp_to_value_at_time(0., start_release + 0.05);

        src.start_at_with_offset_and_duration(offset, start, end);

        offset += 0.005;
    }

    let start = Instant::now();
    let buffer = context.start_rendering_sync();
    let duration = start.elapsed();

    println!("> processing duration (ms): {:?}", duration.as_millis());
    println!("> buffer.duration (s): {:?}", buffer.duration());
    println!(
        "> speedup vs. realtime (ms): {:?}",
        (buffer.duration() * 1000.) / duration.as_millis() as f64
    );
}
```

No visible improvement in the bench numbers, but I guess the `visit` takes so much place this is difficult to see any improvement there.

