### PR TITLE
Drop SampleRate type, switch to plain f32

### DIFF
--- a/examples/audio_buffer.rs
+++ b/examples/audio_buffer.rs
@@ -10,7 +10,7 @@ fn main() {
     println!("> Play sine at 200Hz created manually in an AudioBuffer");
 
     let length = context.sample_rate() as usize;
-    let sample_rate = context.sample_rate_raw();
+    let sample_rate = context.sample_rate();
     let mut buffer = context.create_buffer(1, length, sample_rate);
     let mut sine = vec![];
 

--- a/examples/benchmarks.rs
+++ b/examples/benchmarks.rs
@@ -14,7 +14,6 @@ use web_audio_api::context::{AudioContext, BaseAudioContext, OfflineAudioContext
 use web_audio_api::node::{
     AudioBufferSourceNode, AudioNode, AudioScheduledSourceNode, OscillatorType,
 };
-use web_audio_api::SampleRate;
 
 // benchmark adapted from https://github.com/padenot/webaudio-benchmark
 // missing the "Convolution Reverb" as we don't have the node implemented yet
@@ -28,8 +27,8 @@ struct BenchResult<'a> {
     buffer: AudioBuffer,
 }
 
-fn load_buffer(sources: &mut Vec<AudioBuffer>, pathname: &str, sample_rate: u32) {
-    let context = OfflineAudioContext::new(1, 1, SampleRate(sample_rate));
+fn load_buffer(sources: &mut Vec<AudioBuffer>, pathname: &str, sample_rate: f32) {
+    let context = OfflineAudioContext::new(1, 1, sample_rate);
 
     let file = File::open(pathname).unwrap();
     let audio_buffer = context.decode_audio_data_sync(file).unwrap();
@@ -37,9 +36,9 @@ fn load_buffer(sources: &mut Vec<AudioBuffer>, pathname: &str, sample_rate: u32)
     sources.push(audio_buffer);
 }
 
-fn get_buffer(sources: &[AudioBuffer], sample_rate: u32, number_of_channels: usize) -> AudioBuffer {
+fn get_buffer(sources: &[AudioBuffer], sample_rate: f32, number_of_channels: usize) -> AudioBuffer {
     let buffer = sources.iter().find(|&buffer| {
-        buffer.sample_rate_raw().0 == sample_rate
+        buffer.sample_rate() == sample_rate
             && buffer.number_of_channels() == number_of_channels
     });
 
@@ -80,14 +79,14 @@ fn main() {
     let mut results = Vec::<BenchResult>::new();
 
     const DURATION: usize = 120;
-    let sample_rate = SampleRate(48000);
+    let sample_rate = 48000.;
 
-    load_buffer(&mut sources, "samples/think-mono-38000.wav", 38000);
-    load_buffer(&mut sources, "samples/think-mono-44100.wav", 44100);
-    load_buffer(&mut sources, "samples/think-mono-48000.wav", 48000);
-    load_buffer(&mut sources, "samples/think-stereo-38000.wav", 38000);
-    load_buffer(&mut sources, "samples/think-stereo-44100.wav", 44100);
-    load_buffer(&mut sources, "samples/think-stereo-48000.wav", 48000);
+    load_buffer(&mut sources, "samples/think-mono-38000.wav", 38000.);
+    load_buffer(&mut sources, "samples/think-mono-44100.wav", 44100.);
+    load_buffer(&mut sources, "samples/think-mono-48000.wav", 48000.);
+    load_buffer(&mut sources, "samples/think-stereo-38000.wav", 38000.);
+    load_buffer(&mut sources, "samples/think-stereo-44100.wav", 44100.);
+    load_buffer(&mut sources, "samples/think-stereo-48000.wav", 48000.);
 
     let mut stdout = stdout().into_raw_mode().unwrap();
 
@@ -100,7 +99,7 @@ fn main() {
         let name = "Baseline (silence)";
 
         let mut context =
-            OfflineAudioContext::new(2, DURATION * sample_rate.0 as usize, sample_rate);
+            OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
 
         benchmark(&mut stdout, name, &mut context, &mut results);
     }
@@ -109,9 +108,9 @@ fn main() {
         let name = "Simple source test without resampling (Mono)";
 
         let mut context =
-            OfflineAudioContext::new(1, DURATION * sample_rate.0 as usize, sample_rate);
+            OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
         let source = context.create_buffer_source();
-        let buf = get_buffer(&sources, sample_rate.0, 1);
+        let buf = get_buffer(&sources, sample_rate, 1);
         source.set_buffer(buf);
         source.set_loop(true);
         source.connect(&context.destination());
@@ -124,9 +123,9 @@ fn main() {
         let name = "Simple source test without resampling (Stereo)";
 
         let mut context =
-            OfflineAudioContext::new(2, DURATION * sample_rate.0 as usize, sample_rate);
+            OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
         let source = context.create_buffer_source();
-        let buf = get_buffer(&sources, sample_rate.0, 2);
+        let buf = get_buffer(&sources, sample_rate, 2);
         source.set_buffer(buf);
         source.set_loop(true);
         source.connect(&context.destination());
@@ -139,7 +138,7 @@ fn main() {
         let name = "Simple source test without resampling (Stereo and positionnal)";
 
         let mut context =
-            OfflineAudioContext::new(2, DURATION * sample_rate.0 as usize, sample_rate);
+            OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
 
         let panner = context.create_panner();
         panner.connect(&context.destination());
@@ -153,7 +152,7 @@ fn main() {
         let source = context.create_buffer_source();
         source.connect(&panner);
 
-        let buf = get_buffer(&sources, sample_rate.0, 2);
+        let buf = get_buffer(&sources, sample_rate, 2);
         source.set_buffer(buf);
         source.set_loop(true);
         source.start();
@@ -165,9 +164,9 @@ fn main() {
         let name = "Simple source test with resampling (Mono)";
 
         let mut context =
-            OfflineAudioContext::new(1, DURATION * sample_rate.0 as usize, sample_rate);
+            OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
         let source = context.create_buffer_source();
-        let buf = get_buffer(&sources, 38000, 1);
+        let buf = get_buffer(&sources, 38000., 1);
         source.set_buffer(buf);
         source.set_loop(true);
         source.connect(&context.destination());
@@ -180,9 +179,9 @@ fn main() {
         let name = "Simple source test with resampling (Stereo)";
 
         let mut context =
-            OfflineAudioContext::new(2, DURATION * sample_rate.0 as usize, sample_rate);
+            OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
         let source = context.create_buffer_source();
-        let buf = get_buffer(&sources, 38000, 2);
+        let buf = get_buffer(&sources, 38000., 2);
         source.set_buffer(buf);
         source.set_loop(true);
         source.connect(&context.destination());
@@ -195,7 +194,7 @@ fn main() {
         let name = "Simple source test with resampling (Stereo and positionnal)";
 
         let mut context =
-            OfflineAudioContext::new(2, DURATION * sample_rate.0 as usize, sample_rate);
+            OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
 
         let panner = context.create_panner();
         panner.connect(&context.destination());
@@ -209,7 +208,7 @@ fn main() {
         let source = context.create_buffer_source();
         source.connect(&panner);
 
-        let buf = get_buffer(&sources, 38000, 2);
+        let buf = get_buffer(&sources, 38000., 2);
         source.set_buffer(buf);
         source.set_loop(true);
         source.start();
@@ -221,9 +220,9 @@ fn main() {
         let name = "Upmix without resampling (Mono -> Stereo)";
 
         let mut context =
-            OfflineAudioContext::new(2, DURATION * sample_rate.0 as usize, sample_rate);
+            OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
         let source = context.create_buffer_source();
-        let buf = get_buffer(&sources, sample_rate.0, 1);
+        let buf = get_buffer(&sources, sample_rate, 1);
         source.set_buffer(buf);
         source.set_loop(true);
         source.connect(&context.destination());
@@ -236,9 +235,9 @@ fn main() {
         let name = "Downmix without resampling (Stereo -> Mono)";
 
         let mut context =
-            OfflineAudioContext::new(1, DURATION * sample_rate.0 as usize, sample_rate);
+            OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
         let source = context.create_buffer_source();
-        let buf = get_buffer(&sources, sample_rate.0, 2);
+        let buf = get_buffer(&sources, sample_rate, 2);
         source.set_buffer(buf);
         source.set_loop(true);
         source.connect(&context.destination());
@@ -252,11 +251,11 @@ fn main() {
 
         let adjusted_duration = DURATION / 4;
         let mut context =
-            OfflineAudioContext::new(1, adjusted_duration * sample_rate.0 as usize, sample_rate);
+            OfflineAudioContext::new(1, adjusted_duration * sample_rate as usize, sample_rate);
 
         for _ in 0..100 {
             let source = context.create_buffer_source();
-            let buf = get_buffer(&sources, 38000, 1);
+            let buf = get_buffer(&sources, 38000., 1);
             source.set_buffer(buf);
             source.set_loop(true);
             source.connect(&context.destination());
@@ -271,12 +270,12 @@ fn main() {
 
         let adjusted_duration = DURATION / 4;
         let mut context =
-            OfflineAudioContext::new(1, adjusted_duration * sample_rate.0 as usize, sample_rate);
-        let reference = get_buffer(&sources, 38000, 1);
+            OfflineAudioContext::new(1, adjusted_duration * sample_rate as usize, sample_rate);
+        let reference = get_buffer(&sources, 38000., 1);
         let channel_data = reference.get_channel_data(0);
 
         for _ in 0..100 {
-            let mut buffer = context.create_buffer(1, reference.length(), SampleRate(38000));
+            let mut buffer = context.create_buffer(1, reference.length(), 38000.);
             buffer.copy_to_channel(channel_data, 0);
 
             let source = context.create_buffer_source();
@@ -293,7 +292,7 @@ fn main() {
         let name = "Simple mixing with gains";
 
         let mut context =
-            OfflineAudioContext::new(1, DURATION * sample_rate.0 as usize, sample_rate);
+            OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
 
         let gain = context.create_gain();
         gain.connect(&context.destination());
@@ -309,7 +308,7 @@ fn main() {
         }
 
         for _ in 0..2 {
-            let buf = get_buffer(&sources, 38000, 1);
+            let buf = get_buffer(&sources, 38000., 1);
 
             let source = context.create_buffer_source();
             source.set_buffer(buf);
@@ -331,9 +330,9 @@ fn main() {
         let name = "Granular synthesis";
 
         let adjusted_duration = DURATION as f64 / 16.;
-        let length = (adjusted_duration * sample_rate.0 as f64) as usize;
+        let length = (adjusted_duration * sample_rate as f64) as usize;
         let mut context = OfflineAudioContext::new(1, length, sample_rate);
-        let buffer = get_buffer(&sources, sample_rate.0, 1);
+        let buffer = get_buffer(&sources, sample_rate, 1);
         let mut offset = 0.;
         let mut rng = rand::thread_rng();
 
@@ -373,9 +372,9 @@ fn main() {
     {
         let name = "Synth (Sawtooth with Envelope)";
 
-        let sample_rate = SampleRate(44100);
+        let sample_rate = 44100.;
         let mut context =
-            OfflineAudioContext::new(1, DURATION * sample_rate.0 as usize, sample_rate);
+            OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
         let mut offset = 0.;
 
         let duration = DURATION as f64;
@@ -404,9 +403,9 @@ fn main() {
     {
         let name = "Synth (Sawtooth with gain - no automation)";
 
-        let sample_rate = SampleRate(44100);
+        let sample_rate = 44100.;
         let mut context =
-            OfflineAudioContext::new(1, DURATION * sample_rate.0 as usize, sample_rate);
+            OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
         let mut offset = 0.;
 
         let duration = DURATION as f64;
@@ -431,9 +430,9 @@ fn main() {
     {
         let name = "Synth (Sawtooth without gain)";
 
-        let sample_rate = SampleRate(44100);
+        let sample_rate = 44100.;
         let mut context =
-            OfflineAudioContext::new(1, DURATION * sample_rate.0 as usize, sample_rate);
+            OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
         let mut offset = 0.;
 
         let duration = DURATION as f64;
@@ -455,9 +454,9 @@ fn main() {
     {
         let name = "Substractive Synth";
 
-        let sample_rate = SampleRate(44100);
+        let sample_rate = 44100.;
         let mut context =
-            OfflineAudioContext::new(1, DURATION * sample_rate.0 as usize, sample_rate);
+            OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
         let mut offset = 0.;
 
         let filter = context.create_biquad_filter();
@@ -494,14 +493,14 @@ fn main() {
         let name = "Stereo panning";
 
         let mut context =
-            OfflineAudioContext::new(2, DURATION * sample_rate.0 as usize, sample_rate);
+            OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
 
         let panner = context.create_stereo_panner();
         panner.connect(&context.destination());
         panner.pan().set_value(0.1);
 
         let src = context.create_buffer_source();
-        let buffer = get_buffer(&sources, sample_rate.0, 2);
+        let buffer = get_buffer(&sources, sample_rate, 2);
         src.connect(&panner);
         src.set_buffer(buffer);
         src.set_loop(true);
@@ -514,7 +513,7 @@ fn main() {
         let name = "Stereo panning with automation";
 
         let mut context =
-            OfflineAudioContext::new(2, DURATION * sample_rate.0 as usize, sample_rate);
+            OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
 
         let panner = context.create_stereo_panner();
         panner.connect(&context.destination());
@@ -522,7 +521,7 @@ fn main() {
         panner.pan().set_value_at_time(0.2, 0.5);
 
         let src = context.create_buffer_source();
-        let buffer = get_buffer(&sources, sample_rate.0, 2);
+        let buffer = get_buffer(&sources, sample_rate, 2);
         src.connect(&panner);
         src.set_buffer(buffer);
         src.set_loop(true);
@@ -535,7 +534,7 @@ fn main() {
         let name = "Sawtooth with automation";
 
         let mut context =
-            OfflineAudioContext::new(1, DURATION * sample_rate.0 as usize, sample_rate);
+            OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
 
         let osc = context.create_oscillator();
         osc.connect(&context.destination());

--- a/examples/benchmarks.rs
+++ b/examples/benchmarks.rs
@@ -38,8 +38,7 @@ fn load_buffer(sources: &mut Vec<AudioBuffer>, pathname: &str, sample_rate: f32)
 
 fn get_buffer(sources: &[AudioBuffer], sample_rate: f32, number_of_channels: usize) -> AudioBuffer {
     let buffer = sources.iter().find(|&buffer| {
-        buffer.sample_rate() == sample_rate
-            && buffer.number_of_channels() == number_of_channels
+        buffer.sample_rate() == sample_rate && buffer.number_of_channels() == number_of_channels
     });
 
     buffer.unwrap().clone()
@@ -98,8 +97,7 @@ fn main() {
     {
         let name = "Baseline (silence)";
 
-        let mut context =
-            OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
+        let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
 
         benchmark(&mut stdout, name, &mut context, &mut results);
     }
@@ -107,8 +105,7 @@ fn main() {
     {
         let name = "Simple source test without resampling (Mono)";
 
-        let mut context =
-            OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+        let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
         let source = context.create_buffer_source();
         let buf = get_buffer(&sources, sample_rate, 1);
         source.set_buffer(buf);
@@ -122,8 +119,7 @@ fn main() {
     {
         let name = "Simple source test without resampling (Stereo)";
 
-        let mut context =
-            OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
+        let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
         let source = context.create_buffer_source();
         let buf = get_buffer(&sources, sample_rate, 2);
         source.set_buffer(buf);
@@ -137,8 +133,7 @@ fn main() {
     {
         let name = "Simple source test without resampling (Stereo and positionnal)";
 
-        let mut context =
-            OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
+        let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
 
         let panner = context.create_panner();
         panner.connect(&context.destination());
@@ -163,8 +158,7 @@ fn main() {
     {
         let name = "Simple source test with resampling (Mono)";
 
-        let mut context =
-            OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+        let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
         let source = context.create_buffer_source();
         let buf = get_buffer(&sources, 38000., 1);
         source.set_buffer(buf);
@@ -178,8 +172,7 @@ fn main() {
     {
         let name = "Simple source test with resampling (Stereo)";
 
-        let mut context =
-            OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
+        let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
         let source = context.create_buffer_source();
         let buf = get_buffer(&sources, 38000., 2);
         source.set_buffer(buf);
@@ -193,8 +186,7 @@ fn main() {
     {
         let name = "Simple source test with resampling (Stereo and positionnal)";
 
-        let mut context =
-            OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
+        let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
 
         let panner = context.create_panner();
         panner.connect(&context.destination());
@@ -219,8 +211,7 @@ fn main() {
     {
         let name = "Upmix without resampling (Mono -> Stereo)";
 
-        let mut context =
-            OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
+        let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
         let source = context.create_buffer_source();
         let buf = get_buffer(&sources, sample_rate, 1);
         source.set_buffer(buf);
@@ -234,8 +225,7 @@ fn main() {
     {
         let name = "Downmix without resampling (Stereo -> Mono)";
 
-        let mut context =
-            OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+        let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
         let source = context.create_buffer_source();
         let buf = get_buffer(&sources, sample_rate, 2);
         source.set_buffer(buf);
@@ -291,8 +281,7 @@ fn main() {
     {
         let name = "Simple mixing with gains";
 
-        let mut context =
-            OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+        let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
 
         let gain = context.create_gain();
         gain.connect(&context.destination());
@@ -373,8 +362,7 @@ fn main() {
         let name = "Synth (Sawtooth with Envelope)";
 
         let sample_rate = 44100.;
-        let mut context =
-            OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+        let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
         let mut offset = 0.;
 
         let duration = DURATION as f64;
@@ -404,8 +392,7 @@ fn main() {
         let name = "Synth (Sawtooth with gain - no automation)";
 
         let sample_rate = 44100.;
-        let mut context =
-            OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+        let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
         let mut offset = 0.;
 
         let duration = DURATION as f64;
@@ -431,8 +418,7 @@ fn main() {
         let name = "Synth (Sawtooth without gain)";
 
         let sample_rate = 44100.;
-        let mut context =
-            OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+        let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
         let mut offset = 0.;
 
         let duration = DURATION as f64;
@@ -455,8 +441,7 @@ fn main() {
         let name = "Substractive Synth";
 
         let sample_rate = 44100.;
-        let mut context =
-            OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+        let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
         let mut offset = 0.;
 
         let filter = context.create_biquad_filter();
@@ -492,8 +477,7 @@ fn main() {
     {
         let name = "Stereo panning";
 
-        let mut context =
-            OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
+        let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
 
         let panner = context.create_stereo_panner();
         panner.connect(&context.destination());
@@ -512,8 +496,7 @@ fn main() {
     {
         let name = "Stereo panning with automation";
 
-        let mut context =
-            OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
+        let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
 
         let panner = context.create_stereo_panner();
         panner.connect(&context.destination());
@@ -533,8 +516,7 @@ fn main() {
     {
         let name = "Sawtooth with automation";
 
-        let mut context =
-            OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+        let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
 
         let osc = context.create_oscillator();
         osc.connect(&context.destination());

--- a/examples/mic_playback.rs
+++ b/examples/mic_playback.rs
@@ -10,7 +10,6 @@ use web_audio_api::node::{
     ChannelConfig, GainNode, MediaStreamAudioSourceNode,
 };
 use web_audio_api::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum, RenderScope};
-use web_audio_api::SampleRate;
 
 use std::io::{stdin, stdout, Write};
 use std::sync::Arc;
@@ -75,7 +74,7 @@ impl MediaRecorder {
         })
     }
 
-    fn get_data(self, sample_rate: SampleRate) -> Option<AudioBuffer> {
+    fn get_data(self, sample_rate: f32) -> Option<AudioBuffer> {
         self.receiver
             .try_iter()
             .reduce(|mut accum, item| {
@@ -365,7 +364,7 @@ impl AudioThread {
         let buf = self
             .recorder
             .take()
-            .and_then(|r| r.get_data(self.context.sample_rate_raw()));
+            .and_then(|r| r.get_data(self.context.sample_rate()));
 
         let buffer_source = self.context.create_buffer_source();
         let playback_rate = Self::PLAYBACK_STEP.powi(self.playback_rate_factor);

--- a/examples/resampling.rs
+++ b/examples/resampling.rs
@@ -64,7 +64,7 @@ fn main() {
     println!("--------------------------------------------------------------");
 
     let audio_context_38000 = AudioContext::new(AudioContextOptions {
-        sample_rate: Some(38000),
+        sample_rate: Some(38000.),
         latency_hint: AudioContextLatencyCategory::Interactive,
     });
     let file_38000 = File::open("samples/sample-38000.wav").unwrap();
@@ -73,7 +73,7 @@ fn main() {
         .unwrap();
 
     let audio_context_44100 = AudioContext::new(AudioContextOptions {
-        sample_rate: Some(44100),
+        sample_rate: Some(44100.),
         latency_hint: AudioContextLatencyCategory::Interactive,
     });
     let file_44100 = File::open("samples/sample-44100.wav").unwrap();
@@ -82,7 +82,7 @@ fn main() {
         .unwrap();
 
     let audio_context_48000 = AudioContext::new(AudioContextOptions {
-        sample_rate: Some(48000),
+        sample_rate: Some(48000.),
         latency_hint: AudioContextLatencyCategory::Interactive,
     });
     let file_48000 = File::open("samples/sample-48000.wav").unwrap();

--- a/examples/toy_webrtc.rs
+++ b/examples/toy_webrtc.rs
@@ -29,7 +29,6 @@ use web_audio_api::buffer::AudioBufferOptions;
 use web_audio_api::context::{AudioContext, BaseAudioContext};
 use web_audio_api::media::Microphone;
 use web_audio_api::node::AudioNode;
-use web_audio_api::SampleRate;
 use web_audio_api::RENDER_QUANTUM_SIZE;
 
 const MAX_UDP_SIZE: usize = 508;
@@ -104,7 +103,7 @@ fn serialize(audio_buf: &AudioBuffer, byte_buf: &mut [u8]) -> usize {
     n
 }
 
-fn deserialize(byte_buf: &[u8], sample_rate: SampleRate) -> AudioBuffer {
+fn deserialize(byte_buf: &[u8], sample_rate: f32) -> AudioBuffer {
     let samples: Vec<f32> = byte_buf
         .chunks_exact(2)
         .take(128)
@@ -116,7 +115,7 @@ fn deserialize(byte_buf: &[u8], sample_rate: SampleRate) -> AudioBuffer {
 
 struct SocketStream {
     socket: &'static UdpSocket,
-    sample_rate: SampleRate,
+    sample_rate: f32,
     byte_buf: Vec<u8>,
 }
 
@@ -160,7 +159,7 @@ fn run_client() -> std::io::Result<()> {
     // leg 1: receive server packets and play them
     let stream = SocketStream {
         socket,
-        sample_rate: context.sample_rate_raw(),
+        sample_rate: context.sample_rate(),
         byte_buf: vec![0; 512],
     };
     let stream_in = context.create_media_stream_source(stream);

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -40,7 +40,7 @@ pub struct AudioBufferOptions {
 /// let context = AudioContext::default();
 ///
 /// let length = context.sample_rate() as usize;
-/// let sample_rate = context.sample_rate_raw();
+/// let sample_rate = context.sample_rate();
 /// let mut buffer = context.create_buffer(1, length, sample_rate);
 ///
 /// // fill buffer with a sine wave
@@ -429,7 +429,6 @@ impl ChannelData {
 #[cfg(test)]
 mod tests {
     use float_eq::assert_float_eq;
-    use std::convert::TryFrom;
     use std::f32::consts::PI;
 
     use super::*;
@@ -438,17 +437,16 @@ mod tests {
     fn test_constructor() {
         let options = AudioBufferOptions {
             number_of_channels: 1,
-            length: 10,
+            length: 96000,
             sample_rate: 48000.,
         };
 
         let audio_buffer = AudioBuffer::new(options);
 
         assert_eq!(audio_buffer.number_of_channels(), 1);
-        assert_eq!(audio_buffer.length(), 10);
-        assert_float_eq!(audio_buffer.sample_rate(), 1., abs <= 0.);
-        assert_eq!(audio_buffer.sample_rate_raw().0, 1);
-        assert_float_eq!(audio_buffer.duration(), 10., abs <= 0.);
+        assert_eq!(audio_buffer.length(), 96000);
+        assert_float_eq!(audio_buffer.sample_rate(), 48000., abs <= 0.);
+        assert_float_eq!(audio_buffer.duration(), 2., abs <= 0.);
     }
 
     #[test]
@@ -684,7 +682,7 @@ mod tests {
 
         assert_eq!(b1.length(), 10);
         assert_eq!(b1.number_of_channels(), 2);
-        assert_float_eq!(b1.sample_rate().0, 44100., abs_all <= 0.);
+        assert_float_eq!(b1.sample_rate(), 44100., abs_all <= 0.);
 
         let channel_data = ChannelData::from(vec![1.; 5]);
         let b3 = AudioBuffer::from_channels(vec![channel_data; 2], 44100.);
@@ -693,7 +691,7 @@ mod tests {
 
         assert_eq!(b1.length(), 15);
         assert_eq!(b1.number_of_channels(), 2);
-        assert_float_eq!(b1.sample_rate().0, 44100., abs_all <= 0.);
+        assert_float_eq!(b1.sample_rate(), 44100., abs_all <= 0.);
         assert_float_eq!(
             b1.channel_data(0).as_slice(),
             &[0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 1., 1., 1., 1., 1.][..],
@@ -727,7 +725,7 @@ mod tests {
     fn test_upsample() {
         let channel = ChannelData::from(vec![1., 2., 3., 4., 5.]);
         let mut buffer = AudioBuffer::from_channels(vec![channel], 48000.);
-        buffer.resample(960000.); // double
+        buffer.resample(96000.); // double
 
         let mut expected = [0.; 10];
         let incr = 4. / 9.; // (5 - 1) / (10 - 1)

--- a/src/context/concrete_base.rs
+++ b/src/context/concrete_base.rs
@@ -10,7 +10,7 @@ use crate::param::{AudioParam, AudioParamEvent};
 use crate::render::AudioProcessor;
 use crate::spatial::AudioListenerParams;
 
-use crate::{AudioListener, SampleRate};
+use crate::AudioListener;
 
 use crossbeam_channel::Sender;
 use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
@@ -46,7 +46,7 @@ impl PartialEq for ConcreteBaseAudioContext {
 /// These fields are wrapped inside an `Arc` in the actual `ConcreteBaseAudioContext`.
 struct ConcreteBaseAudioContextInner {
     /// sample rate in Hertz
-    sample_rate: SampleRate,
+    sample_rate: f32,
     /// max number of speaker output channels
     max_channel_count: usize,
     /// incrementing id to assign to audio nodes
@@ -78,7 +78,7 @@ impl BaseAudioContext for ConcreteBaseAudioContext {
 impl ConcreteBaseAudioContext {
     /// Creates a `BaseAudioContext` instance
     pub(super) fn new(
-        sample_rate: SampleRate,
+        sample_rate: f32,
         max_channel_count: usize,
         frames_played: Arc<AtomicU64>,
         render_channel: Sender<ControlMessage>,

--- a/src/context/concrete_base.rs
+++ b/src/context/concrete_base.rs
@@ -204,16 +204,8 @@ impl ConcreteBaseAudioContext {
     }
 
     /// The sample rate (in sample-frames per second) at which the `AudioContext` handles audio.
-    #[allow(clippy::cast_precision_loss)]
     #[must_use]
     pub(super) fn sample_rate(&self) -> f32 {
-        self.inner.sample_rate.0 as f32
-    }
-
-    /// The raw sample rate of the `AudioContext` (which has more precision than the float
-    /// [`sample_rate()`](BaseAudioContext::sample_rate) value).
-    #[must_use]
-    pub(super) fn sample_rate_raw(&self) -> SampleRate {
         self.inner.sample_rate
     }
 
@@ -225,7 +217,7 @@ impl ConcreteBaseAudioContext {
     // Currently, we have no other choice than casting an u64 into f64, with possible loss of precision
     #[allow(clippy::cast_precision_loss)]
     pub(super) fn current_time(&self) -> f64 {
-        self.inner.frames_played.load(Ordering::SeqCst) as f64 / f64::from(self.inner.sample_rate.0)
+        self.inner.frames_played.load(Ordering::SeqCst) as f64 / self.inner.sample_rate as f64
     }
 
     /// Maximum available channels for the audio destination

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -104,7 +104,6 @@ impl Drop for AudioContextRegistration {
 mod tests {
     use super::*;
     use crate::node::AudioNode;
-    use crate::SampleRate;
 
     use float_eq::assert_float_eq;
 
@@ -112,7 +111,7 @@ mod tests {
 
     #[test]
     fn test_audio_context_registration_traits() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 44100.);
         let registration = context.mock_registration();
 
         // we want to be able to ship AudioNodes to another thread, so the Registration should be
@@ -122,19 +121,18 @@ mod tests {
 
     #[test]
     fn test_sample_rate_length() {
-        let context = OfflineAudioContext::new(1, 48000, SampleRate(96000));
+        let context = OfflineAudioContext::new(1, 48000, 96000.);
         assert_float_eq!(context.sample_rate(), 96000., abs_all <= 0.);
-        assert_eq!(context.sample_rate_raw(), SampleRate(96000));
         assert_eq!(context.length(), 48000);
     }
 
     #[test]
     fn test_decode_audio_data() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(44100));
+        let context = OfflineAudioContext::new(1, 0, 44100.);
         let file = std::fs::File::open("samples/sample.wav").unwrap();
         let audio_buffer = context.decode_audio_data_sync(file).unwrap();
 
-        assert_eq!(audio_buffer.sample_rate_raw(), SampleRate(44100));
+        assert_eq!(audio_buffer.sample_rate(), 44100.);
         assert_eq!(audio_buffer.length(), 142_187);
         assert_eq!(audio_buffer.number_of_channels(), 2);
         assert_float_eq!(audio_buffer.duration(), 3.224, abs_all <= 0.001);
@@ -149,7 +147,7 @@ mod tests {
     // disabled: symphonia cannot handle empty WAV-files
     #[allow(dead_code)]
     fn test_decode_audio_data_empty() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(44100));
+        let context = OfflineAudioContext::new(1, 0, 44100.);
         let file = std::fs::File::open("samples/empty_2c.wav").unwrap();
         let audio_buffer = context.decode_audio_data_sync(file).unwrap();
         assert_eq!(audio_buffer.length(), 0);
@@ -157,7 +155,7 @@ mod tests {
 
     #[test]
     fn test_decode_audio_data_decoding_error() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(44100));
+        let context = OfflineAudioContext::new(1, 0, 44100.);
         let file = std::fs::File::open("samples/corrupt.wav").unwrap();
         assert!(context.decode_audio_data_sync(file).is_err());
     }
@@ -166,9 +164,9 @@ mod tests {
     fn test_create_buffer() {
         let number_of_channels = 3;
         let length = 2000;
-        let sample_rate = SampleRate(96_000);
+        let sample_rate = 96_000.;
 
-        let context = OfflineAudioContext::new(1, 0, SampleRate(44100));
+        let context = OfflineAudioContext::new(1, 0, 44100.);
         let buffer = context.create_buffer(number_of_channels, length, sample_rate);
 
         assert_eq!(buffer.number_of_channels(), 3);
@@ -178,7 +176,7 @@ mod tests {
 
     #[test]
     fn test_registration() {
-        let context = OfflineAudioContext::new(1, 48000, SampleRate(96000));
+        let context = OfflineAudioContext::new(1, 48000, 96000.);
         let dest = context.destination();
         assert!(dest.context() == context.base());
     }

--- a/src/context/offline.rs
+++ b/src/context/offline.rs
@@ -102,12 +102,11 @@ impl OfflineAudioContext {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::SampleRate;
     use float_eq::assert_float_eq;
 
     #[test]
     fn render_empty_graph() {
-        let mut context = OfflineAudioContext::new(2, 555, SampleRate(44_100));
+        let mut context = OfflineAudioContext::new(2, 555, 44_100.);
         let buffer = context.start_rendering_sync();
 
         assert_eq!(buffer.number_of_channels(), 2);

--- a/src/context/offline.rs
+++ b/src/context/offline.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use crate::buffer::AudioBuffer;
 use crate::context::{BaseAudioContext, ConcreteBaseAudioContext};
 use crate::render::RenderThread;
-use crate::{AtomicF64, SampleRate, RENDER_QUANTUM_SIZE};
+use crate::{AtomicF64, RENDER_QUANTUM_SIZE, assert_valid_sample_rate};
 
 /// The `OfflineAudioContext` doesn't render the audio to the device hardware; instead, it generates
 /// it, as fast as it can, and outputs the result to an `AudioBuffer`.
@@ -35,7 +35,9 @@ impl OfflineAudioContext {
     /// * `length` - length of the rendering audio buffer
     /// * `sample_rate` - output sample rate
     #[must_use]
-    pub fn new(number_of_channels: usize, length: usize, sample_rate: SampleRate) -> Self {
+    pub fn new(number_of_channels: usize, length: usize, sample_rate: f32) -> Self {
+        assert_valid_sample_rate(sample_rate);
+
         // communication channel to the render thread
         let (sender, receiver) = crossbeam_channel::unbounded();
 

--- a/src/context/offline.rs
+++ b/src/context/offline.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use crate::buffer::AudioBuffer;
 use crate::context::{BaseAudioContext, ConcreteBaseAudioContext};
 use crate::render::RenderThread;
-use crate::{AtomicF64, RENDER_QUANTUM_SIZE, assert_valid_sample_rate};
+use crate::{assert_valid_sample_rate, AtomicF64, RENDER_QUANTUM_SIZE};
 
 /// The `OfflineAudioContext` doesn't render the audio to the device hardware; instead, it generates
 /// it, as fast as it can, and outputs the result to an `AudioBuffer`.

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -91,7 +91,7 @@ impl AudioContext {
     ///
     /// // Request a sample rate of 44.1 kHz and default latency (buffer size 128, if available)
     /// let opts = AudioContextOptions {
-    ///     sample_rate: Some(44100),
+    ///     sample_rate: Some(44100.),
     ///     latency_hint: AudioContextLatencyCategory::Interactive,
     /// };
     ///

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -2,7 +2,7 @@
 use crate::context::{AudioContextState, BaseAudioContext, ConcreteBaseAudioContext};
 use crate::media::MediaStream;
 use crate::node::{self, ChannelConfigOptions};
-use crate::{AtomicF64, SampleRate};
+use crate::AtomicF64;
 
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
@@ -52,7 +52,7 @@ pub struct AudioContextOptions {
     /// tradeoffs between audio output latency and power consumption
     pub latency_hint: AudioContextLatencyCategory,
     /// Sample rate of the audio Context and audio output hardware
-    pub sample_rate: Option<u32>,
+    pub sample_rate: Option<f32>,
 }
 
 /// This interface represents an audio graph whose `AudioDestinationNode` is routed to a real-time
@@ -116,7 +116,7 @@ impl AudioContext {
             io::build_output(frames_played_clone, output_latency_clone, options);
 
         let number_of_channels = usize::from(config.channels);
-        let sample_rate = SampleRate(config.sample_rate.0);
+        let sample_rate = config.sample_rate.0 as f32;
 
         let base = ConcreteBaseAudioContext::new(
             sample_rate,
@@ -138,7 +138,7 @@ impl AudioContext {
     #[allow(clippy::must_use_candidate)]
     #[allow(clippy::needless_pass_by_value)]
     pub fn new(options: AudioContextOptions) -> Self {
-        let sample_rate = SampleRate(options.sample_rate.unwrap_or(44_100));
+        let sample_rate = options.sample_rate.unwrap_or(44100.);
         let number_of_channels = 2;
 
         let (sender, _receiver) = crossbeam_channel::unbounded();

--- a/src/media/decoding.rs
+++ b/src/media/decoding.rs
@@ -2,7 +2,6 @@ use std::error::Error;
 use std::io::{Read, Seek, SeekFrom};
 
 use crate::buffer::{AudioBuffer, ChannelData};
-use crate::SampleRate;
 
 use symphonia::core::audio::AudioBufferRef;
 use symphonia::core::audio::Signal;
@@ -154,7 +153,7 @@ impl Iterator for MediaDecoder {
         // Get the default track.
         let track = format.default_track().unwrap();
         let number_of_channels = track.codec_params.channels.unwrap().count();
-        let input_sample_rate = SampleRate(track.codec_params.sample_rate.unwrap());
+        let input_sample_rate = track.codec_params.sample_rate.unwrap() as f32;
 
         // Store the track identifier, we'll use it to filter packets.
         let track_id = track.id;
@@ -204,7 +203,7 @@ impl Iterator for MediaDecoder {
 fn convert_buf(
     input: AudioBufferRef<'_>,
     number_of_channels: usize,
-    input_sample_rate: SampleRate,
+    input_sample_rate: f32,
 ) -> AudioBuffer {
     let chans = 0..number_of_channels;
 

--- a/src/media/mic.rs
+++ b/src/media/mic.rs
@@ -231,11 +231,7 @@ pub(crate) struct MicrophoneRender {
 
 #[cfg(not(test))]
 impl MicrophoneRender {
-    pub fn new(
-        number_of_channels: usize,
-        sample_rate: f32,
-        sender: Sender<AudioBuffer>,
-    ) -> Self {
+    pub fn new(number_of_channels: usize, sample_rate: f32, sender: Sender<AudioBuffer>) -> Self {
         Self {
             number_of_channels,
             sample_rate,

--- a/src/media/mic.rs
+++ b/src/media/mic.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 
 use crate::buffer::{AudioBuffer, AudioBufferOptions};
 use crate::media::MediaStream;
-use crate::{SampleRate, RENDER_QUANTUM_SIZE};
+use crate::RENDER_QUANTUM_SIZE;
 
 #[cfg(not(test))]
 use crate::context::AudioContextOptions;
@@ -87,7 +87,7 @@ use private::StreamHolder;
 pub struct Microphone {
     receiver: Receiver<AudioBuffer>,
     number_of_channels: usize,
-    sample_rate: SampleRate,
+    sample_rate: f32,
 
     #[cfg(not(test))]
     stream: Arc<Mutex<Option<Stream>>>,
@@ -103,7 +103,7 @@ impl Microphone {
         let (stream, config, receiver) = io::build_input(options);
         log::debug!("Input {:?}", config);
 
-        let sample_rate = SampleRate(config.sample_rate.0);
+        let sample_rate = config.sample_rate.0 as f32;
         let number_of_channels = config.channels as usize;
 
         // shared ownership for the stream, because the Microphone is allowed to go out of scope
@@ -185,7 +185,7 @@ impl Default for Microphone {
 pub struct MicrophoneStream {
     receiver: Receiver<AudioBuffer>,
     number_of_channels: usize,
-    sample_rate: SampleRate,
+    sample_rate: f32,
 
     #[cfg(not(test))]
     _stream: StreamHolder,
@@ -225,7 +225,7 @@ impl Iterator for MicrophoneStream {
 #[cfg(not(test))]
 pub(crate) struct MicrophoneRender {
     number_of_channels: usize,
-    sample_rate: SampleRate,
+    sample_rate: f32,
     sender: Sender<AudioBuffer>,
 }
 
@@ -233,7 +233,7 @@ pub(crate) struct MicrophoneRender {
 impl MicrophoneRender {
     pub fn new(
         number_of_channels: usize,
-        sample_rate: SampleRate,
+        sample_rate: f32,
         sender: Sender<AudioBuffer>,
     ) -> Self {
         Self {

--- a/src/media/mic.rs
+++ b/src/media/mic.rs
@@ -69,7 +69,7 @@ use private::StreamHolder;
 ///
 /// // Request an input sample rate of 44.1 kHz and default latency (buffer size 128, if available)
 /// let opts = AudioContextOptions {
-///     sample_rate: Some(44100),
+///     sample_rate: Some(44100.),
 ///     latency_hint: AudioContextLatencyCategory::Interactive,
 /// };
 /// let mic = Microphone::new(opts);

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -32,7 +32,6 @@ use crate::buffer::AudioBuffer;
 /// # Example
 ///
 /// ```no_run
-/// use web_audio_api::SampleRate;
 /// use web_audio_api::context::{AudioContext, BaseAudioContext};
 /// use web_audio_api::buffer::{AudioBuffer, AudioBufferOptions};
 /// use web_audio_api::node::AudioNode;
@@ -41,7 +40,7 @@ use crate::buffer::AudioBuffer;
 /// let options = AudioBufferOptions {
 ///     number_of_channels: 0,
 ///     length: 512,
-///     sample_rate: SampleRate(44_100),
+///     sample_rate: 44_100.,
 /// };
 /// let silence = AudioBuffer::new(options);
 ///

--- a/src/media/resampling.rs
+++ b/src/media/resampling.rs
@@ -2,7 +2,6 @@ use std::error::Error;
 
 use crate::buffer::{AudioBuffer, AudioBufferOptions};
 use crate::media::MediaStream;
-use crate::SampleRate;
 
 /// Sample rate converter and buffer chunk splitter.
 ///
@@ -10,16 +9,15 @@ use crate::SampleRate;
 /// of the desired sample_rate and length
 ///
 /// ```ignore
-/// use crate::SampleRate;
 /// use crate::buffer::{AudioBuffer, Resampler};
 ///
 /// // construct an input of 3 chunks of 5 samples
 /// let samples = vec![vec![1., 2., 3., 4., 5.]];
-/// let input_buf = AudioBuffer::from(samples, SampleRate(44_100));
+/// let input_buf = AudioBuffer::from(samples, 44_100.);
 /// let input = vec![input_buf; 3].into_iter().map(|b| Ok(b));
 ///
 /// // resample to chunks of 10 samples
-/// let mut resampler = Resampler::new(SampleRate(44_100), 10, input);
+/// let mut resampler = Resampler::new(44_100., 10, input);
 ///
 /// // first chunk contains 10 samples
 /// let next = resampler.next().unwrap().unwrap();
@@ -42,7 +40,7 @@ use crate::SampleRate;
 /// ```
 pub struct Resampler<I> {
     /// desired sample rate
-    sample_rate: SampleRate,
+    sample_rate: f32,
     /// desired sample length
     sample_len: usize,
     /// input stream
@@ -52,7 +50,7 @@ pub struct Resampler<I> {
 }
 
 impl<M: MediaStream> Resampler<M> {
-    pub fn new(sample_rate: SampleRate, sample_len: usize, input: M) -> Self {
+    pub fn new(sample_rate: f32, sample_len: usize, input: M) -> Self {
         Self {
             sample_rate,
             sample_len,
@@ -117,14 +115,13 @@ mod tests {
 
     use super::*;
     use crate::buffer::{AudioBuffer, ChannelData};
-    use crate::SampleRate;
 
     #[test]
     fn test_resampler_concat() {
         let channel = ChannelData::from(vec![1., 2., 3., 4., 5.]);
-        let input_buf = AudioBuffer::from_channels(vec![channel], SampleRate(44_100));
+        let input_buf = AudioBuffer::from_channels(vec![channel], 44_100.);
         let input = vec![input_buf; 3].into_iter().map(Ok);
-        let mut resampler = Resampler::new(SampleRate(44_100), 10, input);
+        let mut resampler = Resampler::new(44_100., 10, input);
 
         let next = resampler.next().unwrap().unwrap();
         assert_eq!(next.length(), 10);
@@ -150,10 +147,10 @@ mod tests {
         let channel = ChannelData::from(vec![1., 2., 3., 4., 5., 6., 7., 8., 9., 10.]);
         let input_buf = Ok(AudioBuffer::from_channels(
             vec![channel],
-            SampleRate(44_100),
+            44_100.,
         ));
         let input = vec![input_buf].into_iter();
-        let mut resampler = Resampler::new(SampleRate(44_100), 5, input);
+        let mut resampler = Resampler::new(44_100., 5, input);
 
         let next = resampler.next().unwrap().unwrap();
         assert_eq!(next.length(), 5);

--- a/src/media/resampling.rs
+++ b/src/media/resampling.rs
@@ -145,10 +145,7 @@ mod tests {
     #[test]
     fn test_resampler_split() {
         let channel = ChannelData::from(vec![1., 2., 3., 4., 5., 6., 7., 8., 9., 10.]);
-        let input_buf = Ok(AudioBuffer::from_channels(
-            vec![channel],
-            44_100.,
-        ));
+        let input_buf = Ok(AudioBuffer::from_channels(vec![channel], 44_100.));
         let input = vec![input_buf].into_iter();
         let mut resampler = Resampler::new(44_100., 5, input);
 

--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -344,7 +344,7 @@ impl AudioProcessor for AudioBufferSourceRenderer {
         // single output node
         let output = &mut outputs[0];
 
-        let sample_rate = scope.sample_rate.0 as f64;
+        let sample_rate = scope.sample_rate as f64;
         let dt = 1. / sample_rate;
         let num_frames = RENDER_QUANTUM_SIZE;
         let next_block_time = scope.current_time + dt * num_frames as f64;
@@ -573,17 +573,16 @@ impl AudioBufferSourceRenderer {
 #[cfg(test)]
 mod tests {
     use float_eq::assert_float_eq;
-    use std::convert::TryFrom;
     use std::f32::consts::PI;
 
     use crate::context::{BaseAudioContext, OfflineAudioContext};
-    use crate::{SampleRate, RENDER_QUANTUM_SIZE};
+    use crate::RENDER_QUANTUM_SIZE;
 
     use super::*;
 
     #[test]
     fn test_playing_some_file() {
-        let mut context = OfflineAudioContext::new(2, RENDER_QUANTUM_SIZE, SampleRate(44_100));
+        let mut context = OfflineAudioContext::new(2, RENDER_QUANTUM_SIZE, 44_100.);
 
         let file = std::fs::File::open("samples/sample.wav").unwrap();
         let audio_buffer = context.decode_audio_data_sync(file).unwrap();
@@ -613,10 +612,9 @@ mod tests {
     #[test]
     fn test_sub_quantum_start() {
         let sample_rate = 128;
-        let sr = SampleRate(sample_rate as u32);
-        let mut context = OfflineAudioContext::new(1, sample_rate, sr);
+        let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
 
-        let mut dirac = context.create_buffer(1, 1, sr);
+        let mut dirac = context.create_buffer(1, 1, sample_rate as f32);
         dirac.copy_to_channel(&[1.], 0);
 
         let src = context.create_buffer_source();
@@ -637,10 +635,9 @@ mod tests {
     fn test_sub_sample_start() {
         // sub sample
         let sample_rate = 128;
-        let sr = SampleRate(sample_rate as u32);
-        let mut context = OfflineAudioContext::new(1, sample_rate, sr);
+        let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
 
-        let mut dirac = context.create_buffer(1, sample_rate, sr);
+        let mut dirac = context.create_buffer(1, sample_rate, sample_rate as f32);
         dirac.copy_to_channel(&[1.], 0);
 
         let src = context.create_buffer_source();
@@ -660,10 +657,9 @@ mod tests {
     #[test]
     fn test_sub_quantum_stop() {
         let sample_rate = 128;
-        let sr = SampleRate(sample_rate as u32);
-        let mut context = OfflineAudioContext::new(1, sample_rate, sr);
+        let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
 
-        let mut dirac = context.create_buffer(1, sample_rate, sr);
+        let mut dirac = context.create_buffer(1, sample_rate, sample_rate as f32);
         dirac.copy_to_channel(&[0., 0., 0., 0., 1.], 0);
 
         let src = context.create_buffer_source();
@@ -683,10 +679,9 @@ mod tests {
     #[test]
     fn test_sub_sample_stop() {
         let sample_rate = 128;
-        let sr = SampleRate(sample_rate as u32);
-        let mut context = OfflineAudioContext::new(1, sample_rate, sr);
+        let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
 
-        let mut dirac = context.create_buffer(1, sample_rate, sr);
+        let mut dirac = context.create_buffer(1, sample_rate, sample_rate as f32);
         dirac.copy_to_channel(&[0., 0., 0., 0., 1., 1.], 0);
 
         let src = context.create_buffer_source();
@@ -708,10 +703,9 @@ mod tests {
     #[test]
     fn test_schedule_in_the_past() {
         let sample_rate = 128;
-        let sr = SampleRate(sample_rate as u32);
-        let mut context = OfflineAudioContext::new(1, sample_rate, sr);
+        let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
 
-        let mut dirac = context.create_buffer(1, 1, sr);
+        let mut dirac = context.create_buffer(1, 1, sample_rate as f32);
         dirac.copy_to_channel(&[1.], 0);
 
         let src = context.create_buffer_source();
@@ -732,12 +726,12 @@ mod tests {
     fn test_audio_buffer_resampling() {
         [22500, 38000, 48000, 96000].iter().for_each(|sr| {
             let base_sr = 44100;
-            let mut context = OfflineAudioContext::new(1, base_sr, SampleRate(base_sr as u32));
+            let mut context = OfflineAudioContext::new(1, base_sr, base_sr as f32);
 
             // 1Hz sine at different sample rates
             let buf_sr = *sr;
             // safe cast for sample rate, see discussion at #113
-            let sample_rate = SampleRate(u32::try_from(buf_sr).unwrap());
+            let sample_rate = buf_sr as f32;
             let mut buffer = context.create_buffer(1, buf_sr, sample_rate);
             let mut sine = vec![];
 

--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -611,10 +611,10 @@ mod tests {
 
     #[test]
     fn test_sub_quantum_start() {
-        let sample_rate = 128;
-        let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
+        let sample_rate = 480000.;
+        let mut context = OfflineAudioContext::new(1, RENDER_QUANTUM_SIZE, sample_rate);
 
-        let mut dirac = context.create_buffer(1, 1, sample_rate as f32);
+        let mut dirac = context.create_buffer(1, 1, sample_rate);
         dirac.copy_to_channel(&[1.], 0);
 
         let src = context.create_buffer_source();
@@ -625,7 +625,7 @@ mod tests {
         let result = context.start_rendering_sync();
         let channel = result.get_channel_data(0);
 
-        let mut expected = vec![0.; sample_rate];
+        let mut expected = vec![0.; RENDER_QUANTUM_SIZE];
         expected[1] = 1.;
 
         assert_float_eq!(channel[..], expected[..], abs_all <= 0.);
@@ -634,10 +634,10 @@ mod tests {
     #[test]
     fn test_sub_sample_start() {
         // sub sample
-        let sample_rate = 128;
-        let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
+        let sample_rate = 480000.;
+        let mut context = OfflineAudioContext::new(1, RENDER_QUANTUM_SIZE, sample_rate);
 
-        let mut dirac = context.create_buffer(1, sample_rate, sample_rate as f32);
+        let mut dirac = context.create_buffer(1, 1, sample_rate);
         dirac.copy_to_channel(&[1.], 0);
 
         let src = context.create_buffer_source();
@@ -648,7 +648,7 @@ mod tests {
         let result = context.start_rendering_sync();
         let channel = result.get_channel_data(0);
 
-        let mut expected = vec![0.; sample_rate];
+        let mut expected = vec![0.; RENDER_QUANTUM_SIZE];
         expected[2] = 0.5;
 
         assert_float_eq!(channel[..], expected[..], abs_all <= 0.);
@@ -656,10 +656,10 @@ mod tests {
 
     #[test]
     fn test_sub_quantum_stop() {
-        let sample_rate = 128;
-        let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
+        let sample_rate = 480000.;
+        let mut context = OfflineAudioContext::new(1, RENDER_QUANTUM_SIZE, sample_rate);
 
-        let mut dirac = context.create_buffer(1, sample_rate, sample_rate as f32);
+        let mut dirac = context.create_buffer(1, RENDER_QUANTUM_SIZE, sample_rate);
         dirac.copy_to_channel(&[0., 0., 0., 0., 1.], 0);
 
         let src = context.create_buffer_source();
@@ -671,17 +671,17 @@ mod tests {
 
         let result = context.start_rendering_sync();
         let channel = result.get_channel_data(0);
-        let expected = vec![0.; sample_rate];
+        let expected = vec![0.; RENDER_QUANTUM_SIZE];
 
         assert_float_eq!(channel[..], expected[..], abs_all <= 0.);
     }
 
     #[test]
     fn test_sub_sample_stop() {
-        let sample_rate = 128;
-        let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
+        let sample_rate = 480000.;
+        let mut context = OfflineAudioContext::new(1, RENDER_QUANTUM_SIZE, sample_rate);
 
-        let mut dirac = context.create_buffer(1, sample_rate, sample_rate as f32);
+        let mut dirac = context.create_buffer(1, RENDER_QUANTUM_SIZE, sample_rate);
         dirac.copy_to_channel(&[0., 0., 0., 0., 1., 1.], 0);
 
         let src = context.create_buffer_source();
@@ -694,7 +694,7 @@ mod tests {
         let result = context.start_rendering_sync();
         let channel = result.get_channel_data(0);
 
-        let mut expected = vec![0.; sample_rate];
+        let mut expected = vec![0.; 128];
         expected[4] = 1.;
 
         assert_float_eq!(channel[..], expected[..], abs_all <= 0.);
@@ -702,10 +702,10 @@ mod tests {
 
     #[test]
     fn test_schedule_in_the_past() {
-        let sample_rate = 128;
-        let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
+        let sample_rate = 48000.;
+        let mut context = OfflineAudioContext::new(1, RENDER_QUANTUM_SIZE, sample_rate);
 
-        let mut dirac = context.create_buffer(1, 1, sample_rate as f32);
+        let mut dirac = context.create_buffer(1, 1, sample_rate);
         dirac.copy_to_channel(&[1.], 0);
 
         let src = context.create_buffer_source();
@@ -716,7 +716,7 @@ mod tests {
         let result = context.start_rendering_sync();
         let channel = result.get_channel_data(0);
 
-        let mut expected = vec![0.; sample_rate];
+        let mut expected = vec![0.; RENDER_QUANTUM_SIZE];
         expected[0] = 1.;
 
         assert_float_eq!(channel[..], expected[..], abs_all <= 0.);

--- a/src/node/constant_source.rs
+++ b/src/node/constant_source.rs
@@ -151,7 +151,7 @@ impl AudioProcessor for ConstantSourceRenderer {
         // single output node
         let output = &mut outputs[0];
 
-        let dt = 1. / scope.sample_rate.0 as f64;
+        let dt = 1. / scope.sample_rate as f64;
         let next_block_time = scope.current_time + dt * RENDER_QUANTUM_SIZE as f64;
 
         let start_time = self.scheduler.get_start_at();
@@ -194,21 +194,21 @@ impl AudioProcessor for ConstantSourceRenderer {
 mod tests {
     use crate::context::{BaseAudioContext, OfflineAudioContext};
     use crate::node::{AudioNode, AudioScheduledSourceNode};
-    use crate::SampleRate;
 
     use float_eq::assert_float_eq;
 
     #[test]
     fn test_start_stop() {
+        let sample_rate = 48000.;
         let start_in_samples = (128 + 1) as f64; // start rendering in 2d block
         let stop_in_samples = (256 + 1) as f64; // stop rendering of 3rd block
-        let mut context = OfflineAudioContext::new(1, 128 * 4, SampleRate(128));
+        let mut context = OfflineAudioContext::new(1, 128 * 4, sample_rate);
 
         let src = context.create_constant_source();
         src.connect(&context.destination());
 
-        src.start_at(start_in_samples / 128.);
-        src.stop_at(stop_in_samples / 128.);
+        src.start_at(start_in_samples / sample_rate as f64);
+        src.stop_at(stop_in_samples / sample_rate as f64);
 
         let buffer = context.start_rendering_sync();
         let channel = buffer.get_channel_data(0);
@@ -232,7 +232,7 @@ mod tests {
 
     #[test]
     fn test_start_in_the_past() {
-        let mut context = OfflineAudioContext::new(1, 128, SampleRate(128));
+        let mut context = OfflineAudioContext::new(1, 128, 48000.);
 
         let src = context.create_constant_source();
         src.connect(&context.destination());

--- a/src/node/delay.rs
+++ b/src/node/delay.rs
@@ -536,7 +536,7 @@ mod tests {
             let mut expected = vec![0.; 256];
             expected[*delay_in_samples as usize] = 1.;
 
-            assert_float_eq!(channel[..], expected[..], abs_all <= 0.);
+            assert_float_eq!(channel[..], expected[..], abs_all <= 0.00001);
         }
     }
 
@@ -566,7 +566,7 @@ mod tests {
             expected[128] = 0.5;
             expected[129] = 0.5;
 
-            assert_float_eq!(channel[..], expected[..], abs_all <= 0.);
+            assert_float_eq!(channel[..], expected[..], abs_all <= 0.00001);
         }
 
         {
@@ -656,7 +656,7 @@ mod tests {
         let src2 = context.create_buffer_source();
         src2.connect(&delay);
         src2.set_buffer(two_chan_dirac);
-        src2.start_at(1.);
+        src2.start_at(delay_in_samples as f64 / sample_rate as f64);
 
         let result = context.start_rendering_sync();
 
@@ -686,7 +686,7 @@ mod tests {
             // otherwise the lifecycle rules do not kick in
             {
                 let delay = context.create_delay(1.);
-                delay.delay_time.set_value(1. / sample_rate);
+                delay.delay_time.set_value(128. / sample_rate);
                 delay.connect(&context.destination());
 
                 let mut dirac = context.create_buffer(1, 1, sample_rate);
@@ -697,7 +697,7 @@ mod tests {
                 src.set_buffer(dirac);
                 // 3rd block - play buffer
                 // 4th block - play silence and dropped in render thread
-                src.start_at(3. / sample_rate as f64);
+                src.start_at(128. * 3. / sample_rate as f64);
             } // src and delay nodes are dropped
 
             let result = context.start_rendering_sync();
@@ -722,7 +722,7 @@ mod tests {
             let mut context = OfflineAudioContext::new(1, 256, sample_rate);
 
             let delay = context.create_delay(1.);
-            delay.delay_time.set_value(1. / sample_rate);
+            delay.delay_time.set_value(128. / sample_rate);
             delay.connect(&context.destination());
 
             let mut dirac = context.create_buffer(1, 1, sample_rate);
@@ -748,7 +748,7 @@ mod tests {
             let mut context = OfflineAudioContext::new(1, 3 * 128, sample_rate);
 
             let delay = context.create_delay(2.);
-            delay.delay_time.set_value(2. / sample_rate);
+            delay.delay_time.set_value(128. * 2. / sample_rate);
             delay.connect(&context.destination());
 
             let mut dirac = context.create_buffer(1, 1, sample_rate);
@@ -765,7 +765,7 @@ mod tests {
             let mut expected = vec![0.; 3 * 128];
             expected[256] = 1.;
 
-            assert_float_eq!(channel[..], expected[..], abs_all <= 0.);
+            assert_float_eq!(channel[..], expected[..], abs_all <= 0.00001);
         }
     }
 

--- a/src/node/delay.rs
+++ b/src/node/delay.rs
@@ -168,7 +168,7 @@ impl DelayNode {
     ///
     /// Panics when the max delay value is smaller than zero or langer than three minutes.
     pub fn new<C: BaseAudioContext>(context: &C, options: DelayOptions) -> Self {
-        let sample_rate = context.sample_rate_raw().0 as f64;
+        let sample_rate = context.sample_rate() as f64;
 
         // Specifies the maximum delay time in seconds allowed for the delay line.
         // If specified, this value MUST be greater than zero and less than three
@@ -410,7 +410,7 @@ impl AudioProcessor for DelayReader {
         output.set_number_of_channels(number_of_channels);
 
         // shadow and cast sample_rate, we don't need the wrapper type here
-        let sample_rate = scope.sample_rate.0 as f64;
+        let sample_rate = scope.sample_rate as f64;
         let dt = 1. / sample_rate;
         let quantum_duration = RENDER_QUANTUM_SIZE as f64 * dt;
 
@@ -509,18 +509,17 @@ mod tests {
 
     use crate::context::OfflineAudioContext;
     use crate::node::AudioScheduledSourceNode;
-    use crate::SampleRate;
 
     use super::*;
 
     #[test]
     fn test_sample_accurate() {
         for delay_in_samples in [128., 131., 197.].iter() {
-            let sample_rate = SampleRate(128);
+            let sample_rate = 48000.;
             let mut context = OfflineAudioContext::new(1, 256, sample_rate);
 
             let delay = context.create_delay(2.);
-            delay.delay_time.set_value(delay_in_samples / 128.);
+            delay.delay_time.set_value(delay_in_samples / sample_rate);
             delay.connect(&context.destination());
 
             let mut dirac = context.create_buffer(1, 1, sample_rate);
@@ -545,11 +544,11 @@ mod tests {
     fn test_sub_sample_accurate() {
         {
             let delay_in_samples = 128.5;
-            let sample_rate = SampleRate(128);
+            let sample_rate = 48000.;
             let mut context = OfflineAudioContext::new(1, 256, sample_rate);
 
             let delay = context.create_delay(2.);
-            delay.delay_time.set_value(delay_in_samples / 128.);
+            delay.delay_time.set_value(delay_in_samples / sample_rate);
             delay.connect(&context.destination());
 
             let mut dirac = context.create_buffer(1, 1, sample_rate);
@@ -572,11 +571,11 @@ mod tests {
 
         {
             let delay_in_samples = 128.8;
-            let sample_rate = SampleRate(128);
+            let sample_rate = 48000.;
             let mut context = OfflineAudioContext::new(1, 256, sample_rate);
 
             let delay = context.create_delay(2.);
-            delay.delay_time.set_value(delay_in_samples / 128.);
+            delay.delay_time.set_value(delay_in_samples / sample_rate);
             delay.connect(&context.destination());
 
             let mut dirac = context.create_buffer(1, 1, sample_rate);
@@ -601,11 +600,11 @@ mod tests {
     #[test]
     fn test_multichannel() {
         let delay_in_samples = 128.;
-        let sample_rate = SampleRate(128);
+        let sample_rate = 48000.;
         let mut context = OfflineAudioContext::new(2, 2 * 128, sample_rate);
 
         let delay = context.create_delay(2.);
-        delay.delay_time.set_value(delay_in_samples / 128.);
+        delay.delay_time.set_value(delay_in_samples / sample_rate);
         delay.connect(&context.destination());
 
         let mut two_chan_dirac = context.create_buffer(2, 256, sample_rate);
@@ -634,11 +633,11 @@ mod tests {
     #[test]
     fn test_input_number_of_channels_change() {
         let delay_in_samples = 128.;
-        let sample_rate = SampleRate(128);
+        let sample_rate = 48000.;
         let mut context = OfflineAudioContext::new(2, 3 * 128, sample_rate);
 
         let delay = context.create_delay(2.);
-        delay.delay_time.set_value(delay_in_samples / 128.);
+        delay.delay_time.set_value(delay_in_samples / sample_rate);
         delay.connect(&context.destination());
 
         let mut one_chan_dirac = context.create_buffer(1, 128, sample_rate);
@@ -678,7 +677,7 @@ mod tests {
     fn test_node_stays_alive_long_enough() {
         // make sure there are no hidden order problem
         for _ in 0..10 {
-            let sample_rate = SampleRate(128);
+            let sample_rate = 48000.;
             let mut context = OfflineAudioContext::new(1, 5 * 128, sample_rate);
 
             // Set up a source that starts only after 5 render quanta.
@@ -687,7 +686,7 @@ mod tests {
             // otherwise the lifecycle rules do not kick in
             {
                 let delay = context.create_delay(1.);
-                delay.delay_time.set_value(1.);
+                delay.delay_time.set_value(1. / sample_rate);
                 delay.connect(&context.destination());
 
                 let mut dirac = context.create_buffer(1, 1, sample_rate);
@@ -698,7 +697,7 @@ mod tests {
                 src.set_buffer(dirac);
                 // 3rd block - play buffer
                 // 4th block - play silence and dropped in render thread
-                src.start_at(3.);
+                src.start_at(3. / sample_rate as f64);
             } // src and delay nodes are dropped
 
             let result = context.start_rendering_sync();
@@ -719,11 +718,11 @@ mod tests {
         // Writer is called earlier than the Reader. 10 times should do:
         for _ in 0..10 {
             // set delay and max delay time exactly 1 render quantum
-            let sample_rate = SampleRate(128);
+            let sample_rate = 48000.;
             let mut context = OfflineAudioContext::new(1, 256, sample_rate);
 
             let delay = context.create_delay(1.);
-            delay.delay_time.set_value(1.);
+            delay.delay_time.set_value(1. / sample_rate);
             delay.connect(&context.destination());
 
             let mut dirac = context.create_buffer(1, 1, sample_rate);
@@ -745,11 +744,11 @@ mod tests {
 
         for _ in 0..10 {
             // set delay and max delay time exactly 2 render quantum
-            let sample_rate = SampleRate(128);
+            let sample_rate = 48000.;
             let mut context = OfflineAudioContext::new(1, 3 * 128, sample_rate);
 
             let delay = context.create_delay(2.);
-            delay.delay_time.set_value(2.);
+            delay.delay_time.set_value(2. / sample_rate);
             delay.connect(&context.destination());
 
             let mut dirac = context.create_buffer(1, 1, sample_rate);
@@ -779,11 +778,11 @@ mod tests {
         // When allowing sub quantum delay, this will also guarantees that the node
         // gracefully fallback to min
         for _ in 0..10 {
-            let sample_rate = SampleRate(128);
+            let sample_rate = 480000.;
             let mut context = OfflineAudioContext::new(1, 256, sample_rate);
 
             let delay = context.create_delay(0.5); // this will be internally clamped to 1.
-            delay.delay_time.set_value(0.5); // this will be clamped to 1. by the Reader
+            delay.delay_time.set_value(0.5 / sample_rate); // this will be clamped to 1. by the Reader
             delay.connect(&context.destination());
 
             let mut dirac = context.create_buffer(1, 1, sample_rate);

--- a/src/node/iir_filter.rs
+++ b/src/node/iir_filter.rs
@@ -127,7 +127,7 @@ impl IIRFilterNode {
         phase_response: &mut [f32],
     ) {
         self.validate_inputs(frequency_hz, mag_response, phase_response);
-        let sample_rate = f64::from(self.context().sample_rate_raw().0);
+        let sample_rate = self.context().sample_rate() as f64;
 
         for (i, &f) in frequency_hz.iter().enumerate() {
             let mut num: Complex<f64> = Complex::new(0., 0.);
@@ -354,7 +354,6 @@ mod test {
     use crate::{
         context::{BaseAudioContext, OfflineAudioContext},
         node::{AudioNode, AudioScheduledSourceNode},
-        SampleRate,
     };
 
     use super::{ChannelConfigOptions, IIRFilterNode, IIRFilterOptions};
@@ -363,7 +362,7 @@ mod test {
 
     #[test]
     fn build_with_new() {
-        let context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
+        let context = OfflineAudioContext::new(2, LENGTH, 44_100.);
 
         let feedforward = vec![
             0.000_016_636_797_512_844_526,
@@ -383,7 +382,7 @@ mod test {
 
     #[test]
     fn build_with_factory_func() {
-        let context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
+        let context = OfflineAudioContext::new(2, LENGTH, 44_100.);
 
         let feedforward = vec![
             0.000_016_636_797_512_844_526,
@@ -398,7 +397,7 @@ mod test {
     #[test]
     #[should_panic]
     fn panics_when_ffs_is_above_max_len() {
-        let context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
+        let context = OfflineAudioContext::new(2, LENGTH, 44_100.);
         let feedforward = vec![
             0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
         ];
@@ -410,7 +409,7 @@ mod test {
     #[test]
     #[should_panic]
     fn panics_when_fbs_is_above_max_len() {
-        let context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
+        let context = OfflineAudioContext::new(2, LENGTH, 44_100.);
         let feedback = vec![
             0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
         ];
@@ -422,7 +421,7 @@ mod test {
     #[test]
     #[should_panic]
     fn panics_when_fbs_is_empty() {
-        let context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
+        let context = OfflineAudioContext::new(2, LENGTH, 44_100.);
         let feedback = vec![];
         let feedforward = vec![1.0, -1.988_430_010_622_553_9, 0.988_496_557_812_605_4];
 
@@ -432,7 +431,7 @@ mod test {
     #[test]
     #[should_panic]
     fn panics_when_ffs_is_empty() {
-        let context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
+        let context = OfflineAudioContext::new(2, LENGTH, 44_100.);
         let feedforward = vec![];
         let feedback = vec![1.0, -1.988_430_010_622_553_9, 0.988_496_557_812_605_4];
 
@@ -442,7 +441,7 @@ mod test {
     #[test]
     #[should_panic]
     fn panics_when_ffs_are_zeros() {
-        let context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
+        let context = OfflineAudioContext::new(2, LENGTH, 44_100.);
         let feedforward = vec![0., 0.];
         let feedback = vec![1.0, -1.988_430_010_622_553_9, 0.988_496_557_812_605_4];
 
@@ -452,7 +451,7 @@ mod test {
     #[test]
     #[should_panic]
     fn panics_when_fbs_are_zeros() {
-        let context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
+        let context = OfflineAudioContext::new(2, LENGTH, 44_100.);
         let feedback = vec![0., 0.];
         let feedforward = vec![1.0, -1.988_430_010_622_553_9, 0.988_496_557_812_605_4];
 
@@ -462,7 +461,7 @@ mod test {
     #[test]
     #[should_panic]
     fn panics_when_not_the_same_length() {
-        let context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
+        let context = OfflineAudioContext::new(2, LENGTH, 44_100.);
         let feedforward = vec![
             0.000_016_636_797_512_844_526,
             0.000_033_273_595_025_689_05,
@@ -487,7 +486,7 @@ mod test {
     #[test]
     #[should_panic]
     fn panics_when_not_the_same_length_2() {
-        let context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
+        let context = OfflineAudioContext::new(2, LENGTH, 44_100.);
         let feedforward = vec![
             0.000_016_636_797_512_844_526,
             0.000_033_273_595_025_689_05,
@@ -511,7 +510,7 @@ mod test {
 
     #[test]
     fn frequencies_are_clamped() {
-        let context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
+        let context = OfflineAudioContext::new(2, LENGTH, 44_100.);
         let feedforward = vec![
             0.000_016_636_797_512_844_526,
             0.000_033_273_595_025_689_05,
@@ -556,7 +555,7 @@ mod test {
             2.146_620_2e-1,
             6.802_952e-1,
         ];
-        let context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
+        let context = OfflineAudioContext::new(2, LENGTH, 44_100.);
         let feedforward = vec![
             0.019_618_022_238_052_212,
             -0.036_007_928_102_449_24,
@@ -593,7 +592,7 @@ mod test {
             .map(|l| l.unwrap().parse::<f32>().unwrap())
             .collect();
 
-        let mut context = OfflineAudioContext::new(1, LENGTH, SampleRate(44_100));
+        let mut context = OfflineAudioContext::new(1, LENGTH, 44_100.);
 
         let file = File::open("samples/white.ogg").unwrap();
         let audio_buffer = context.decode_audio_data_sync(file).unwrap();

--- a/src/node/media_stream_source.rs
+++ b/src/node/media_stream_source.rs
@@ -53,7 +53,7 @@ impl MediaStreamAudioSourceNode {
             };
 
             let resampler = Resampler::new(
-                context.sample_rate_raw(),
+                context.sample_rate(),
                 RENDER_QUANTUM_SIZE,
                 options.media_stream,
             );

--- a/src/node/oscillator.rs
+++ b/src/node/oscillator.rs
@@ -349,7 +349,7 @@ impl AudioProcessor for OscillatorRenderer {
             self.periodic_wave = Some(periodic_wave);
         }
 
-        let sample_rate = scope.sample_rate.0 as f64;
+        let sample_rate = scope.sample_rate as f64;
         let dt = 1. / sample_rate;
         let num_frames = RENDER_QUANTUM_SIZE;
         let next_block_time = scope.current_time + dt * num_frames as f64;
@@ -537,7 +537,6 @@ mod tests {
     use crate::context::{BaseAudioContext, OfflineAudioContext};
     use crate::node::{AudioNode, AudioScheduledSourceNode};
     use crate::periodic_wave::{PeriodicWave, PeriodicWaveOptions};
-    use crate::SampleRate;
 
     use super::{OscillatorNode, OscillatorOptions, OscillatorRenderer, OscillatorType};
 
@@ -547,7 +546,7 @@ mod tests {
         let default_det = 0.;
         let default_type = OscillatorType::Sine;
 
-        let context = OfflineAudioContext::new(2, 1, SampleRate(44_100));
+        let context = OfflineAudioContext::new(2, 1, 44_100.);
 
         let osc = context.create_oscillator();
 
@@ -567,7 +566,7 @@ mod tests {
         let default_det = 0.;
         let default_type = OscillatorType::Sine;
 
-        let context = OfflineAudioContext::new(2, 1, SampleRate(44_100));
+        let context = OfflineAudioContext::new(2, 1, 44_100.);
 
         let osc = OscillatorNode::new(&context, OscillatorOptions::default());
 
@@ -584,7 +583,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn set_type_to_custom_should_panic() {
-        let context = OfflineAudioContext::new(2, 1, SampleRate(44_100));
+        let context = OfflineAudioContext::new(2, 1, 44_100.);
         let osc = OscillatorNode::new(&context, OscillatorOptions::default());
         osc.set_type(OscillatorType::Custom);
     }
@@ -593,7 +592,7 @@ mod tests {
     fn type_is_custom_when_periodic_wave_is_some() {
         let expected_type = OscillatorType::Custom;
 
-        let context = OfflineAudioContext::new(2, 1, SampleRate(44_100));
+        let context = OfflineAudioContext::new(2, 1, 44_100.);
 
         let periodic_wave = PeriodicWave::new(&context, PeriodicWaveOptions::default());
 
@@ -612,7 +611,7 @@ mod tests {
     fn set_type_is_ignored_when_periodic_wave_is_some() {
         let expected_type = OscillatorType::Custom;
 
-        let context = OfflineAudioContext::new(2, 1, SampleRate(44_100));
+        let context = OfflineAudioContext::new(2, 1, 44_100.);
 
         let periodic_wave = PeriodicWave::new(&context, PeriodicWaveOptions::default());
 
@@ -649,8 +648,7 @@ mod tests {
             let freq = 10_f32.powf(i as f32);
             let sample_rate = 44_100;
 
-            let mut context =
-                OfflineAudioContext::new(1, sample_rate, SampleRate(sample_rate as u32));
+            let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
 
             let osc = context.create_oscillator();
             osc.connect(&context.destination());
@@ -686,8 +684,7 @@ mod tests {
             let freq = 10_f32.powf(i as f32);
             let sample_rate = 44_100;
 
-            let mut context =
-                OfflineAudioContext::new(1, sample_rate, SampleRate(sample_rate as u32));
+            let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
 
             let osc = context.create_oscillator();
             osc.connect(&context.destination());
@@ -716,8 +713,7 @@ mod tests {
             let freq = 10_f32.powf(i as f32);
             let sample_rate = 44100;
 
-            let mut context =
-                OfflineAudioContext::new(1, sample_rate, SampleRate(sample_rate as u32));
+            let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
 
             let osc = context.create_oscillator();
             osc.connect(&context.destination());
@@ -755,8 +751,7 @@ mod tests {
             let freq = 10_f32.powf(i as f32);
             let sample_rate = 44_100;
 
-            let mut context =
-                OfflineAudioContext::new(1, sample_rate, SampleRate(sample_rate as u32));
+            let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
 
             let osc = context.create_oscillator();
             osc.connect(&context.destination());
@@ -803,8 +798,7 @@ mod tests {
             let freq = 10_f32.powf(i as f32);
             let sample_rate = 44_100;
 
-            let mut context =
-                OfflineAudioContext::new(1, sample_rate, SampleRate(sample_rate as u32));
+            let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
 
             let osc = context.create_oscillator();
             osc.connect(&context.destination());
@@ -849,8 +843,7 @@ mod tests {
             let freq = 10_f32.powf(i as f32);
             let sample_rate = 44_100;
 
-            let mut context =
-                OfflineAudioContext::new(1, sample_rate, SampleRate(sample_rate as u32));
+            let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
 
             let options = PeriodicWaveOptions {
                 real: Some(vec![0., 0.]),
@@ -896,8 +889,7 @@ mod tests {
             let freq = 10_f32.powf(i as f32);
             let sample_rate = 44_100;
 
-            let mut context =
-                OfflineAudioContext::new(1, sample_rate, SampleRate(sample_rate as u32));
+            let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
 
             let options = PeriodicWaveOptions {
                 real: Some(vec![0., 0., 0.]),
@@ -984,7 +976,7 @@ mod tests {
         let freq = 1.25;
         let sample_rate = 44_100;
 
-        let mut context = OfflineAudioContext::new(1, sample_rate, SampleRate(sample_rate as u32));
+        let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
         let osc = context.create_oscillator();
         osc.connect(&context.destination());
         osc.frequency().set_value(freq);
@@ -1014,9 +1006,9 @@ mod tests {
     #[test]
     fn osc_sub_sample_start() {
         let freq = 1.;
-        let sample_rate = 128;
+        let sample_rate = 96000;
 
-        let mut context = OfflineAudioContext::new(1, sample_rate, SampleRate(sample_rate as u32));
+        let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
         let osc = context.create_oscillator();
         osc.connect(&context.destination());
         osc.frequency().set_value(freq);
@@ -1048,7 +1040,7 @@ mod tests {
         let freq = 2345.6;
         let sample_rate = 44_100;
 
-        let mut context = OfflineAudioContext::new(1, sample_rate, SampleRate(sample_rate as u32));
+        let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
         let osc = context.create_oscillator();
         osc.connect(&context.destination());
         osc.frequency().set_value(freq);
@@ -1080,7 +1072,7 @@ mod tests {
         let freq = 8910.1;
         let sample_rate = 44_100;
 
-        let mut context = OfflineAudioContext::new(1, sample_rate, SampleRate(sample_rate as u32));
+        let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
         let osc = context.create_oscillator();
         osc.connect(&context.destination());
         osc.frequency().set_value(freq);
@@ -1112,7 +1104,7 @@ mod tests {
         let freq = 8910.1;
         let sample_rate = 44_100;
 
-        let mut context = OfflineAudioContext::new(1, sample_rate, SampleRate(sample_rate as u32));
+        let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
         let osc = context.create_oscillator();
         osc.connect(&context.destination());
         osc.frequency().set_value(freq);

--- a/src/node/stereo_panner.rs
+++ b/src/node/stereo_panner.rs
@@ -261,23 +261,20 @@ impl StereoPannerRenderer {
 mod test {
     use float_eq::assert_float_eq;
 
-    use crate::{
-        context::{BaseAudioContext, OfflineAudioContext},
-        SampleRate,
-    };
+    use crate::context::{BaseAudioContext, OfflineAudioContext};
 
     use super::{StereoPannerNode, StereoPannerOptions, StereoPannerRenderer};
     const LENGTH: usize = 555;
 
     #[test]
     fn build_with_new() {
-        let context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
+        let context = OfflineAudioContext::new(2, LENGTH, 44_100.);
         let _panner = StereoPannerNode::new(&context, StereoPannerOptions::default());
     }
 
     #[test]
     fn build_with_factory_func() {
-        let context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
+        let context = OfflineAudioContext::new(2, LENGTH, 44_100.);
         let _panner = context.create_stereo_panner();
     }
 
@@ -285,7 +282,7 @@ mod test {
     fn assert_stereo_default_build() {
         let default_pan = 0.;
 
-        let mut context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
+        let mut context = OfflineAudioContext::new(2, LENGTH, 44_100.);
 
         let panner = StereoPannerNode::new(&context, StereoPannerOptions::default());
 
@@ -300,7 +297,7 @@ mod test {
         let default_pan = 0.;
         let new_pan = 0.1;
 
-        let mut context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
+        let mut context = OfflineAudioContext::new(2, LENGTH, 44_100.);
 
         let panner = StereoPannerNode::new(&context, StereoPannerOptions::default());
 
@@ -357,7 +354,7 @@ mod test {
         let default_pan = 0.;
         let new_pan = 1.1;
 
-        let mut context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
+        let mut context = OfflineAudioContext::new(2, LENGTH, 44_100.);
 
         let panner = StereoPannerNode::new(&context, StereoPannerOptions::default());
 
@@ -377,7 +374,7 @@ mod test {
         let default_pan = 0.;
         let new_pan = -1.1;
 
-        let mut context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
+        let mut context = OfflineAudioContext::new(2, LENGTH, 44_100.);
 
         let panner = StereoPannerNode::new(&context, StereoPannerOptions::default());
 

--- a/src/node/waveshaper.rs
+++ b/src/node/waveshaper.rs
@@ -170,7 +170,7 @@ impl WaveShaperNode {
                 channel_config,
             } = options;
 
-            let sample_rate = context.sample_rate_raw().0 as usize;
+            let sample_rate = context.sample_rate() as usize;
             let channel_config = channel_config.into();
             let oversample = Arc::new(AtomicU32::new(oversample as u32));
 
@@ -455,7 +455,6 @@ mod tests {
 
     use crate::context::OfflineAudioContext;
     use crate::node::AudioScheduledSourceNode;
-    use crate::SampleRate;
 
     use super::*;
 
@@ -463,19 +462,19 @@ mod tests {
 
     #[test]
     fn build_with_new() {
-        let context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
+        let context = OfflineAudioContext::new(2, LENGTH, 44_100.);
         let _shaper = WaveShaperNode::new(&context, WaveShaperOptions::default());
     }
 
     #[test]
     fn build_with_factory_func() {
-        let context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
+        let context = OfflineAudioContext::new(2, LENGTH, 44_100.);
         let _shaper = context.create_wave_shaper();
     }
 
     #[test]
     fn test_default_options() {
-        let context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
+        let context = OfflineAudioContext::new(2, LENGTH, 44_100.);
         let shaper = WaveShaperNode::new(&context, WaveShaperOptions::default());
 
         assert_eq!(shaper.curve(), None);
@@ -484,7 +483,7 @@ mod tests {
 
     #[test]
     fn test_user_defined_options() {
-        let mut context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
+        let mut context = OfflineAudioContext::new(2, LENGTH, 44_100.);
 
         let options = WaveShaperOptions {
             curve: Some(vec![1.0]),
@@ -503,7 +502,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn change_a_curve_for_another_curve_should_panic() {
-        let mut context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
+        let mut context = OfflineAudioContext::new(2, LENGTH, 44_100.);
 
         let options = WaveShaperOptions {
             curve: Some(vec![1.0]),
@@ -526,7 +525,7 @@ mod tests {
 
     #[test]
     fn change_none_for_curve_after_build() {
-        let mut context = OfflineAudioContext::new(2, LENGTH, SampleRate(44_100));
+        let mut context = OfflineAudioContext::new(2, LENGTH, 44_100.);
 
         let options = WaveShaperOptions {
             curve: None,
@@ -549,7 +548,7 @@ mod tests {
 
     #[test]
     fn test_shape_boundaries() {
-        let sample_rate = SampleRate(128);
+        let sample_rate = 44100.;
         let mut context = OfflineAudioContext::new(1, 3 * 128, sample_rate);
 
         let shaper = context.create_wave_shaper();
@@ -587,7 +586,7 @@ mod tests {
 
     #[test]
     fn test_shape_interpolation() {
-        let sample_rate = SampleRate(128);
+        let sample_rate = 44100.;
         let mut context = OfflineAudioContext::new(1, 128, sample_rate);
 
         let shaper = context.create_wave_shaper();

--- a/src/param.rs
+++ b/src/param.rs
@@ -565,7 +565,7 @@ impl AudioProcessor for AudioParamProcessor {
         _params: AudioParamValues,
         scope: &RenderScope,
     ) -> bool {
-        let period = 1. / scope.sample_rate.0 as f64;
+        let period = 1. / scope.sample_rate as f64;
         let param_intrisic_values = self.tick(scope.current_time, period, RENDER_QUANTUM_SIZE);
 
         let input = &inputs[0]; // single input mode

--- a/src/param.rs
+++ b/src/param.rs
@@ -1432,7 +1432,6 @@ mod tests {
     use float_eq::assert_float_eq;
 
     use crate::context::{BaseAudioContext, OfflineAudioContext};
-    use crate::SampleRate;
 
     use super::*;
 
@@ -1483,7 +1482,7 @@ mod tests {
 
     #[test]
     fn test_default_and_accessors() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 48000.);
 
         let opts = AudioParamDescriptor {
             automation_rate: AutomationRate::A,
@@ -1502,7 +1501,7 @@ mod tests {
 
     #[test]
     fn test_set_value() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 48000.);
 
         let opts = AudioParamDescriptor {
             automation_rate: AutomationRate::A,
@@ -1524,7 +1523,7 @@ mod tests {
 
     #[test]
     fn test_set_value_clamped() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 48000.);
 
         let opts = AudioParamDescriptor {
             automation_rate: AutomationRate::A,
@@ -1546,7 +1545,7 @@ mod tests {
 
     #[test]
     fn test_steps_a_rate() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 48000.);
 
         {
             let opts = AudioParamDescriptor {
@@ -1603,7 +1602,7 @@ mod tests {
 
     #[test]
     fn test_steps_k_rate() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 48000.);
         let opts = AudioParamDescriptor {
             automation_rate: AutomationRate::K,
             default_value: 0.,
@@ -1629,7 +1628,7 @@ mod tests {
 
     #[test]
     fn test_linear_ramp_arate() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 48000.);
 
         let opts = AudioParamDescriptor {
             automation_rate: AutomationRate::A,
@@ -1656,7 +1655,7 @@ mod tests {
 
     #[test]
     fn test_linear_ramp_arate_end_of_block() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 48000.);
 
         let opts = AudioParamDescriptor {
             automation_rate: AutomationRate::A,
@@ -1681,7 +1680,7 @@ mod tests {
 
     #[test]
     fn test_linear_ramp_arate_implicit_set_value() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 48000.);
 
         let opts = AudioParamDescriptor {
             automation_rate: AutomationRate::A,
@@ -1712,7 +1711,7 @@ mod tests {
     #[test]
     fn test_linear_ramp_arate_multiple_blocks() {
         // regression test for issue #9
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 48000.);
 
         let opts = AudioParamDescriptor {
             automation_rate: AutomationRate::A,
@@ -1752,7 +1751,7 @@ mod tests {
     #[test]
     fn test_linear_ramp_arate_clamp() {
         // must be compliant with ex.7 cf. https://www.w3.org/TR/webaudio/#computation-of-value
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 48000.);
 
         let opts = AudioParamDescriptor {
             automation_rate: AutomationRate::A,
@@ -1779,7 +1778,7 @@ mod tests {
     #[test]
     fn test_linear_ramp_krate_multiple_blocks() {
         // regression test for issue #9
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 48000.);
 
         {
             let opts = AudioParamDescriptor {
@@ -1835,7 +1834,7 @@ mod tests {
 
     #[test]
     fn test_exponential_ramp_a_rate() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 48000.);
 
         let opts = AudioParamDescriptor {
             automation_rate: AutomationRate::A,
@@ -1870,7 +1869,7 @@ mod tests {
 
     #[test]
     fn test_exponential_ramp_a_rate_multiple_blocks() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 48000.);
 
         let opts = AudioParamDescriptor {
             automation_rate: AutomationRate::A,
@@ -1908,7 +1907,7 @@ mod tests {
 
     #[test]
     fn test_exponential_ramp_a_rate_zero_and_opposite_target() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 48000.);
 
         {
             // zero target
@@ -1960,7 +1959,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_exponential_ramp_to_zero() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 48000.);
 
         let opts = AudioParamDescriptor {
             automation_rate: AutomationRate::A,
@@ -1974,7 +1973,7 @@ mod tests {
 
     #[test]
     fn test_exponential_ramp_k_rate_multiple_blocks() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 48000.);
 
         let opts = AudioParamDescriptor {
             automation_rate: AutomationRate::K,
@@ -2014,7 +2013,7 @@ mod tests {
 
     #[test]
     fn test_exponential_ramp_k_rate_zero_and_opposite_target() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 48000.);
 
         {
             // zero target
@@ -2059,7 +2058,7 @@ mod tests {
 
     #[test]
     fn test_set_target_at_time_a_rate() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 48000.);
 
         {
             let opts = AudioParamDescriptor {
@@ -2166,7 +2165,7 @@ mod tests {
 
     #[test]
     fn test_set_target_at_time_a_rate_multiple_blocks() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 48000.);
 
         {
             let opts = AudioParamDescriptor {
@@ -2201,7 +2200,7 @@ mod tests {
 
     #[test]
     fn test_set_target_at_time_a_rate_followed_by_set_value() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 48000.);
 
         {
             let opts = AudioParamDescriptor {
@@ -2240,7 +2239,7 @@ mod tests {
 
     #[test]
     fn test_set_target_at_time_a_rate_followed_by_ramp() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 48000.);
         {
             let opts = AudioParamDescriptor {
                 automation_rate: AutomationRate::A,
@@ -2293,7 +2292,7 @@ mod tests {
 
     #[test]
     fn test_set_target_at_time_k_rate_multiple_blocks() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 48000.);
 
         {
             let opts = AudioParamDescriptor {
@@ -2328,7 +2327,7 @@ mod tests {
 
     #[test]
     fn test_cancel_scheduled_values() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 48000.);
 
         let opts = AudioParamDescriptor {
             automation_rate: AutomationRate::A,
@@ -2353,7 +2352,7 @@ mod tests {
 
     #[test]
     fn test_cancel_scheduled_values_ramp() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 48000.);
 
         {
             let opts = AudioParamDescriptor {
@@ -2442,7 +2441,7 @@ mod tests {
 
     #[test]
     fn test_cancel_and_hold() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 48000.);
         {
             let opts = AudioParamDescriptor {
                 automation_rate: AutomationRate::A,
@@ -2469,7 +2468,7 @@ mod tests {
 
     #[test]
     fn test_cancel_and_hold_during_set_target() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 48000.);
 
         {
             let opts = AudioParamDescriptor {
@@ -2510,7 +2509,7 @@ mod tests {
 
     #[test]
     fn test_cancel_and_hold_during_linear_ramp() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 48000.);
 
         {
             let opts = AudioParamDescriptor {
@@ -2556,7 +2555,7 @@ mod tests {
 
     #[test]
     fn test_cancel_and_hold_during_exponential_ramp() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 48000.);
 
         {
             let opts = AudioParamDescriptor {
@@ -2626,7 +2625,7 @@ mod tests {
 
     #[test]
     fn test_cancel_and_hold_during_set_value_curve() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 48000.);
 
         {
             let opts = AudioParamDescriptor {
@@ -2674,7 +2673,7 @@ mod tests {
 
     #[test]
     fn test_set_value_curve_at_time_a_rate() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 48000.);
 
         let opts = AudioParamDescriptor {
             automation_rate: AutomationRate::A,
@@ -2701,7 +2700,7 @@ mod tests {
 
     #[test]
     fn test_set_value_curve_at_time_a_rate_multiple_frames() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 48000.);
 
         let opts = AudioParamDescriptor {
             automation_rate: AutomationRate::A,
@@ -2736,7 +2735,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_set_value_curve_at_time_insert_while_another_event() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 48000.);
 
         let opts = AudioParamDescriptor {
             automation_rate: AutomationRate::A,
@@ -2758,7 +2757,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_set_value_curve_at_time_insert_another_event_inside() {
-        let context = OfflineAudioContext::new(1, 0, SampleRate(0));
+        let context = OfflineAudioContext::new(1, 0, 48000.);
 
         let opts = AudioParamDescriptor {
             automation_rate: AutomationRate::A,

--- a/src/render/processor.rs
+++ b/src/render/processor.rs
@@ -3,7 +3,6 @@
 use std::collections::HashMap;
 
 use crate::context::AudioParamId;
-use crate::SampleRate;
 
 use super::{graph::Node, AudioRenderQuantum, NodeIndex};
 
@@ -16,7 +15,7 @@ use super::{graph::Node, AudioRenderQuantum, NodeIndex};
 pub struct RenderScope {
     pub current_frame: u64,
     pub current_time: f64,
-    pub sample_rate: SampleRate,
+    pub sample_rate: f32,
 }
 
 /// Interface for audio processing code that runs on the audio rendering thread.

--- a/src/render/thread.rs
+++ b/src/render/thread.rs
@@ -11,14 +11,14 @@ use crate::buffer::{AudioBuffer, AudioBufferOptions};
 use crate::message::ControlMessage;
 use crate::node::ChannelInterpretation;
 use crate::render::RenderScope;
-use crate::{AtomicF64, SampleRate, RENDER_QUANTUM_SIZE};
+use crate::{AtomicF64, RENDER_QUANTUM_SIZE};
 
 use super::graph::Graph;
 
 /// Operations running off the system-level audio callback
 pub(crate) struct RenderThread {
     graph: Graph,
-    sample_rate: SampleRate,
+    sample_rate: f32,
     number_of_channels: usize,
     frames_played: Arc<AtomicU64>,
     output_latency: Arc<AtomicF64>,
@@ -36,7 +36,7 @@ unsafe impl Send for RenderThread {}
 
 impl RenderThread {
     pub fn new(
-        sample_rate: SampleRate,
+        sample_rate: f32,
         number_of_channels: usize,
         receiver: Receiver<ControlMessage>,
         frames_played: Arc<AtomicU64>,
@@ -114,7 +114,7 @@ impl RenderThread {
             let current_frame = self
                 .frames_played
                 .fetch_add(RENDER_QUANTUM_SIZE as u64, Ordering::SeqCst);
-            let current_time = current_frame as f64 / self.sample_rate.0 as f64;
+            let current_time = current_frame as f64 / self.sample_rate as f64;
 
             let scope = RenderScope {
                 current_frame,
@@ -186,7 +186,7 @@ impl RenderThread {
             let current_frame = self
                 .frames_played
                 .fetch_add(RENDER_QUANTUM_SIZE as u64, Ordering::SeqCst);
-            let current_time = current_frame as f64 / self.sample_rate.0 as f64;
+            let current_time = current_frame as f64 / self.sample_rate as f64;
 
             let scope = RenderScope {
                 current_frame,

--- a/tests/mixing.rs
+++ b/tests/mixing.rs
@@ -6,13 +6,12 @@ use web_audio_api::node::{
     ChannelCountMode::{self, *},
     ChannelInterpretation::{self, *},
 };
-use web_audio_api::SampleRate;
 
 fn setup_with_destination_channel_config(
     number_of_channels: usize,
     channel_interpretation: ChannelInterpretation,
 ) -> OfflineAudioContext {
-    let context = OfflineAudioContext::new(number_of_channels, 128, SampleRate(44_100));
+    let context = OfflineAudioContext::new(number_of_channels, 128, 44_100.);
     let dest = context.destination();
     dest.set_channel_interpretation(channel_interpretation);
     context

--- a/tests/offline.rs
+++ b/tests/offline.rs
@@ -150,11 +150,7 @@ fn test_audio_param_graph() {
 #[test]
 fn test_listener() {
     let sample_rate = 480000.;
-    let mut context = OfflineAudioContext::new(
-        1,
-        RENDER_QUANTUM_SIZE,
-        sample_rate,
-    );
+    let mut context = OfflineAudioContext::new(1, RENDER_QUANTUM_SIZE, sample_rate);
 
     {
         let listener1 = context.listener();
@@ -208,11 +204,7 @@ fn test_cycle() {
 #[test]
 fn test_cycle_breaker() {
     let sample_rate = 480000.;
-    let mut context = OfflineAudioContext::new(
-        1,
-        RENDER_QUANTUM_SIZE * 3,
-        sample_rate,
-    );
+    let mut context = OfflineAudioContext::new(1, RENDER_QUANTUM_SIZE * 3, sample_rate);
 
     {
         let delay = context.create_delay(1. / sample_rate as f64);

--- a/tests/offline.rs
+++ b/tests/offline.rs
@@ -61,8 +61,8 @@ fn test_start_stop() {
         let osc = OscillatorNode::new(&context, opts);
         osc.connect(&context.destination());
 
-        osc.start_at(1. / sample_rate as f64);
-        osc.stop_at(3. / sample_rate as f64);
+        osc.start_at(128. / sample_rate as f64);
+        osc.stop_at(128. * 3. / sample_rate as f64);
     }
 
     let output = context.start_rendering_sync();
@@ -76,7 +76,7 @@ fn test_start_stop() {
     expected.append(&mut vec![1.; 2 * RENDER_QUANTUM_SIZE]);
     expected.append(&mut vec![0.; RENDER_QUANTUM_SIZE]);
 
-    assert_eq!(channel_data, expected.as_slice());
+    assert_float_eq!(channel_data, expected.as_slice(), abs_all <= 0.);
 }
 
 #[test]
@@ -88,8 +88,8 @@ fn test_delayed_constant_source() {
     assert_eq!(context.length(), len);
 
     {
-        let delay = context.create_delay(10. / sample_rate as f64);
-        delay.delay_time().set_value(2. / sample_rate);
+        let delay = context.create_delay(1.);
+        delay.delay_time().set_value(128. * 2. / sample_rate);
         delay.connect(&context.destination());
 
         let source = context.create_constant_source();
@@ -107,7 +107,7 @@ fn test_delayed_constant_source() {
     let mut expected = vec![0.; 2 * RENDER_QUANTUM_SIZE];
     expected.append(&mut vec![1.; 2 * RENDER_QUANTUM_SIZE]);
 
-    assert_eq!(channel_data, expected.as_slice());
+    assert_float_eq!(channel_data, expected.as_slice(), abs_all <= 0.00001);
 }
 
 #[test]


### PR DESCRIPTION
Work in progress, the build succeeds but I need to fix some tests still.
Just wanted to let you know I have this in the pipeline. Please base new PRs on this one to avoid merge conflicts.

For the benchmarks in the WAC paper, we could choose to run on this branch already, altough it probably won't make any difference compared to `main`