### PR TITLE
Make OfflineAudiocontext `Send` and `Sync`

### DIFF
--- a/examples/benchmarks.rs
+++ b/examples/benchmarks.rs
@@ -47,7 +47,7 @@ fn get_buffer(sources: &[AudioBuffer], sample_rate: f32, number_of_channels: usi
 fn benchmark<'a>(
     stdout: &mut termion::raw::RawTerminal<std::io::Stdout>,
     name: &'a str,
-    context: &mut OfflineAudioContext,
+    context: OfflineAudioContext,
     results: &mut Vec<BenchResult<'a>>,
 ) {
     write!(
@@ -97,15 +97,15 @@ fn main() {
     {
         let name = "Baseline (silence)";
 
-        let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
+        let context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
 
-        benchmark(&mut stdout, name, &mut context, &mut results);
+        benchmark(&mut stdout, name, context, &mut results);
     }
 
     {
         let name = "Simple source test without resampling (Mono)";
 
-        let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+        let context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
         let source = context.create_buffer_source();
         let buf = get_buffer(&sources, sample_rate, 1);
         source.set_buffer(buf);
@@ -113,13 +113,13 @@ fn main() {
         source.connect(&context.destination());
         source.start();
 
-        benchmark(&mut stdout, name, &mut context, &mut results);
+        benchmark(&mut stdout, name, context, &mut results);
     }
 
     {
         let name = "Simple source test without resampling (Stereo)";
 
-        let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
+        let context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
         let source = context.create_buffer_source();
         let buf = get_buffer(&sources, sample_rate, 2);
         source.set_buffer(buf);
@@ -127,13 +127,13 @@ fn main() {
         source.connect(&context.destination());
         source.start();
 
-        benchmark(&mut stdout, name, &mut context, &mut results);
+        benchmark(&mut stdout, name, context, &mut results);
     }
 
     {
         let name = "Simple source test without resampling (Stereo and positionnal)";
 
-        let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
+        let context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
 
         let panner = context.create_panner();
         panner.connect(&context.destination());
@@ -152,13 +152,13 @@ fn main() {
         source.set_loop(true);
         source.start();
 
-        benchmark(&mut stdout, name, &mut context, &mut results);
+        benchmark(&mut stdout, name, context, &mut results);
     }
 
     {
         let name = "Simple source test with resampling (Mono)";
 
-        let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+        let context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
         let source = context.create_buffer_source();
         let buf = get_buffer(&sources, 38000., 1);
         source.set_buffer(buf);
@@ -166,13 +166,13 @@ fn main() {
         source.connect(&context.destination());
         source.start();
 
-        benchmark(&mut stdout, name, &mut context, &mut results);
+        benchmark(&mut stdout, name, context, &mut results);
     }
 
     {
         let name = "Simple source test with resampling (Stereo)";
 
-        let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
+        let context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
         let source = context.create_buffer_source();
         let buf = get_buffer(&sources, 38000., 2);
         source.set_buffer(buf);
@@ -180,13 +180,13 @@ fn main() {
         source.connect(&context.destination());
         source.start();
 
-        benchmark(&mut stdout, name, &mut context, &mut results);
+        benchmark(&mut stdout, name, context, &mut results);
     }
 
     {
         let name = "Simple source test with resampling (Stereo and positionnal)";
 
-        let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
+        let context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
 
         let panner = context.create_panner();
         panner.connect(&context.destination());
@@ -205,13 +205,13 @@ fn main() {
         source.set_loop(true);
         source.start();
 
-        benchmark(&mut stdout, name, &mut context, &mut results);
+        benchmark(&mut stdout, name, context, &mut results);
     }
 
     {
         let name = "Upmix without resampling (Mono -> Stereo)";
 
-        let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
+        let context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
         let source = context.create_buffer_source();
         let buf = get_buffer(&sources, sample_rate, 1);
         source.set_buffer(buf);
@@ -219,13 +219,13 @@ fn main() {
         source.connect(&context.destination());
         source.start();
 
-        benchmark(&mut stdout, name, &mut context, &mut results);
+        benchmark(&mut stdout, name, context, &mut results);
     }
 
     {
         let name = "Downmix without resampling (Stereo -> Mono)";
 
-        let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+        let context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
         let source = context.create_buffer_source();
         let buf = get_buffer(&sources, sample_rate, 2);
         source.set_buffer(buf);
@@ -233,14 +233,14 @@ fn main() {
         source.connect(&context.destination());
         source.start();
 
-        benchmark(&mut stdout, name, &mut context, &mut results);
+        benchmark(&mut stdout, name, context, &mut results);
     }
 
     {
         let name = "Simple mixing (100x same buffer) - be careful w/ volume here!";
 
         let adjusted_duration = DURATION / 4;
-        let mut context =
+        let context =
             OfflineAudioContext::new(1, adjusted_duration * sample_rate as usize, sample_rate);
 
         for _ in 0..100 {
@@ -252,14 +252,14 @@ fn main() {
             source.start();
         }
 
-        benchmark(&mut stdout, name, &mut context, &mut results);
+        benchmark(&mut stdout, name, context, &mut results);
     }
 
     {
         let name = "Simple mixing (100 different buffers) - be careful w/ volume here!";
 
         let adjusted_duration = DURATION / 4;
-        let mut context =
+        let context =
             OfflineAudioContext::new(1, adjusted_duration * sample_rate as usize, sample_rate);
         let reference = get_buffer(&sources, 38000., 1);
         let channel_data = reference.get_channel_data(0);
@@ -275,13 +275,13 @@ fn main() {
             source.start();
         }
 
-        benchmark(&mut stdout, name, &mut context, &mut results);
+        benchmark(&mut stdout, name, context, &mut results);
     }
 
     {
         let name = "Simple mixing with gains";
 
-        let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+        let context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
 
         let gain = context.create_gain();
         gain.connect(&context.destination());
@@ -312,7 +312,7 @@ fn main() {
             }
         }
 
-        benchmark(&mut stdout, name, &mut context, &mut results);
+        benchmark(&mut stdout, name, context, &mut results);
     }
 
     {
@@ -320,7 +320,7 @@ fn main() {
 
         let adjusted_duration = DURATION as f64 / 16.;
         let length = (adjusted_duration * sample_rate as f64) as usize;
-        let mut context = OfflineAudioContext::new(1, length, sample_rate);
+        let context = OfflineAudioContext::new(1, length, sample_rate);
         let buffer = get_buffer(&sources, sample_rate, 1);
         let mut offset = 0.;
         let mut rng = rand::thread_rng();
@@ -355,14 +355,14 @@ fn main() {
             offset += 0.005;
         }
 
-        benchmark(&mut stdout, name, &mut context, &mut results);
+        benchmark(&mut stdout, name, context, &mut results);
     }
 
     {
         let name = "Synth (Sawtooth with Envelope)";
 
         let sample_rate = 44100.;
-        let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+        let context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
         let mut offset = 0.;
 
         let duration = DURATION as f64;
@@ -385,14 +385,14 @@ fn main() {
             offset += 140. / 60. / 4.; // 140 bpm (?)
         }
 
-        benchmark(&mut stdout, name, &mut context, &mut results);
+        benchmark(&mut stdout, name, context, &mut results);
     }
 
     {
         let name = "Synth (Sawtooth with gain - no automation)";
 
         let sample_rate = 44100.;
-        let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+        let context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
         let mut offset = 0.;
 
         let duration = DURATION as f64;
@@ -411,14 +411,14 @@ fn main() {
             offset += 140. / 60. / 4.; // 140 bpm (?)
         }
 
-        benchmark(&mut stdout, name, &mut context, &mut results);
+        benchmark(&mut stdout, name, context, &mut results);
     }
 
     {
         let name = "Synth (Sawtooth without gain)";
 
         let sample_rate = 44100.;
-        let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+        let context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
         let mut offset = 0.;
 
         let duration = DURATION as f64;
@@ -434,14 +434,14 @@ fn main() {
             offset += 140. / 60. / 4.; // 140 bpm (?)
         }
 
-        benchmark(&mut stdout, name, &mut context, &mut results);
+        benchmark(&mut stdout, name, context, &mut results);
     }
 
     {
         let name = "Substractive Synth";
 
         let sample_rate = 44100.;
-        let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+        let context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
         let mut offset = 0.;
 
         let filter = context.create_biquad_filter();
@@ -471,13 +471,13 @@ fn main() {
             offset += 140. / 60. / 16.; // 140 bpm (?)
         }
 
-        benchmark(&mut stdout, name, &mut context, &mut results);
+        benchmark(&mut stdout, name, context, &mut results);
     }
 
     {
         let name = "Stereo panning";
 
-        let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
+        let context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
 
         let panner = context.create_stereo_panner();
         panner.connect(&context.destination());
@@ -490,13 +490,13 @@ fn main() {
         src.set_loop(true);
         src.start();
 
-        benchmark(&mut stdout, name, &mut context, &mut results);
+        benchmark(&mut stdout, name, context, &mut results);
     }
 
     {
         let name = "Stereo panning with automation";
 
-        let mut context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
+        let context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
 
         let panner = context.create_stereo_panner();
         panner.connect(&context.destination());
@@ -510,13 +510,13 @@ fn main() {
         src.set_loop(true);
         src.start();
 
-        benchmark(&mut stdout, name, &mut context, &mut results);
+        benchmark(&mut stdout, name, context, &mut results);
     }
 
     {
         let name = "Sawtooth with automation";
 
-        let mut context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+        let context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
 
         let osc = context.create_oscillator();
         osc.connect(&context.destination());
@@ -525,7 +525,7 @@ fn main() {
         osc.frequency().linear_ramp_to_value_at_time(20., 10.);
         osc.start_at(0.);
 
-        benchmark(&mut stdout, name, &mut context, &mut results);
+        benchmark(&mut stdout, name, context, &mut results);
     }
 
     write!(

--- a/examples/decode_multithreaded.rs
+++ b/examples/decode_multithreaded.rs
@@ -1,0 +1,34 @@
+use float_eq::assert_float_eq;
+use std::sync::Arc;
+use web_audio_api::context::{BaseAudioContext, OfflineAudioContext};
+
+pub fn main() {
+    // Setup an OfflineAudioContext for decoding, the actual length and channel count do not matter
+    let context = OfflineAudioContext::new(2, 100, 44100.);
+
+    // We need shared ownership of the context because the Rust compiler cannot infer that our
+    // threads will not outlive the main thread.
+    //
+    // TODO update after Rust 1.63 to use scoped threads
+    let context = Arc::new(context);
+
+    // Setup five threads and let them decode audio buffers concurrently
+    let handles = (0..5).into_iter().map(|_| {
+        let context = context.clone();
+        std::thread::spawn(move || {
+            let file = std::fs::File::open("samples/sample.wav").unwrap();
+            let audio_buffer = context.decode_audio_data_sync(file).unwrap();
+            audio_buffer
+        })
+    });
+
+    // Await the concurrent threads and validate their results
+    handles.for_each(|handle| {
+        let audio_buffer = handle.join().unwrap();
+
+        assert_eq!(audio_buffer.sample_rate(), context.sample_rate());
+        assert_eq!(audio_buffer.length(), 142_187);
+        assert_eq!(audio_buffer.number_of_channels(), 2);
+        assert_float_eq!(audio_buffer.duration(), 3.224, abs_all <= 0.001);
+    });
+}

--- a/src/context/base.rs
+++ b/src/context/base.rs
@@ -53,7 +53,7 @@ pub trait BaseAudioContext {
     ///
     /// This method returns an Error in various cases (IO, mime sniffing, decoding).
     ///
-    /// # Example
+    /// # Usage
     ///
     /// ```no_run
     /// use std::io::Cursor;
@@ -69,6 +69,12 @@ pub trait BaseAudioContext {
     /// // await result from the decoder thread
     /// let decode_buffer_result = handle.join();
     /// ```
+    ///
+    /// # Examples
+    ///
+    /// The following example shows how to use a thread pool for audio buffer decoding:
+    ///
+    /// `cargo run --release --example decode_multithreaded`
     fn decode_audio_data_sync<R: std::io::Read + Send + Sync + 'static>(
         &self,
         input: R,

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -121,6 +121,12 @@ mod tests {
     }
 
     #[test]
+    fn test_offline_audio_context_send_sync() {
+        let context = OfflineAudioContext::new(1, 0, 44100.);
+        require_send_sync_static(context);
+    }
+
+    #[test]
     fn test_sample_rate_length() {
         let context = OfflineAudioContext::new(1, 48000, 96000.);
         assert_float_eq!(context.sample_rate(), 96000., abs_all <= 0.);

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -64,7 +64,7 @@ pub struct AudioContext {
     base: ConcreteBaseAudioContext,
     /// cpal stream (play/pause functionality)
     #[cfg(not(test))] // in tests, do not set up a cpal Stream
-    stream: Mutex<Option<Stream>>,
+    stream: Arc<Mutex<Option<Stream>>>,
     /// delay between render and actual system audio output
     output_latency: Arc<AtomicF64>,
 }
@@ -129,7 +129,7 @@ impl AudioContext {
 
         Self {
             base,
-            stream: Mutex::new(Some(stream)),
+            stream: Arc::new(Mutex::new(Some(stream))),
             output_latency,
         }
     }

--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -564,7 +564,7 @@ mod tests {
 
     #[test]
     fn test_playing_some_file() {
-        let mut context = OfflineAudioContext::new(2, RENDER_QUANTUM_SIZE, 44_100.);
+        let context = OfflineAudioContext::new(2, RENDER_QUANTUM_SIZE, 44_100.);
 
         let file = std::fs::File::open("samples/sample.wav").unwrap();
         let audio_buffer = context.decode_audio_data_sync(file).unwrap();
@@ -594,7 +594,7 @@ mod tests {
     #[test]
     fn test_sub_quantum_start() {
         let sample_rate = 480000.;
-        let mut context = OfflineAudioContext::new(1, RENDER_QUANTUM_SIZE, sample_rate);
+        let context = OfflineAudioContext::new(1, RENDER_QUANTUM_SIZE, sample_rate);
 
         let mut dirac = context.create_buffer(1, 1, sample_rate);
         dirac.copy_to_channel(&[1.], 0);
@@ -617,7 +617,7 @@ mod tests {
     fn test_sub_sample_start() {
         // sub sample
         let sample_rate = 480000.;
-        let mut context = OfflineAudioContext::new(1, RENDER_QUANTUM_SIZE, sample_rate);
+        let context = OfflineAudioContext::new(1, RENDER_QUANTUM_SIZE, sample_rate);
 
         let mut dirac = context.create_buffer(1, 1, sample_rate);
         dirac.copy_to_channel(&[1.], 0);
@@ -639,7 +639,7 @@ mod tests {
     #[test]
     fn test_sub_quantum_stop() {
         let sample_rate = 480000.;
-        let mut context = OfflineAudioContext::new(1, RENDER_QUANTUM_SIZE, sample_rate);
+        let context = OfflineAudioContext::new(1, RENDER_QUANTUM_SIZE, sample_rate);
 
         let mut dirac = context.create_buffer(1, RENDER_QUANTUM_SIZE, sample_rate);
         dirac.copy_to_channel(&[0., 0., 0., 0., 1.], 0);
@@ -661,7 +661,7 @@ mod tests {
     #[test]
     fn test_sub_sample_stop() {
         let sample_rate = 480000.;
-        let mut context = OfflineAudioContext::new(1, RENDER_QUANTUM_SIZE, sample_rate);
+        let context = OfflineAudioContext::new(1, RENDER_QUANTUM_SIZE, sample_rate);
 
         let mut dirac = context.create_buffer(1, RENDER_QUANTUM_SIZE, sample_rate);
         dirac.copy_to_channel(&[0., 0., 0., 0., 1., 1.], 0);
@@ -685,7 +685,7 @@ mod tests {
     #[test]
     fn test_schedule_in_the_past() {
         let sample_rate = 48000.;
-        let mut context = OfflineAudioContext::new(1, RENDER_QUANTUM_SIZE, sample_rate);
+        let context = OfflineAudioContext::new(1, RENDER_QUANTUM_SIZE, sample_rate);
 
         let mut dirac = context.create_buffer(1, 1, sample_rate);
         dirac.copy_to_channel(&[1.], 0);
@@ -708,7 +708,7 @@ mod tests {
     fn test_audio_buffer_resampling() {
         [22500, 38000, 48000, 96000].iter().for_each(|sr| {
             let base_sr = 44100;
-            let mut context = OfflineAudioContext::new(1, base_sr, base_sr as f32);
+            let context = OfflineAudioContext::new(1, base_sr, base_sr as f32);
 
             // 1Hz sine at different sample rates
             let buf_sr = *sr;

--- a/src/node/biquad_filter.rs
+++ b/src/node/biquad_filter.rs
@@ -1095,7 +1095,7 @@ mod test {
         let default_freq = 350.;
         let default_type = BiquadFilterType::Lowpass;
 
-        let mut context = OfflineAudioContext::new(2, LENGTH, 44_100.);
+        let context = OfflineAudioContext::new(2, LENGTH, 44_100.);
         let biquad = BiquadFilterNode::new(&context, BiquadFilterOptions::default());
 
         context.start_rendering_sync();
@@ -1114,7 +1114,7 @@ mod test {
         let gain = 1.;
         let frequency = 3050.;
         let type_ = BiquadFilterType::Highpass;
-        let mut context = OfflineAudioContext::new(2, LENGTH, 44_100.);
+        let context = OfflineAudioContext::new(2, LENGTH, 44_100.);
 
         let options = BiquadFilterOptions {
             q,
@@ -1143,7 +1143,7 @@ mod test {
         let gain = 1.;
         let frequency = 3050.;
         let type_ = BiquadFilterType::Highpass;
-        let mut context = OfflineAudioContext::new(2, LENGTH, 44_100.);
+        let context = OfflineAudioContext::new(2, LENGTH, 44_100.);
 
         let biquad = BiquadFilterNode::new(&context, BiquadFilterOptions::default());
 

--- a/src/node/constant_source.rs
+++ b/src/node/constant_source.rs
@@ -202,7 +202,7 @@ mod tests {
         let sample_rate = 48000.;
         let start_in_samples = (128 + 1) as f64; // start rendering in 2d block
         let stop_in_samples = (256 + 1) as f64; // stop rendering of 3rd block
-        let mut context = OfflineAudioContext::new(1, 128 * 4, sample_rate);
+        let context = OfflineAudioContext::new(1, 128 * 4, sample_rate);
 
         let src = context.create_constant_source();
         src.connect(&context.destination());
@@ -232,7 +232,7 @@ mod tests {
 
     #[test]
     fn test_start_in_the_past() {
-        let mut context = OfflineAudioContext::new(1, 128, 48000.);
+        let context = OfflineAudioContext::new(1, 128, 48000.);
 
         let src = context.create_constant_source();
         src.connect(&context.destination());

--- a/src/node/delay.rs
+++ b/src/node/delay.rs
@@ -514,7 +514,7 @@ mod tests {
     fn test_sample_accurate() {
         for delay_in_samples in [128., 131., 197.].iter() {
             let sample_rate = 48000.;
-            let mut context = OfflineAudioContext::new(1, 256, sample_rate);
+            let context = OfflineAudioContext::new(1, 256, sample_rate);
 
             let delay = context.create_delay(2.);
             delay.delay_time.set_value(delay_in_samples / sample_rate);
@@ -543,7 +543,7 @@ mod tests {
         {
             let delay_in_samples = 128.5;
             let sample_rate = 48000.;
-            let mut context = OfflineAudioContext::new(1, 256, sample_rate);
+            let context = OfflineAudioContext::new(1, 256, sample_rate);
 
             let delay = context.create_delay(2.);
             delay.delay_time.set_value(delay_in_samples / sample_rate);
@@ -570,7 +570,7 @@ mod tests {
         {
             let delay_in_samples = 128.8;
             let sample_rate = 48000.;
-            let mut context = OfflineAudioContext::new(1, 256, sample_rate);
+            let context = OfflineAudioContext::new(1, 256, sample_rate);
 
             let delay = context.create_delay(2.);
             delay.delay_time.set_value(delay_in_samples / sample_rate);
@@ -599,7 +599,7 @@ mod tests {
     fn test_multichannel() {
         let delay_in_samples = 128.;
         let sample_rate = 48000.;
-        let mut context = OfflineAudioContext::new(2, 2 * 128, sample_rate);
+        let context = OfflineAudioContext::new(2, 2 * 128, sample_rate);
 
         let delay = context.create_delay(2.);
         delay.delay_time.set_value(delay_in_samples / sample_rate);
@@ -632,7 +632,7 @@ mod tests {
     fn test_input_number_of_channels_change() {
         let delay_in_samples = 128.;
         let sample_rate = 48000.;
-        let mut context = OfflineAudioContext::new(2, 3 * 128, sample_rate);
+        let context = OfflineAudioContext::new(2, 3 * 128, sample_rate);
 
         let delay = context.create_delay(2.);
         delay.delay_time.set_value(delay_in_samples / sample_rate);
@@ -676,7 +676,7 @@ mod tests {
         // make sure there are no hidden order problem
         for _ in 0..10 {
             let sample_rate = 48000.;
-            let mut context = OfflineAudioContext::new(1, 5 * 128, sample_rate);
+            let context = OfflineAudioContext::new(1, 5 * 128, sample_rate);
 
             // Set up a source that starts only after 5 render quanta.
             // The delay writer and reader should stay alive in this period of silence.
@@ -717,7 +717,7 @@ mod tests {
         for _ in 0..10 {
             // set delay and max delay time exactly 1 render quantum
             let sample_rate = 48000.;
-            let mut context = OfflineAudioContext::new(1, 256, sample_rate);
+            let context = OfflineAudioContext::new(1, 256, sample_rate);
 
             let delay = context.create_delay(1.);
             delay.delay_time.set_value(128. / sample_rate);
@@ -743,7 +743,7 @@ mod tests {
         for _ in 0..10 {
             // set delay and max delay time exactly 2 render quantum
             let sample_rate = 48000.;
-            let mut context = OfflineAudioContext::new(1, 3 * 128, sample_rate);
+            let context = OfflineAudioContext::new(1, 3 * 128, sample_rate);
 
             let delay = context.create_delay(2.);
             delay.delay_time.set_value(128. * 2. / sample_rate);
@@ -777,7 +777,7 @@ mod tests {
         // gracefully fallback to min
         for _ in 0..10 {
             let sample_rate = 480000.;
-            let mut context = OfflineAudioContext::new(1, 256, sample_rate);
+            let context = OfflineAudioContext::new(1, 256, sample_rate);
 
             let delay = context.create_delay(0.5); // this will be internally clamped to 1.
             delay.delay_time.set_value(0.5 / sample_rate); // this will be clamped to 1. by the Reader

--- a/src/node/iir_filter.rs
+++ b/src/node/iir_filter.rs
@@ -592,7 +592,7 @@ mod test {
             .map(|l| l.unwrap().parse::<f32>().unwrap())
             .collect();
 
-        let mut context = OfflineAudioContext::new(1, LENGTH, 44_100.);
+        let context = OfflineAudioContext::new(1, LENGTH, 44_100.);
 
         let file = File::open("samples/white.ogg").unwrap();
         let audio_buffer = context.decode_audio_data_sync(file).unwrap();

--- a/src/node/oscillator.rs
+++ b/src/node/oscillator.rs
@@ -644,7 +644,7 @@ mod tests {
             let freq = 10_f32.powf(i as f32);
             let sample_rate = 44_100;
 
-            let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
+            let context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
 
             let osc = context.create_oscillator();
             osc.connect(&context.destination());
@@ -680,7 +680,7 @@ mod tests {
             let freq = 10_f32.powf(i as f32);
             let sample_rate = 44_100;
 
-            let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
+            let context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
 
             let osc = context.create_oscillator();
             osc.connect(&context.destination());
@@ -709,7 +709,7 @@ mod tests {
             let freq = 10_f32.powf(i as f32);
             let sample_rate = 44100;
 
-            let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
+            let context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
 
             let osc = context.create_oscillator();
             osc.connect(&context.destination());
@@ -747,7 +747,7 @@ mod tests {
             let freq = 10_f32.powf(i as f32);
             let sample_rate = 44_100;
 
-            let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
+            let context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
 
             let osc = context.create_oscillator();
             osc.connect(&context.destination());
@@ -794,7 +794,7 @@ mod tests {
             let freq = 10_f32.powf(i as f32);
             let sample_rate = 44_100;
 
-            let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
+            let context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
 
             let osc = context.create_oscillator();
             osc.connect(&context.destination());
@@ -839,7 +839,7 @@ mod tests {
             let freq = 10_f32.powf(i as f32);
             let sample_rate = 44_100;
 
-            let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
+            let context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
 
             let options = PeriodicWaveOptions {
                 real: Some(vec![0., 0.]),
@@ -885,7 +885,7 @@ mod tests {
             let freq = 10_f32.powf(i as f32);
             let sample_rate = 44_100;
 
-            let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
+            let context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
 
             let options = PeriodicWaveOptions {
                 real: Some(vec![0., 0., 0.]),
@@ -972,7 +972,7 @@ mod tests {
         let freq = 1.25;
         let sample_rate = 44_100;
 
-        let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
+        let context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
         let osc = context.create_oscillator();
         osc.connect(&context.destination());
         osc.frequency().set_value(freq);
@@ -1004,7 +1004,7 @@ mod tests {
         let freq = 1.;
         let sample_rate = 96000;
 
-        let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
+        let context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
         let osc = context.create_oscillator();
         osc.connect(&context.destination());
         osc.frequency().set_value(freq);
@@ -1036,7 +1036,7 @@ mod tests {
         let freq = 2345.6;
         let sample_rate = 44_100;
 
-        let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
+        let context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
         let osc = context.create_oscillator();
         osc.connect(&context.destination());
         osc.frequency().set_value(freq);
@@ -1068,7 +1068,7 @@ mod tests {
         let freq = 8910.1;
         let sample_rate = 44_100;
 
-        let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
+        let context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
         let osc = context.create_oscillator();
         osc.connect(&context.destination());
         osc.frequency().set_value(freq);
@@ -1100,7 +1100,7 @@ mod tests {
         let freq = 8910.1;
         let sample_rate = 44_100;
 
-        let mut context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
+        let context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
         let osc = context.create_oscillator();
         osc.connect(&context.destination());
         osc.frequency().set_value(freq);

--- a/src/node/stereo_panner.rs
+++ b/src/node/stereo_panner.rs
@@ -280,7 +280,7 @@ mod test {
     fn assert_stereo_default_build() {
         let default_pan = 0.;
 
-        let mut context = OfflineAudioContext::new(2, LENGTH, 44_100.);
+        let context = OfflineAudioContext::new(2, LENGTH, 44_100.);
 
         let panner = StereoPannerNode::new(&context, StereoPannerOptions::default());
 
@@ -295,7 +295,7 @@ mod test {
         let default_pan = 0.;
         let new_pan = 0.1;
 
-        let mut context = OfflineAudioContext::new(2, LENGTH, 44_100.);
+        let context = OfflineAudioContext::new(2, LENGTH, 44_100.);
 
         let panner = StereoPannerNode::new(&context, StereoPannerOptions::default());
 
@@ -352,7 +352,7 @@ mod test {
         let default_pan = 0.;
         let new_pan = 1.1;
 
-        let mut context = OfflineAudioContext::new(2, LENGTH, 44_100.);
+        let context = OfflineAudioContext::new(2, LENGTH, 44_100.);
 
         let panner = StereoPannerNode::new(&context, StereoPannerOptions::default());
 
@@ -372,7 +372,7 @@ mod test {
         let default_pan = 0.;
         let new_pan = -1.1;
 
-        let mut context = OfflineAudioContext::new(2, LENGTH, 44_100.);
+        let context = OfflineAudioContext::new(2, LENGTH, 44_100.);
 
         let panner = StereoPannerNode::new(&context, StereoPannerOptions::default());
 

--- a/src/node/waveshaper.rs
+++ b/src/node/waveshaper.rs
@@ -483,7 +483,7 @@ mod tests {
 
     #[test]
     fn test_user_defined_options() {
-        let mut context = OfflineAudioContext::new(2, LENGTH, 44_100.);
+        let context = OfflineAudioContext::new(2, LENGTH, 44_100.);
 
         let options = WaveShaperOptions {
             curve: Some(vec![1.0]),
@@ -502,7 +502,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn change_a_curve_for_another_curve_should_panic() {
-        let mut context = OfflineAudioContext::new(2, LENGTH, 44_100.);
+        let context = OfflineAudioContext::new(2, LENGTH, 44_100.);
 
         let options = WaveShaperOptions {
             curve: Some(vec![1.0]),
@@ -525,7 +525,7 @@ mod tests {
 
     #[test]
     fn change_none_for_curve_after_build() {
-        let mut context = OfflineAudioContext::new(2, LENGTH, 44_100.);
+        let context = OfflineAudioContext::new(2, LENGTH, 44_100.);
 
         let options = WaveShaperOptions {
             curve: None,
@@ -549,7 +549,7 @@ mod tests {
     #[test]
     fn test_shape_boundaries() {
         let sample_rate = 44100.;
-        let mut context = OfflineAudioContext::new(1, 3 * 128, sample_rate);
+        let context = OfflineAudioContext::new(1, 3 * 128, sample_rate);
 
         let shaper = context.create_wave_shaper();
         let curve = vec![-0.5, 0., 0.5];
@@ -587,7 +587,7 @@ mod tests {
     #[test]
     fn test_shape_interpolation() {
         let sample_rate = 44100.;
-        let mut context = OfflineAudioContext::new(1, 128, sample_rate);
+        let context = OfflineAudioContext::new(1, 128, sample_rate);
 
         let shaper = context.create_wave_shaper();
         let curve = vec![-0.5, 0., 0.5];

--- a/src/render/thread.rs
+++ b/src/render/thread.rs
@@ -94,7 +94,7 @@ impl RenderThread {
     }
 
     // render method of the OfflineAudioContext
-    pub fn render_audiobuffer(&mut self, length: usize) -> AudioBuffer {
+    pub fn render_audiobuffer(mut self, length: usize) -> AudioBuffer {
         // assert input was properly sized
         debug_assert_eq!(length % RENDER_QUANTUM_SIZE, 0);
 

--- a/tests/mixing.rs
+++ b/tests/mixing.rs
@@ -19,7 +19,7 @@ fn setup_with_destination_channel_config(
 }
 
 fn run_with_intermediate_channel_config(
-    mut context: OfflineAudioContext,
+    context: OfflineAudioContext,
     number_of_channels: usize,
     channel_count_mode: ChannelCountMode,
     channel_interpretation: ChannelInterpretation,

--- a/tests/offline.rs
+++ b/tests/offline.rs
@@ -12,7 +12,7 @@ fn test_offline_render() {
 
     assert_ne!(LENGTH % RENDER_QUANTUM_SIZE, 0);
 
-    let mut context = OfflineAudioContext::new(2, LENGTH, 44_100.);
+    let context = OfflineAudioContext::new(2, LENGTH, 44_100.);
     assert_eq!(context.length(), LENGTH);
 
     {
@@ -49,7 +49,7 @@ fn test_start_stop() {
     let len = RENDER_QUANTUM_SIZE * 4;
     let sample_rate = 480000.;
 
-    let mut context = OfflineAudioContext::new(1, len, sample_rate);
+    let context = OfflineAudioContext::new(1, len, sample_rate);
     assert_eq!(context.length(), len);
 
     {
@@ -84,7 +84,7 @@ fn test_delayed_constant_source() {
     let len = RENDER_QUANTUM_SIZE * 4;
     let sample_rate = 480000.;
 
-    let mut context = OfflineAudioContext::new(1, len, sample_rate);
+    let context = OfflineAudioContext::new(1, len, sample_rate);
     assert_eq!(context.length(), len);
 
     {
@@ -113,7 +113,7 @@ fn test_delayed_constant_source() {
 #[test]
 fn test_audio_param_graph() {
     let sample_rate = 480000.;
-    let mut context = OfflineAudioContext::new(1, RENDER_QUANTUM_SIZE, sample_rate);
+    let context = OfflineAudioContext::new(1, RENDER_QUANTUM_SIZE, sample_rate);
     {
         let gain = context.create_gain();
         gain.gain().set_value(0.5); // intrinsic value
@@ -150,7 +150,7 @@ fn test_audio_param_graph() {
 #[test]
 fn test_listener() {
     let sample_rate = 480000.;
-    let mut context = OfflineAudioContext::new(1, RENDER_QUANTUM_SIZE, sample_rate);
+    let context = OfflineAudioContext::new(1, RENDER_QUANTUM_SIZE, sample_rate);
 
     {
         let listener1 = context.listener();
@@ -159,16 +159,16 @@ fn test_listener() {
         listener2.position_y().set_value(2.);
     }
 
+    let listener = context.listener();
     let _ = context.start_rendering_sync();
 
-    let listener = context.listener();
     assert_float_eq!(listener.position_y().value(), 2., abs <= 0.);
     assert_float_eq!(listener.position_x().value(), 1., abs <= 0.);
 }
 
 #[test]
 fn test_cycle() {
-    let mut context = OfflineAudioContext::new(1, RENDER_QUANTUM_SIZE, 48000.);
+    let context = OfflineAudioContext::new(1, RENDER_QUANTUM_SIZE, 48000.);
 
     {
         let cycle1 = context.create_gain();
@@ -204,7 +204,7 @@ fn test_cycle() {
 #[test]
 fn test_cycle_breaker() {
     let sample_rate = 480000.;
-    let mut context = OfflineAudioContext::new(1, RENDER_QUANTUM_SIZE * 3, sample_rate);
+    let context = OfflineAudioContext::new(1, RENDER_QUANTUM_SIZE * 3, sample_rate);
 
     {
         let delay = context.create_delay(1. / sample_rate as f64);
@@ -245,7 +245,7 @@ fn test_cycle_breaker() {
 #[test]
 fn test_spatial() {
     // setup stereo
-    let mut context = OfflineAudioContext::new(2, RENDER_QUANTUM_SIZE, 480000.);
+    let context = OfflineAudioContext::new(2, RENDER_QUANTUM_SIZE, 480000.);
 
     // put listener at (10, 0, 0), directed at (1, 0, 0)
     let listener = context.listener();


### PR DESCRIPTION
Regarding the discussion at #170
This is the first step, with a bit of reasoning, a safety wrapper and a small API change we can make the OfflineAudiocontext `Send` and `Sync`