### PR TITLE
Improved AudioScheduledSourceNode

### DIFF
--- a/examples/benchmarks.rs
+++ b/examples/benchmarks.rs
@@ -130,30 +130,30 @@ fn main() {
         benchmark(&mut stdout, name, &mut context, &mut results);
     }
 
-    {
-        let name = "Simple source test without resampling (Stereo and positionnal)";
+    // {
+    //     let name = "Simple source test without resampling (Stereo and positionnal)";
 
-        let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
+    //     let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
 
-        let panner = context.create_panner();
-        panner.connect(&context.destination());
-        panner.position_x().set_value(1.);
-        panner.position_y().set_value(2.);
-        panner.position_z().set_value(3.);
-        panner.orientation_x().set_value(1.);
-        panner.orientation_y().set_value(2.);
-        panner.orientation_z().set_value(3.);
+    //     let panner = context.create_panner();
+    //     panner.connect(&context.destination());
+    //     panner.position_x().set_value(1.);
+    //     panner.position_y().set_value(2.);
+    //     panner.position_z().set_value(3.);
+    //     panner.orientation_x().set_value(1.);
+    //     panner.orientation_y().set_value(2.);
+    //     panner.orientation_z().set_value(3.);
 
-        let source = context.create_buffer_source();
-        source.connect(&panner);
+    //     let source = context.create_buffer_source();
+    //     source.connect(&panner);
 
-        let buf = get_buffer(&sources, sample_rate, 2);
-        source.set_buffer(buf);
-        source.set_loop(true);
-        source.start();
+    //     let buf = get_buffer(&sources, sample_rate, 2);
+    //     source.set_buffer(buf);
+    //     source.set_loop(true);
+    //     source.start();
 
-        benchmark(&mut stdout, name, &mut context, &mut results);
-    }
+    //     benchmark(&mut stdout, name, &mut context, &mut results);
+    // }
 
     {
         let name = "Simple source test with resampling (Mono)";
@@ -183,350 +183,350 @@ fn main() {
         benchmark(&mut stdout, name, &mut context, &mut results);
     }
 
-    {
-        let name = "Simple source test with resampling (Stereo and positionnal)";
-
-        let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
-
-        let panner = context.create_panner();
-        panner.connect(&context.destination());
-        panner.position_x().set_value(1.);
-        panner.position_y().set_value(2.);
-        panner.position_z().set_value(3.);
-        panner.orientation_x().set_value(1.);
-        panner.orientation_y().set_value(2.);
-        panner.orientation_z().set_value(3.);
-
-        let source = context.create_buffer_source();
-        source.connect(&panner);
-
-        let buf = get_buffer(&sources, 38000., 2);
-        source.set_buffer(buf);
-        source.set_loop(true);
-        source.start();
-
-        benchmark(&mut stdout, name, &mut context, &mut results);
-    }
-
-    {
-        let name = "Upmix without resampling (Mono -> Stereo)";
-
-        let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
-        let source = context.create_buffer_source();
-        let buf = get_buffer(&sources, sample_rate, 1);
-        source.set_buffer(buf);
-        source.set_loop(true);
-        source.connect(&context.destination());
-        source.start();
-
-        benchmark(&mut stdout, name, &mut context, &mut results);
-    }
-
-    {
-        let name = "Downmix without resampling (Stereo -> Mono)";
-
-        let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
-        let source = context.create_buffer_source();
-        let buf = get_buffer(&sources, sample_rate, 2);
-        source.set_buffer(buf);
-        source.set_loop(true);
-        source.connect(&context.destination());
-        source.start();
-
-        benchmark(&mut stdout, name, &mut context, &mut results);
-    }
-
-    {
-        let name = "Simple mixing (100x same buffer) - be careful w/ volume here!";
-
-        let adjusted_duration = DURATION / 4;
-        let mut context =
-            OfflineAudioContext::new(1, adjusted_duration * sample_rate as usize, sample_rate);
-
-        for _ in 0..100 {
-            let source = context.create_buffer_source();
-            let buf = get_buffer(&sources, 38000., 1);
-            source.set_buffer(buf);
-            source.set_loop(true);
-            source.connect(&context.destination());
-            source.start();
-        }
-
-        benchmark(&mut stdout, name, &mut context, &mut results);
-    }
-
-    {
-        let name = "Simple mixing (100 different buffers) - be careful w/ volume here!";
-
-        let adjusted_duration = DURATION / 4;
-        let mut context =
-            OfflineAudioContext::new(1, adjusted_duration * sample_rate as usize, sample_rate);
-        let reference = get_buffer(&sources, 38000., 1);
-        let channel_data = reference.get_channel_data(0);
-
-        for _ in 0..100 {
-            let mut buffer = context.create_buffer(1, reference.length(), 38000.);
-            buffer.copy_to_channel(channel_data, 0);
-
-            let source = context.create_buffer_source();
-            source.set_buffer(buffer);
-            source.set_loop(true);
-            source.connect(&context.destination());
-            source.start();
-        }
-
-        benchmark(&mut stdout, name, &mut context, &mut results);
-    }
-
-    {
-        let name = "Simple mixing with gains";
-
-        let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
-
-        let gain = context.create_gain();
-        gain.connect(&context.destination());
-        gain.gain().set_value(-1.);
-
-        let mut gains_i = vec![];
-
-        for _ in 0..4 {
-            let gain_i = context.create_gain();
-            gain_i.connect(&gain);
-            gain_i.gain().set_value(0.25);
-            gains_i.push(gain_i);
-        }
-
-        for _ in 0..2 {
-            let buf = get_buffer(&sources, 38000., 1);
-
-            let source = context.create_buffer_source();
-            source.set_buffer(buf);
-            source.set_loop(true);
-            source.start();
-
-            for gain_i in gains_i.iter() {
-                let gain_ij = context.create_gain();
-                gain_ij.gain().set_value(0.5);
-                gain_ij.connect(gain_i);
-                source.connect(&gain_ij);
-            }
-        }
-
-        benchmark(&mut stdout, name, &mut context, &mut results);
-    }
-
-    {
-        let name = "Granular synthesis";
-
-        let adjusted_duration = DURATION as f64 / 16.;
-        let length = (adjusted_duration * sample_rate as f64) as usize;
-        let mut context = OfflineAudioContext::new(1, length, sample_rate);
-        let buffer = get_buffer(&sources, sample_rate, 1);
-        let mut offset = 0.;
-        let mut rng = rand::thread_rng();
-
-        // @todo - make a PR
-        // - problem w/ env.gain().set_value_at_time(0., offset);
-        // - variables are badly named, but just follow the source here
-
-        // this 1500 sources...
-        while offset < adjusted_duration {
-            let env = context.create_gain();
-            env.connect(&context.destination());
-
-            let src = context.create_buffer_source();
-            src.connect(&env);
-            src.set_buffer(buffer.clone());
-
-            let rand_start = rng.gen_range(0..1000) as f64 / 1000. * 0.5;
-            let rand_duration = rng.gen_range(0..1000) as f64 / 1000. * 0.999;
-            let start = offset * rand_start;
-            let end = start + 0.005 * rand_duration;
-            let start_release = (offset + end - start).max(0.);
-
-            env.gain().set_value_at_time(0., offset);
-            env.gain().linear_ramp_to_value_at_time(0.5, offset + 0.005);
-            env.gain().set_value_at_time(0.5, start_release);
-            env.gain()
-                .linear_ramp_to_value_at_time(0., start_release + 0.05);
-
-            src.start_at_with_offset_and_duration(offset, start, end);
-
-            offset += 0.005;
-        }
-
-        benchmark(&mut stdout, name, &mut context, &mut results);
-    }
-
-    {
-        let name = "Synth (Sawtooth with Envelope)";
-
-        let sample_rate = 44100.;
-        let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
-        let mut offset = 0.;
-
-        let duration = DURATION as f64;
-
-        while offset < duration {
-            let env = context.create_gain();
-            env.connect(&context.destination());
-
-            let osc = context.create_oscillator();
-            osc.connect(&env);
-            osc.set_type(OscillatorType::Sawtooth);
-            osc.frequency().set_value(110.);
+    // {
+    //     let name = "Simple source test with resampling (Stereo and positionnal)";
+
+    //     let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
+
+    //     let panner = context.create_panner();
+    //     panner.connect(&context.destination());
+    //     panner.position_x().set_value(1.);
+    //     panner.position_y().set_value(2.);
+    //     panner.position_z().set_value(3.);
+    //     panner.orientation_x().set_value(1.);
+    //     panner.orientation_y().set_value(2.);
+    //     panner.orientation_z().set_value(3.);
+
+    //     let source = context.create_buffer_source();
+    //     source.connect(&panner);
+
+    //     let buf = get_buffer(&sources, 38000., 2);
+    //     source.set_buffer(buf);
+    //     source.set_loop(true);
+    //     source.start();
+
+    //     benchmark(&mut stdout, name, &mut context, &mut results);
+    // }
+
+    // {
+    //     let name = "Upmix without resampling (Mono -> Stereo)";
+
+    //     let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
+    //     let source = context.create_buffer_source();
+    //     let buf = get_buffer(&sources, sample_rate, 1);
+    //     source.set_buffer(buf);
+    //     source.set_loop(true);
+    //     source.connect(&context.destination());
+    //     source.start();
+
+    //     benchmark(&mut stdout, name, &mut context, &mut results);
+    // }
+
+    // {
+    //     let name = "Downmix without resampling (Stereo -> Mono)";
+
+    //     let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+    //     let source = context.create_buffer_source();
+    //     let buf = get_buffer(&sources, sample_rate, 2);
+    //     source.set_buffer(buf);
+    //     source.set_loop(true);
+    //     source.connect(&context.destination());
+    //     source.start();
+
+    //     benchmark(&mut stdout, name, &mut context, &mut results);
+    // }
+
+    // {
+    //     let name = "Simple mixing (100x same buffer) - be careful w/ volume here!";
+
+    //     let adjusted_duration = DURATION / 4;
+    //     let mut context =
+    //         OfflineAudioContext::new(1, adjusted_duration * sample_rate as usize, sample_rate);
+
+    //     for _ in 0..100 {
+    //         let source = context.create_buffer_source();
+    //         let buf = get_buffer(&sources, 38000., 1);
+    //         source.set_buffer(buf);
+    //         source.set_loop(true);
+    //         source.connect(&context.destination());
+    //         source.start();
+    //     }
+
+    //     benchmark(&mut stdout, name, &mut context, &mut results);
+    // }
+
+    // {
+    //     let name = "Simple mixing (100 different buffers) - be careful w/ volume here!";
+
+    //     let adjusted_duration = DURATION / 4;
+    //     let mut context =
+    //         OfflineAudioContext::new(1, adjusted_duration * sample_rate as usize, sample_rate);
+    //     let reference = get_buffer(&sources, 38000., 1);
+    //     let channel_data = reference.get_channel_data(0);
+
+    //     for _ in 0..100 {
+    //         let mut buffer = context.create_buffer(1, reference.length(), 38000.);
+    //         buffer.copy_to_channel(channel_data, 0);
+
+    //         let source = context.create_buffer_source();
+    //         source.set_buffer(buffer);
+    //         source.set_loop(true);
+    //         source.connect(&context.destination());
+    //         source.start();
+    //     }
+
+    //     benchmark(&mut stdout, name, &mut context, &mut results);
+    // }
+
+    // {
+    //     let name = "Simple mixing with gains";
+
+    //     let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+
+    //     let gain = context.create_gain();
+    //     gain.connect(&context.destination());
+    //     gain.gain().set_value(-1.);
+
+    //     let mut gains_i = vec![];
+
+    //     for _ in 0..4 {
+    //         let gain_i = context.create_gain();
+    //         gain_i.connect(&gain);
+    //         gain_i.gain().set_value(0.25);
+    //         gains_i.push(gain_i);
+    //     }
+
+    //     for _ in 0..2 {
+    //         let buf = get_buffer(&sources, 38000., 1);
+
+    //         let source = context.create_buffer_source();
+    //         source.set_buffer(buf);
+    //         source.set_loop(true);
+    //         source.start();
+
+    //         for gain_i in gains_i.iter() {
+    //             let gain_ij = context.create_gain();
+    //             gain_ij.gain().set_value(0.5);
+    //             gain_ij.connect(gain_i);
+    //             source.connect(&gain_ij);
+    //         }
+    //     }
+
+    //     benchmark(&mut stdout, name, &mut context, &mut results);
+    // }
+
+    // {
+    //     let name = "Granular synthesis";
+
+    //     let adjusted_duration = DURATION as f64 / 16.;
+    //     let length = (adjusted_duration * sample_rate as f64) as usize;
+    //     let mut context = OfflineAudioContext::new(1, length, sample_rate);
+    //     let buffer = get_buffer(&sources, sample_rate, 1);
+    //     let mut offset = 0.;
+    //     let mut rng = rand::thread_rng();
+
+    //     // @todo - make a PR
+    //     // - problem w/ env.gain().set_value_at_time(0., offset);
+    //     // - variables are badly named, but just follow the source here
+
+    //     // this 1500 sources...
+    //     while offset < adjusted_duration {
+    //         let env = context.create_gain();
+    //         env.connect(&context.destination());
+
+    //         let src = context.create_buffer_source();
+    //         src.connect(&env);
+    //         src.set_buffer(buffer.clone());
+
+    //         let rand_start = rng.gen_range(0..1000) as f64 / 1000. * 0.5;
+    //         let rand_duration = rng.gen_range(0..1000) as f64 / 1000. * 0.999;
+    //         let start = offset * rand_start;
+    //         let end = start + 0.005 * rand_duration;
+    //         let start_release = (offset + end - start).max(0.);
+
+    //         env.gain().set_value_at_time(0., offset);
+    //         env.gain().linear_ramp_to_value_at_time(0.5, offset + 0.005);
+    //         env.gain().set_value_at_time(0.5, start_release);
+    //         env.gain()
+    //             .linear_ramp_to_value_at_time(0., start_release + 0.05);
+
+    //         src.start_at_with_offset_and_duration(offset, start, end);
+
+    //         offset += 0.005;
+    //     }
+
+    //     benchmark(&mut stdout, name, &mut context, &mut results);
+    // }
+
+    // {
+    //     let name = "Synth (Sawtooth with Envelope)";
+
+    //     let sample_rate = 44100.;
+    //     let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+    //     let mut offset = 0.;
+
+    //     let duration = DURATION as f64;
+
+    //     while offset < duration {
+    //         let env = context.create_gain();
+    //         env.connect(&context.destination());
+
+    //         let osc = context.create_oscillator();
+    //         osc.connect(&env);
+    //         osc.set_type(OscillatorType::Sawtooth);
+    //         osc.frequency().set_value(110.);
 
-            env.gain().set_value_at_time(0., 0.);
-            env.gain().set_value_at_time(0.5, offset);
-            env.gain().set_target_at_time(0., offset + 0.01, 0.1);
-            osc.start_at(offset);
-            osc.stop_at(offset + 1.); // why not 0.1 ?
+    //         env.gain().set_value_at_time(0., 0.);
+    //         env.gain().set_value_at_time(0.5, offset);
+    //         env.gain().set_target_at_time(0., offset + 0.01, 0.1);
+    //         osc.start_at(offset);
+    //         osc.stop_at(offset + 1.); // why not 0.1 ?
 
-            offset += 140. / 60. / 4.; // 140 bpm (?)
-        }
+    //         offset += 140. / 60. / 4.; // 140 bpm (?)
+    //     }
 
-        benchmark(&mut stdout, name, &mut context, &mut results);
-    }
+    //     benchmark(&mut stdout, name, &mut context, &mut results);
+    // }
 
-    {
-        let name = "Synth (Sawtooth with gain - no automation)";
+    // {
+    //     let name = "Synth (Sawtooth with gain - no automation)";
 
-        let sample_rate = 44100.;
-        let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
-        let mut offset = 0.;
+    //     let sample_rate = 44100.;
+    //     let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+    //     let mut offset = 0.;
 
-        let duration = DURATION as f64;
+    //     let duration = DURATION as f64;
 
-        while offset < duration {
-            let env = context.create_gain();
-            env.connect(&context.destination());
+    //     while offset < duration {
+    //         let env = context.create_gain();
+    //         env.connect(&context.destination());
 
-            let osc = context.create_oscillator();
-            osc.connect(&env);
-            osc.set_type(OscillatorType::Sawtooth);
-            osc.frequency().set_value(110.);
-            osc.start_at(offset);
-            osc.stop_at(offset + 1.); // why not 0.1 ?
+    //         let osc = context.create_oscillator();
+    //         osc.connect(&env);
+    //         osc.set_type(OscillatorType::Sawtooth);
+    //         osc.frequency().set_value(110.);
+    //         osc.start_at(offset);
+    //         osc.stop_at(offset + 1.); // why not 0.1 ?
 
-            offset += 140. / 60. / 4.; // 140 bpm (?)
-        }
+    //         offset += 140. / 60. / 4.; // 140 bpm (?)
+    //     }
 
-        benchmark(&mut stdout, name, &mut context, &mut results);
-    }
+    //     benchmark(&mut stdout, name, &mut context, &mut results);
+    // }
 
-    {
-        let name = "Synth (Sawtooth without gain)";
+    // {
+    //     let name = "Synth (Sawtooth without gain)";
 
-        let sample_rate = 44100.;
-        let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
-        let mut offset = 0.;
+    //     let sample_rate = 44100.;
+    //     let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+    //     let mut offset = 0.;
 
-        let duration = DURATION as f64;
+    //     let duration = DURATION as f64;
 
-        while offset < duration {
-            let osc = context.create_oscillator();
-            osc.connect(&context.destination());
-            osc.set_type(OscillatorType::Sawtooth);
-            osc.frequency().set_value(110.);
-            osc.start_at(offset);
-            osc.stop_at(offset + 1.); // why not 0.1 ?
+    //     while offset < duration {
+    //         let osc = context.create_oscillator();
+    //         osc.connect(&context.destination());
+    //         osc.set_type(OscillatorType::Sawtooth);
+    //         osc.frequency().set_value(110.);
+    //         osc.start_at(offset);
+    //         osc.stop_at(offset + 1.); // why not 0.1 ?
 
-            offset += 140. / 60. / 4.; // 140 bpm (?)
-        }
+    //         offset += 140. / 60. / 4.; // 140 bpm (?)
+    //     }
 
-        benchmark(&mut stdout, name, &mut context, &mut results);
-    }
+    //     benchmark(&mut stdout, name, &mut context, &mut results);
+    // }
 
-    {
-        let name = "Substractive Synth";
+    // {
+    //     let name = "Substractive Synth";
 
-        let sample_rate = 44100.;
-        let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
-        let mut offset = 0.;
+    //     let sample_rate = 44100.;
+    //     let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+    //     let mut offset = 0.;
 
-        let filter = context.create_biquad_filter();
-        filter.connect(&context.destination());
-        filter.frequency().set_value_at_time(0., 0.);
-        filter.q().set_value_at_time(20., 0.);
+    //     let filter = context.create_biquad_filter();
+    //     filter.connect(&context.destination());
+    //     filter.frequency().set_value_at_time(0., 0.);
+    //     filter.q().set_value_at_time(20., 0.);
 
-        let env = context.create_gain();
-        env.connect(&filter);
-        env.gain().set_value_at_time(0., 0.);
+    //     let env = context.create_gain();
+    //     env.connect(&filter);
+    //     env.gain().set_value_at_time(0., 0.);
 
-        let osc = context.create_oscillator();
-        osc.connect(&env);
-        osc.set_type(OscillatorType::Sawtooth);
-        osc.frequency().set_value(110.);
-        osc.start();
+    //     let osc = context.create_oscillator();
+    //     osc.connect(&env);
+    //     osc.set_type(OscillatorType::Sawtooth);
+    //     osc.frequency().set_value(110.);
+    //     osc.start();
 
-        let duration = DURATION as f64;
+    //     let duration = DURATION as f64;
 
-        while offset < duration {
-            env.gain().set_value_at_time(1., offset);
-            env.gain().set_target_at_time(0., offset, 0.1);
+    //     while offset < duration {
+    //         env.gain().set_value_at_time(1., offset);
+    //         env.gain().set_target_at_time(0., offset, 0.1);
 
-            filter.frequency().set_value_at_time(0., offset);
-            filter.frequency().set_target_at_time(3500., offset, 0.03);
+    //         filter.frequency().set_value_at_time(0., offset);
+    //         filter.frequency().set_target_at_time(3500., offset, 0.03);
 
-            offset += 140. / 60. / 16.; // 140 bpm (?)
-        }
+    //         offset += 140. / 60. / 16.; // 140 bpm (?)
+    //     }
 
-        benchmark(&mut stdout, name, &mut context, &mut results);
-    }
+    //     benchmark(&mut stdout, name, &mut context, &mut results);
+    // }
 
-    {
-        let name = "Stereo panning";
+    // {
+    //     let name = "Stereo panning";
 
-        let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
+    //     let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
 
-        let panner = context.create_stereo_panner();
-        panner.connect(&context.destination());
-        panner.pan().set_value(0.1);
+    //     let panner = context.create_stereo_panner();
+    //     panner.connect(&context.destination());
+    //     panner.pan().set_value(0.1);
 
-        let src = context.create_buffer_source();
-        let buffer = get_buffer(&sources, sample_rate, 2);
-        src.connect(&panner);
-        src.set_buffer(buffer);
-        src.set_loop(true);
-        src.start();
+    //     let src = context.create_buffer_source();
+    //     let buffer = get_buffer(&sources, sample_rate, 2);
+    //     src.connect(&panner);
+    //     src.set_buffer(buffer);
+    //     src.set_loop(true);
+    //     src.start();
 
-        benchmark(&mut stdout, name, &mut context, &mut results);
-    }
+    //     benchmark(&mut stdout, name, &mut context, &mut results);
+    // }
 
-    {
-        let name = "Stereo panning with automation";
+    // {
+    //     let name = "Stereo panning with automation";
 
-        let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
+    //     let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
 
-        let panner = context.create_stereo_panner();
-        panner.connect(&context.destination());
-        panner.pan().set_value_at_time(-1., 0.);
-        panner.pan().set_value_at_time(0.2, 0.5);
+    //     let panner = context.create_stereo_panner();
+    //     panner.connect(&context.destination());
+    //     panner.pan().set_value_at_time(-1., 0.);
+    //     panner.pan().set_value_at_time(0.2, 0.5);
 
-        let src = context.create_buffer_source();
-        let buffer = get_buffer(&sources, sample_rate, 2);
-        src.connect(&panner);
-        src.set_buffer(buffer);
-        src.set_loop(true);
-        src.start();
+    //     let src = context.create_buffer_source();
+    //     let buffer = get_buffer(&sources, sample_rate, 2);
+    //     src.connect(&panner);
+    //     src.set_buffer(buffer);
+    //     src.set_loop(true);
+    //     src.start();
 
-        benchmark(&mut stdout, name, &mut context, &mut results);
-    }
+    //     benchmark(&mut stdout, name, &mut context, &mut results);
+    // }
 
-    {
-        let name = "Sawtooth with automation";
+    // {
+    //     let name = "Sawtooth with automation";
 
-        let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+    //     let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
 
-        let osc = context.create_oscillator();
-        osc.connect(&context.destination());
-        osc.set_type(OscillatorType::Sawtooth);
-        osc.frequency().set_value(2000.);
-        osc.frequency().linear_ramp_to_value_at_time(20., 10.);
-        osc.start_at(0.);
+    //     let osc = context.create_oscillator();
+    //     osc.connect(&context.destination());
+    //     osc.set_type(OscillatorType::Sawtooth);
+    //     osc.frequency().set_value(2000.);
+    //     osc.frequency().linear_ramp_to_value_at_time(20., 10.);
+    //     osc.start_at(0.);
 
-        benchmark(&mut stdout, name, &mut context, &mut results);
-    }
+    //     benchmark(&mut stdout, name, &mut context, &mut results);
+    // }
 
     write!(
         stdout,

--- a/examples/benchmarks.rs
+++ b/examples/benchmarks.rs
@@ -130,30 +130,30 @@ fn main() {
         benchmark(&mut stdout, name, &mut context, &mut results);
     }
 
-    // {
-    //     let name = "Simple source test without resampling (Stereo and positionnal)";
+    {
+        let name = "Simple source test without resampling (Stereo and positionnal)";
 
-    //     let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
+        let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
 
-    //     let panner = context.create_panner();
-    //     panner.connect(&context.destination());
-    //     panner.position_x().set_value(1.);
-    //     panner.position_y().set_value(2.);
-    //     panner.position_z().set_value(3.);
-    //     panner.orientation_x().set_value(1.);
-    //     panner.orientation_y().set_value(2.);
-    //     panner.orientation_z().set_value(3.);
+        let panner = context.create_panner();
+        panner.connect(&context.destination());
+        panner.position_x().set_value(1.);
+        panner.position_y().set_value(2.);
+        panner.position_z().set_value(3.);
+        panner.orientation_x().set_value(1.);
+        panner.orientation_y().set_value(2.);
+        panner.orientation_z().set_value(3.);
 
-    //     let source = context.create_buffer_source();
-    //     source.connect(&panner);
+        let source = context.create_buffer_source();
+        source.connect(&panner);
 
-    //     let buf = get_buffer(&sources, sample_rate, 2);
-    //     source.set_buffer(buf);
-    //     source.set_loop(true);
-    //     source.start();
+        let buf = get_buffer(&sources, sample_rate, 2);
+        source.set_buffer(buf);
+        source.set_loop(true);
+        source.start();
 
-    //     benchmark(&mut stdout, name, &mut context, &mut results);
-    // }
+        benchmark(&mut stdout, name, &mut context, &mut results);
+    }
 
     {
         let name = "Simple source test with resampling (Mono)";
@@ -183,350 +183,350 @@ fn main() {
         benchmark(&mut stdout, name, &mut context, &mut results);
     }
 
-    // {
-    //     let name = "Simple source test with resampling (Stereo and positionnal)";
-
-    //     let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
-
-    //     let panner = context.create_panner();
-    //     panner.connect(&context.destination());
-    //     panner.position_x().set_value(1.);
-    //     panner.position_y().set_value(2.);
-    //     panner.position_z().set_value(3.);
-    //     panner.orientation_x().set_value(1.);
-    //     panner.orientation_y().set_value(2.);
-    //     panner.orientation_z().set_value(3.);
-
-    //     let source = context.create_buffer_source();
-    //     source.connect(&panner);
-
-    //     let buf = get_buffer(&sources, 38000., 2);
-    //     source.set_buffer(buf);
-    //     source.set_loop(true);
-    //     source.start();
-
-    //     benchmark(&mut stdout, name, &mut context, &mut results);
-    // }
-
-    // {
-    //     let name = "Upmix without resampling (Mono -> Stereo)";
-
-    //     let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
-    //     let source = context.create_buffer_source();
-    //     let buf = get_buffer(&sources, sample_rate, 1);
-    //     source.set_buffer(buf);
-    //     source.set_loop(true);
-    //     source.connect(&context.destination());
-    //     source.start();
-
-    //     benchmark(&mut stdout, name, &mut context, &mut results);
-    // }
-
-    // {
-    //     let name = "Downmix without resampling (Stereo -> Mono)";
-
-    //     let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
-    //     let source = context.create_buffer_source();
-    //     let buf = get_buffer(&sources, sample_rate, 2);
-    //     source.set_buffer(buf);
-    //     source.set_loop(true);
-    //     source.connect(&context.destination());
-    //     source.start();
-
-    //     benchmark(&mut stdout, name, &mut context, &mut results);
-    // }
-
-    // {
-    //     let name = "Simple mixing (100x same buffer) - be careful w/ volume here!";
-
-    //     let adjusted_duration = DURATION / 4;
-    //     let mut context =
-    //         OfflineAudioContext::new(1, adjusted_duration * sample_rate as usize, sample_rate);
-
-    //     for _ in 0..100 {
-    //         let source = context.create_buffer_source();
-    //         let buf = get_buffer(&sources, 38000., 1);
-    //         source.set_buffer(buf);
-    //         source.set_loop(true);
-    //         source.connect(&context.destination());
-    //         source.start();
-    //     }
-
-    //     benchmark(&mut stdout, name, &mut context, &mut results);
-    // }
-
-    // {
-    //     let name = "Simple mixing (100 different buffers) - be careful w/ volume here!";
-
-    //     let adjusted_duration = DURATION / 4;
-    //     let mut context =
-    //         OfflineAudioContext::new(1, adjusted_duration * sample_rate as usize, sample_rate);
-    //     let reference = get_buffer(&sources, 38000., 1);
-    //     let channel_data = reference.get_channel_data(0);
-
-    //     for _ in 0..100 {
-    //         let mut buffer = context.create_buffer(1, reference.length(), 38000.);
-    //         buffer.copy_to_channel(channel_data, 0);
-
-    //         let source = context.create_buffer_source();
-    //         source.set_buffer(buffer);
-    //         source.set_loop(true);
-    //         source.connect(&context.destination());
-    //         source.start();
-    //     }
-
-    //     benchmark(&mut stdout, name, &mut context, &mut results);
-    // }
-
-    // {
-    //     let name = "Simple mixing with gains";
-
-    //     let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
-
-    //     let gain = context.create_gain();
-    //     gain.connect(&context.destination());
-    //     gain.gain().set_value(-1.);
-
-    //     let mut gains_i = vec![];
-
-    //     for _ in 0..4 {
-    //         let gain_i = context.create_gain();
-    //         gain_i.connect(&gain);
-    //         gain_i.gain().set_value(0.25);
-    //         gains_i.push(gain_i);
-    //     }
-
-    //     for _ in 0..2 {
-    //         let buf = get_buffer(&sources, 38000., 1);
-
-    //         let source = context.create_buffer_source();
-    //         source.set_buffer(buf);
-    //         source.set_loop(true);
-    //         source.start();
-
-    //         for gain_i in gains_i.iter() {
-    //             let gain_ij = context.create_gain();
-    //             gain_ij.gain().set_value(0.5);
-    //             gain_ij.connect(gain_i);
-    //             source.connect(&gain_ij);
-    //         }
-    //     }
-
-    //     benchmark(&mut stdout, name, &mut context, &mut results);
-    // }
-
-    // {
-    //     let name = "Granular synthesis";
-
-    //     let adjusted_duration = DURATION as f64 / 16.;
-    //     let length = (adjusted_duration * sample_rate as f64) as usize;
-    //     let mut context = OfflineAudioContext::new(1, length, sample_rate);
-    //     let buffer = get_buffer(&sources, sample_rate, 1);
-    //     let mut offset = 0.;
-    //     let mut rng = rand::thread_rng();
-
-    //     // @todo - make a PR
-    //     // - problem w/ env.gain().set_value_at_time(0., offset);
-    //     // - variables are badly named, but just follow the source here
-
-    //     // this 1500 sources...
-    //     while offset < adjusted_duration {
-    //         let env = context.create_gain();
-    //         env.connect(&context.destination());
-
-    //         let src = context.create_buffer_source();
-    //         src.connect(&env);
-    //         src.set_buffer(buffer.clone());
-
-    //         let rand_start = rng.gen_range(0..1000) as f64 / 1000. * 0.5;
-    //         let rand_duration = rng.gen_range(0..1000) as f64 / 1000. * 0.999;
-    //         let start = offset * rand_start;
-    //         let end = start + 0.005 * rand_duration;
-    //         let start_release = (offset + end - start).max(0.);
-
-    //         env.gain().set_value_at_time(0., offset);
-    //         env.gain().linear_ramp_to_value_at_time(0.5, offset + 0.005);
-    //         env.gain().set_value_at_time(0.5, start_release);
-    //         env.gain()
-    //             .linear_ramp_to_value_at_time(0., start_release + 0.05);
-
-    //         src.start_at_with_offset_and_duration(offset, start, end);
-
-    //         offset += 0.005;
-    //     }
-
-    //     benchmark(&mut stdout, name, &mut context, &mut results);
-    // }
-
-    // {
-    //     let name = "Synth (Sawtooth with Envelope)";
-
-    //     let sample_rate = 44100.;
-    //     let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
-    //     let mut offset = 0.;
-
-    //     let duration = DURATION as f64;
-
-    //     while offset < duration {
-    //         let env = context.create_gain();
-    //         env.connect(&context.destination());
-
-    //         let osc = context.create_oscillator();
-    //         osc.connect(&env);
-    //         osc.set_type(OscillatorType::Sawtooth);
-    //         osc.frequency().set_value(110.);
+    {
+        let name = "Simple source test with resampling (Stereo and positionnal)";
+
+        let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
+
+        let panner = context.create_panner();
+        panner.connect(&context.destination());
+        panner.position_x().set_value(1.);
+        panner.position_y().set_value(2.);
+        panner.position_z().set_value(3.);
+        panner.orientation_x().set_value(1.);
+        panner.orientation_y().set_value(2.);
+        panner.orientation_z().set_value(3.);
+
+        let source = context.create_buffer_source();
+        source.connect(&panner);
+
+        let buf = get_buffer(&sources, 38000., 2);
+        source.set_buffer(buf);
+        source.set_loop(true);
+        source.start();
+
+        benchmark(&mut stdout, name, &mut context, &mut results);
+    }
+
+    {
+        let name = "Upmix without resampling (Mono -> Stereo)";
+
+        let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
+        let source = context.create_buffer_source();
+        let buf = get_buffer(&sources, sample_rate, 1);
+        source.set_buffer(buf);
+        source.set_loop(true);
+        source.connect(&context.destination());
+        source.start();
+
+        benchmark(&mut stdout, name, &mut context, &mut results);
+    }
+
+    {
+        let name = "Downmix without resampling (Stereo -> Mono)";
+
+        let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+        let source = context.create_buffer_source();
+        let buf = get_buffer(&sources, sample_rate, 2);
+        source.set_buffer(buf);
+        source.set_loop(true);
+        source.connect(&context.destination());
+        source.start();
+
+        benchmark(&mut stdout, name, &mut context, &mut results);
+    }
+
+    {
+        let name = "Simple mixing (100x same buffer) - be careful w/ volume here!";
+
+        let adjusted_duration = DURATION / 4;
+        let mut context =
+            OfflineAudioContext::new(1, adjusted_duration * sample_rate as usize, sample_rate);
+
+        for _ in 0..100 {
+            let source = context.create_buffer_source();
+            let buf = get_buffer(&sources, 38000., 1);
+            source.set_buffer(buf);
+            source.set_loop(true);
+            source.connect(&context.destination());
+            source.start();
+        }
+
+        benchmark(&mut stdout, name, &mut context, &mut results);
+    }
+
+    {
+        let name = "Simple mixing (100 different buffers) - be careful w/ volume here!";
+
+        let adjusted_duration = DURATION / 4;
+        let mut context =
+            OfflineAudioContext::new(1, adjusted_duration * sample_rate as usize, sample_rate);
+        let reference = get_buffer(&sources, 38000., 1);
+        let channel_data = reference.get_channel_data(0);
+
+        for _ in 0..100 {
+            let mut buffer = context.create_buffer(1, reference.length(), 38000.);
+            buffer.copy_to_channel(channel_data, 0);
+
+            let source = context.create_buffer_source();
+            source.set_buffer(buffer);
+            source.set_loop(true);
+            source.connect(&context.destination());
+            source.start();
+        }
+
+        benchmark(&mut stdout, name, &mut context, &mut results);
+    }
+
+    {
+        let name = "Simple mixing with gains";
+
+        let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+
+        let gain = context.create_gain();
+        gain.connect(&context.destination());
+        gain.gain().set_value(-1.);
+
+        let mut gains_i = vec![];
+
+        for _ in 0..4 {
+            let gain_i = context.create_gain();
+            gain_i.connect(&gain);
+            gain_i.gain().set_value(0.25);
+            gains_i.push(gain_i);
+        }
+
+        for _ in 0..2 {
+            let buf = get_buffer(&sources, 38000., 1);
+
+            let source = context.create_buffer_source();
+            source.set_buffer(buf);
+            source.set_loop(true);
+            source.start();
+
+            for gain_i in gains_i.iter() {
+                let gain_ij = context.create_gain();
+                gain_ij.gain().set_value(0.5);
+                gain_ij.connect(gain_i);
+                source.connect(&gain_ij);
+            }
+        }
+
+        benchmark(&mut stdout, name, &mut context, &mut results);
+    }
+
+    {
+        let name = "Granular synthesis";
+
+        let adjusted_duration = DURATION as f64 / 16.;
+        let length = (adjusted_duration * sample_rate as f64) as usize;
+        let mut context = OfflineAudioContext::new(1, length, sample_rate);
+        let buffer = get_buffer(&sources, sample_rate, 1);
+        let mut offset = 0.;
+        let mut rng = rand::thread_rng();
+
+        // @todo - make a PR
+        // - problem w/ env.gain().set_value_at_time(0., offset);
+        // - variables are badly named, but just follow the source here
+
+        // this 1500 sources...
+        while offset < adjusted_duration {
+            let env = context.create_gain();
+            env.connect(&context.destination());
+
+            let src = context.create_buffer_source();
+            src.connect(&env);
+            src.set_buffer(buffer.clone());
+
+            let rand_start = rng.gen_range(0..1000) as f64 / 1000. * 0.5;
+            let rand_duration = rng.gen_range(0..1000) as f64 / 1000. * 0.999;
+            let start = offset * rand_start;
+            let end = start + 0.005 * rand_duration;
+            let start_release = (offset + end - start).max(0.);
+
+            env.gain().set_value_at_time(0., offset);
+            env.gain().linear_ramp_to_value_at_time(0.5, offset + 0.005);
+            env.gain().set_value_at_time(0.5, start_release);
+            env.gain()
+                .linear_ramp_to_value_at_time(0., start_release + 0.05);
+
+            src.start_at_with_offset_and_duration(offset, start, end);
+
+            offset += 0.005;
+        }
+
+        benchmark(&mut stdout, name, &mut context, &mut results);
+    }
+
+    {
+        let name = "Synth (Sawtooth with Envelope)";
+
+        let sample_rate = 44100.;
+        let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+        let mut offset = 0.;
+
+        let duration = DURATION as f64;
+
+        while offset < duration {
+            let env = context.create_gain();
+            env.connect(&context.destination());
+
+            let osc = context.create_oscillator();
+            osc.connect(&env);
+            osc.set_type(OscillatorType::Sawtooth);
+            osc.frequency().set_value(110.);
 
-    //         env.gain().set_value_at_time(0., 0.);
-    //         env.gain().set_value_at_time(0.5, offset);
-    //         env.gain().set_target_at_time(0., offset + 0.01, 0.1);
-    //         osc.start_at(offset);
-    //         osc.stop_at(offset + 1.); // why not 0.1 ?
+            env.gain().set_value_at_time(0., 0.);
+            env.gain().set_value_at_time(0.5, offset);
+            env.gain().set_target_at_time(0., offset + 0.01, 0.1);
+            osc.start_at(offset);
+            osc.stop_at(offset + 1.); // why not 0.1 ?
 
-    //         offset += 140. / 60. / 4.; // 140 bpm (?)
-    //     }
+            offset += 140. / 60. / 4.; // 140 bpm (?)
+        }
 
-    //     benchmark(&mut stdout, name, &mut context, &mut results);
-    // }
+        benchmark(&mut stdout, name, &mut context, &mut results);
+    }
 
-    // {
-    //     let name = "Synth (Sawtooth with gain - no automation)";
+    {
+        let name = "Synth (Sawtooth with gain - no automation)";
 
-    //     let sample_rate = 44100.;
-    //     let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
-    //     let mut offset = 0.;
+        let sample_rate = 44100.;
+        let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+        let mut offset = 0.;
 
-    //     let duration = DURATION as f64;
+        let duration = DURATION as f64;
 
-    //     while offset < duration {
-    //         let env = context.create_gain();
-    //         env.connect(&context.destination());
+        while offset < duration {
+            let env = context.create_gain();
+            env.connect(&context.destination());
 
-    //         let osc = context.create_oscillator();
-    //         osc.connect(&env);
-    //         osc.set_type(OscillatorType::Sawtooth);
-    //         osc.frequency().set_value(110.);
-    //         osc.start_at(offset);
-    //         osc.stop_at(offset + 1.); // why not 0.1 ?
+            let osc = context.create_oscillator();
+            osc.connect(&env);
+            osc.set_type(OscillatorType::Sawtooth);
+            osc.frequency().set_value(110.);
+            osc.start_at(offset);
+            osc.stop_at(offset + 1.); // why not 0.1 ?
 
-    //         offset += 140. / 60. / 4.; // 140 bpm (?)
-    //     }
+            offset += 140. / 60. / 4.; // 140 bpm (?)
+        }
 
-    //     benchmark(&mut stdout, name, &mut context, &mut results);
-    // }
+        benchmark(&mut stdout, name, &mut context, &mut results);
+    }
 
-    // {
-    //     let name = "Synth (Sawtooth without gain)";
+    {
+        let name = "Synth (Sawtooth without gain)";
 
-    //     let sample_rate = 44100.;
-    //     let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
-    //     let mut offset = 0.;
+        let sample_rate = 44100.;
+        let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+        let mut offset = 0.;
 
-    //     let duration = DURATION as f64;
+        let duration = DURATION as f64;
 
-    //     while offset < duration {
-    //         let osc = context.create_oscillator();
-    //         osc.connect(&context.destination());
-    //         osc.set_type(OscillatorType::Sawtooth);
-    //         osc.frequency().set_value(110.);
-    //         osc.start_at(offset);
-    //         osc.stop_at(offset + 1.); // why not 0.1 ?
+        while offset < duration {
+            let osc = context.create_oscillator();
+            osc.connect(&context.destination());
+            osc.set_type(OscillatorType::Sawtooth);
+            osc.frequency().set_value(110.);
+            osc.start_at(offset);
+            osc.stop_at(offset + 1.); // why not 0.1 ?
 
-    //         offset += 140. / 60. / 4.; // 140 bpm (?)
-    //     }
+            offset += 140. / 60. / 4.; // 140 bpm (?)
+        }
 
-    //     benchmark(&mut stdout, name, &mut context, &mut results);
-    // }
+        benchmark(&mut stdout, name, &mut context, &mut results);
+    }
 
-    // {
-    //     let name = "Substractive Synth";
+    {
+        let name = "Substractive Synth";
 
-    //     let sample_rate = 44100.;
-    //     let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
-    //     let mut offset = 0.;
+        let sample_rate = 44100.;
+        let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+        let mut offset = 0.;
 
-    //     let filter = context.create_biquad_filter();
-    //     filter.connect(&context.destination());
-    //     filter.frequency().set_value_at_time(0., 0.);
-    //     filter.q().set_value_at_time(20., 0.);
+        let filter = context.create_biquad_filter();
+        filter.connect(&context.destination());
+        filter.frequency().set_value_at_time(0., 0.);
+        filter.q().set_value_at_time(20., 0.);
 
-    //     let env = context.create_gain();
-    //     env.connect(&filter);
-    //     env.gain().set_value_at_time(0., 0.);
+        let env = context.create_gain();
+        env.connect(&filter);
+        env.gain().set_value_at_time(0., 0.);
 
-    //     let osc = context.create_oscillator();
-    //     osc.connect(&env);
-    //     osc.set_type(OscillatorType::Sawtooth);
-    //     osc.frequency().set_value(110.);
-    //     osc.start();
+        let osc = context.create_oscillator();
+        osc.connect(&env);
+        osc.set_type(OscillatorType::Sawtooth);
+        osc.frequency().set_value(110.);
+        osc.start();
 
-    //     let duration = DURATION as f64;
+        let duration = DURATION as f64;
 
-    //     while offset < duration {
-    //         env.gain().set_value_at_time(1., offset);
-    //         env.gain().set_target_at_time(0., offset, 0.1);
+        while offset < duration {
+            env.gain().set_value_at_time(1., offset);
+            env.gain().set_target_at_time(0., offset, 0.1);
 
-    //         filter.frequency().set_value_at_time(0., offset);
-    //         filter.frequency().set_target_at_time(3500., offset, 0.03);
+            filter.frequency().set_value_at_time(0., offset);
+            filter.frequency().set_target_at_time(3500., offset, 0.03);
 
-    //         offset += 140. / 60. / 16.; // 140 bpm (?)
-    //     }
+            offset += 140. / 60. / 16.; // 140 bpm (?)
+        }
 
-    //     benchmark(&mut stdout, name, &mut context, &mut results);
-    // }
+        benchmark(&mut stdout, name, &mut context, &mut results);
+    }
 
-    // {
-    //     let name = "Stereo panning";
+    {
+        let name = "Stereo panning";
 
-    //     let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
+        let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
 
-    //     let panner = context.create_stereo_panner();
-    //     panner.connect(&context.destination());
-    //     panner.pan().set_value(0.1);
+        let panner = context.create_stereo_panner();
+        panner.connect(&context.destination());
+        panner.pan().set_value(0.1);
 
-    //     let src = context.create_buffer_source();
-    //     let buffer = get_buffer(&sources, sample_rate, 2);
-    //     src.connect(&panner);
-    //     src.set_buffer(buffer);
-    //     src.set_loop(true);
-    //     src.start();
+        let src = context.create_buffer_source();
+        let buffer = get_buffer(&sources, sample_rate, 2);
+        src.connect(&panner);
+        src.set_buffer(buffer);
+        src.set_loop(true);
+        src.start();
 
-    //     benchmark(&mut stdout, name, &mut context, &mut results);
-    // }
+        benchmark(&mut stdout, name, &mut context, &mut results);
+    }
 
-    // {
-    //     let name = "Stereo panning with automation";
+    {
+        let name = "Stereo panning with automation";
 
-    //     let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
+        let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
 
-    //     let panner = context.create_stereo_panner();
-    //     panner.connect(&context.destination());
-    //     panner.pan().set_value_at_time(-1., 0.);
-    //     panner.pan().set_value_at_time(0.2, 0.5);
+        let panner = context.create_stereo_panner();
+        panner.connect(&context.destination());
+        panner.pan().set_value_at_time(-1., 0.);
+        panner.pan().set_value_at_time(0.2, 0.5);
 
-    //     let src = context.create_buffer_source();
-    //     let buffer = get_buffer(&sources, sample_rate, 2);
-    //     src.connect(&panner);
-    //     src.set_buffer(buffer);
-    //     src.set_loop(true);
-    //     src.start();
+        let src = context.create_buffer_source();
+        let buffer = get_buffer(&sources, sample_rate, 2);
+        src.connect(&panner);
+        src.set_buffer(buffer);
+        src.set_loop(true);
+        src.start();
 
-    //     benchmark(&mut stdout, name, &mut context, &mut results);
-    // }
+        benchmark(&mut stdout, name, &mut context, &mut results);
+    }
 
-    // {
-    //     let name = "Sawtooth with automation";
+    {
+        let name = "Sawtooth with automation";
 
-    //     let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+        let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
 
-    //     let osc = context.create_oscillator();
-    //     osc.connect(&context.destination());
-    //     osc.set_type(OscillatorType::Sawtooth);
-    //     osc.frequency().set_value(2000.);
-    //     osc.frequency().linear_ramp_to_value_at_time(20., 10.);
-    //     osc.start_at(0.);
+        let osc = context.create_oscillator();
+        osc.connect(&context.destination());
+        osc.set_type(OscillatorType::Sawtooth);
+        osc.frequency().set_value(2000.);
+        osc.frequency().linear_ramp_to_value_at_time(20., 10.);
+        osc.start_at(0.);
 
-    //     benchmark(&mut stdout, name, &mut context, &mut results);
-    // }
+        benchmark(&mut stdout, name, &mut context, &mut results);
+    }
 
     write!(
         stdout,

--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -180,10 +180,7 @@ impl AudioBufferSourceNode {
                 detune: d_proc,
                 playback_rate: pr_proc,
                 render_state: AudioBufferRendererState::default(),
-                // `internal_buffer` is used to compute the samples per channel at each frame. Note
-                // that the `vec` will always be resized to actual buffer number_of_channels when
-                // received on the render thread.
-                internal_buffer: Vec::<f32>::with_capacity(crate::MAX_CHANNELS),
+                positions: [-1.; RENDER_QUANTUM_SIZE],
             };
 
             let node = Self {
@@ -327,7 +324,10 @@ struct AudioBufferSourceRenderer {
     detune: AudioParamId,
     playback_rate: AudioParamId,
     render_state: AudioBufferRendererState,
-    internal_buffer: Vec<f32>,
+    /// Internal buffer used to compute the position to be played in the
+    /// source buffer per sample.
+    /// By convention a position of -1. means output should be zero.
+    positions: [f64; RENDER_QUANTUM_SIZE],
 }
 
 impl AudioProcessor for AudioBufferSourceRenderer {
@@ -347,10 +347,7 @@ impl AudioProcessor for AudioBufferSourceRenderer {
         let next_block_time = scope.current_time + dt * num_frames as f64;
 
         if let Ok(msg) = self.receiver.try_recv() {
-            let buffer = msg.0;
-
-            self.internal_buffer.resize(buffer.number_of_channels(), 0.);
-            self.buffer = Some(buffer);
+            self.buffer = Some(msg.0);
         }
 
         // grab all timing informations
@@ -445,13 +442,13 @@ impl AudioProcessor for AudioBufferSourceRenderer {
             self.render_state.entered_loop = false;
         }
 
+        // compute position for each sample and push into self.positionsq
         for index in 0..num_frames {
             if current_time < start_time
                 || current_time >= stop_time
                 || self.render_state.buffer_time_elapsed >= duration
             {
-                self.internal_buffer.fill(0.);
-                output.set_channels_values_at(index, &self.internal_buffer);
+                self.positions[index] = -1.;
                 current_time += dt;
 
                 continue; // nothing more to do for this sample
@@ -506,64 +503,59 @@ impl AudioProcessor for AudioBufferSourceRenderer {
                 && self.render_state.buffer_time < buffer_duration
             {
                 let position = self.render_state.buffer_time * sampling_ratio;
-                self.compute_playback_at_position(position, sample_rate);
+                self.positions[index] = position;
             } else {
-                self.internal_buffer.fill(0.);
+                self.positions[index] = -1.;
             }
 
-            output.set_channels_values_at(index, &self.internal_buffer);
-
-            self.render_state.buffer_time += dt * computed_playback_rate;
-            self.render_state.buffer_time_elapsed += dt * computed_playback_rate;
+            let time_incr = dt * computed_playback_rate;
+            self.render_state.buffer_time += time_incr;
+            self.render_state.buffer_time_elapsed += time_incr;
             current_time += dt;
         }
 
+        // fill output according to computed positions
+        self.buffer
+            .as_ref()
+            .unwrap()
+            .channels()
+            .iter()
+            .zip(output.channels_mut().iter_mut())
+            .for_each(|(buffer_channel, output_channel)| {
+                let buffer_channel = buffer_channel.as_slice();
+
+                self.positions
+                    .iter()
+                    .zip(output_channel.iter_mut())
+                    .for_each(|(position, o)| {
+                        if *position == -1. {
+                            *o = 0.;
+                        } else {
+                            let playhead = position * sample_rate;
+                            let playhead_floored = playhead.floor();
+                            let prev_index = playhead_floored as usize; // can't be < 0.
+                            let next_index = playhead.ceil() as usize; // can be >= length
+
+                            let k = (playhead - playhead_floored) as f32;
+                            let k_inv = 1. - k;
+
+                            let prev_sample = buffer_channel[prev_index];
+                            let next_sample = if next_index >= buffer_channel.len() {
+                                0.
+                            } else {
+                                buffer_channel[next_index]
+                            };
+
+                            // @todo - [spec] If |position| is greater than or equal to |loopEnd|
+                            // and there is no subsequent sample frame in buffer, then interpolation
+                            // should be based on the sequence of subsequent frames beginning at |loopStart|.
+                            let value = k_inv * prev_sample + k * next_sample;
+                            *o = value;
+                        }
+                    });
+            });
+
         true
-    }
-}
-
-impl AudioBufferSourceRenderer {
-    // Pick the closest index to the given position
-    //
-    // @note - this is not used but we keep that around as it could be usefull
-    // for testing and/or to for perf improvement if the playback is aligned on
-    // `sample_rate` and `playback_rate.abs() = 1` and as not been modified
-    #[allow(dead_code)]
-    fn compute_playback_at_position_direct(&mut self, position: f64, sample_rate: f64) {
-        let sample_index = (position * sample_rate).round() as usize;
-
-        let iterator = self.buffer.as_ref().unwrap().channels().iter().enumerate();
-        for (channel_index, channel) in iterator {
-            self.internal_buffer[channel_index] = channel.as_slice()[sample_index];
-        }
-    }
-
-    // Linear interpolate betwen tow frames according to a given position
-    fn compute_playback_at_position(&mut self, position: f64, sample_rate: f64) {
-        let playhead = position * sample_rate;
-        let playhead_floored = playhead.floor();
-        let prev_index = playhead_floored as usize; // can't be < 0.
-        let next_index = playhead.ceil() as usize; // can be >= length
-
-        let k = (playhead - playhead_floored) as f32;
-        let k_inv = 1. - k;
-
-        let iterator = self.buffer.as_ref().unwrap().channels().iter().enumerate();
-        for (channel_index, channel) in iterator {
-            // @todo - [spec] If |position| is greater than or equal to |loopEnd|
-            // and there is no subsequent sample frame in buffer, then interpolation
-            // should be based on the sequence of subsequent frames beginning at |loopStart|.
-            //
-            // for now we just interpolate with zero
-            let prev_sample = channel.as_slice()[prev_index];
-            let next_sample = if next_index >= channel.len() {
-                0.
-            } else {
-                channel.as_slice()[next_index]
-            };
-            let value = k_inv * prev_sample + k * next_sample;
-            self.internal_buffer[channel_index] = value;
-        }
     }
 }
 

--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -541,10 +541,9 @@ impl AudioProcessor for AudioBufferSourceRenderer {
                                     None => 0.,
                                 };
 
-                                let value = (1. - k) * prev_sample + k * next_sample;
-                                value
+                                (1. - k) * prev_sample + k * next_sample
                             }
-                            None => 0.
+                            None => 0.,
                         };
                     });
             });

--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -442,7 +442,7 @@ impl AudioProcessor for AudioBufferSourceRenderer {
             self.render_state.entered_loop = false;
         }
 
-        // compute position for each sample and push into self.positionsq
+        // compute position for each sample and store into `self.positions`
         for index in 0..num_frames {
             if current_time < start_time
                 || current_time >= stop_time

--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -543,7 +543,7 @@ impl AudioProcessor for AudioBufferSourceRenderer {
 
                                 (1. - k) * prev_sample + k * next_sample
                             }
-                            None => 0.,
+                            None => 0.
                         };
                     });
             });

--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -539,16 +539,17 @@ impl AudioProcessor for AudioBufferSourceRenderer {
                             let k = (playhead - playhead_floored) as f32;
                             let k_inv = 1. - k;
 
-                            let prev_sample = buffer_channel[prev_index];
-                            let next_sample = if next_index >= buffer_channel.len() {
-                                0.
-                            } else {
-                                buffer_channel[next_index]
-                            };
-
                             // @todo - [spec] If |position| is greater than or equal to |loopEnd|
                             // and there is no subsequent sample frame in buffer, then interpolation
                             // should be based on the sequence of subsequent frames beginning at |loopStart|.
+
+                            // `prev_index` cannot be out of bounds
+                            let prev_sample = buffer_channel[prev_index];
+                            let next_sample = match buffer_channel.get(next_index) {
+                                Some(val) => *val,
+                                None => 0.,
+                            };
+
                             let value = k_inv * prev_sample + k * next_sample;
                             *o = value;
                         }

--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -543,7 +543,7 @@ impl AudioProcessor for AudioBufferSourceRenderer {
 
                                 (1. - k) * prev_sample + k * next_sample
                             }
-                            None => 0.
+                            None => 0.,
                         };
                     });
             });


### PR DESCRIPTION
Hey,

A first progress in improving `AudioScheduledSourceNode` performances

Mostly reviewed how output is created:
- fill `output` channel by channel to access memory in an aligned way
- uses more functional paradigms

This improves perf between 1.3 and 1.5 in benchmarks on my mac, which I think is really outside the noise

### before

| id      | name                                                                     | duration (ms) | Speedup vs. realtime  | buffer.duration (s) |
| - | - | - | - | - |
| 2       | Simple source test without resampling (Mono)                             | 147           | 816.3x                | 120 |
| 3       | Simple source test without resampling (Stereo)                           | 193           | 621.8x                | 120 |
| 4       | Simple source test with resampling (Mono)                                | 145           | 827.6x                | 120 |
| 5       | Simple source test with resampling (Stereo)                              | 195           | 615.4x                | 120 |

### after

| id      | name                                                                     | duration (ms) | Speedup vs. realtime  | buffer.duration (s)
| - | - | - | - | - |
| 2       | Simple source test without resampling (Mono)                             | 98            | 1224.5x               | 120
| 3       | Simple source test without resampling (Stereo)                           | 141           | 851.1x                | 120
| 4       | Simple source test with resampling (Mono)                                | 98            | 1224.5x               | 120
| 5       | Simple source test with resampling (Stereo)                              | 140           | 857.1x                | 120

I would be interested if you see the same kind of changes on your side ?

In any case, do not merge yet, I would also like to try something else.

I think we could also apply that strategy to the delay node (which also would allow to remove `set_channels_values_at` fomr `AudioRenderQuantum`)

### edit after 023e767

| id      | name                                                                     | duration (ms) | Speedup vs. realtime  | buffer.duration (s)
| - | - | - | - | - |
| 2       | Simple source test without resampling (Mono)                             | 90            | 1333.3x               | 120
| 3       | Simple source test without resampling (Stereo)                           | 108           | 1111.1x               | 120
| 4       | Simple source test with resampling (Mono)                                | 91            | 1318.7x               | 120
| 5       | Simple source test with resampling (Stereo)                              | 110           | 1090.9x               | 120