### PR TITLE
Fix/latency category

### DIFF
--- a/examples/granular.rs
+++ b/examples/granular.rs
@@ -12,9 +12,9 @@ use web_audio_api::AudioBuffer;
 
 // nonte: the is a naive lookhead scheduler implementation, a proper implementation should:
 // - generalize to handle several engines and type of engines
-// see https://web.dev/audio-scheduling/ for some explanations
 // - run the loop in a dedicated thread
-// - use a priority queue
+// - eventually use a proper priority queue
+// see https://web.dev/audio-scheduling/ for some explanations
 struct Scheduler {
     period: f64,
     lookahead: f64,
@@ -60,8 +60,8 @@ impl Scheduler {
                 .unwrap()
                 .trigger_grain(&self.audio_context, trigger_time);
 
-            if next_time.is_some() {
-                self.queue.push(next_time.unwrap());
+            if let Some(time) = next_time {
+                self.queue.push(time);
                 self.queue.sort_by(|a, b| b.partial_cmp(a).unwrap());
             }
 

--- a/examples/granular.rs
+++ b/examples/granular.rs
@@ -132,6 +132,7 @@ impl ScrubEngine {
 
 fn main() {
     env_logger::init();
+    println!("++ scrub into file forward and backward at 0.5 speed");
 
     let audio_context = AudioContext::default();
 
@@ -140,7 +141,6 @@ fn main() {
 
     let scrub_engine = ScrubEngine::new(audio_buffer);
     let start_time = audio_context.current_time();
-    // println!("++ scrub into file forward and backward at 0.5 speed");
     let mut scheduler = Scheduler::new(audio_context);
     scheduler.add(Some(scrub_engine), start_time);
 }

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -30,7 +30,7 @@ pub enum AudioContextLatencyCategory {
     /// Specify the number of seconds of latency
     /// this latency is not guaranted to be applied,
     /// it depends on the audio hardware capabilities
-    Specific(f64),
+    Custom(f64),
 }
 
 impl Default for AudioContextLatencyCategory {

--- a/src/io.rs
+++ b/src/io.rs
@@ -127,53 +127,70 @@ impl StreamConfigsBuilder {
     }
 
     /// set preferred sample rate
-    fn with_sample_rate(&mut self, v: f32) {
-        crate::assert_valid_sample_rate(v);
-        self.prefered.sample_rate.0 = v as u32;
+    fn with_sample_rate(&mut self, sample_rate: f32) {
+        crate::assert_valid_sample_rate(sample_rate);
+        self.prefered.sample_rate.0 = sample_rate as u32;
     }
 
-    /// buffer size
+    /// define requested hardware buffer size
     #[allow(clippy::needless_pass_by_value)]
-    fn with_latency_hint(&mut self, v: AudioContextLatencyCategory) {
-        let buffer_size: u32 = u32::try_from(RENDER_QUANTUM_SIZE).unwrap();
-        let default_buffer_size = match self.supported.buffer_size() {
-            SupportedBufferSize::Range { min, .. } => buffer_size.max(*min),
-            SupportedBufferSize::Unknown => buffer_size,
-        };
+    fn with_latency_hint(&mut self, latency_hint: AudioContextLatencyCategory) {
+        let render_quantum_size = u32::try_from(RENDER_QUANTUM_SIZE).unwrap();
 
-        let calculated = match v {
-            AudioContextLatencyCategory::Interactive => default_buffer_size,
-            AudioContextLatencyCategory::Balanced => match self.supported.buffer_size() {
-                SupportedBufferSize::Range { max, .. } => {
-                    let b = (default_buffer_size * 2).min(*max);
-                    (b + buffer_size - 1) / buffer_size * buffer_size
-                }
-                SupportedBufferSize::Unknown => {
-                    let b = default_buffer_size * 2;
-                    (b + buffer_size - 1) / buffer_size * buffer_size
-                }
-            },
-            AudioContextLatencyCategory::Playback => match self.supported.buffer_size() {
-                SupportedBufferSize::Range { max, .. } => {
-                    let b = (default_buffer_size * 4).min(*max);
-                    (b + buffer_size - 1) / buffer_size * buffer_size
-                }
-                SupportedBufferSize::Unknown => {
-                    let b = default_buffer_size * 4;
-                    (b + buffer_size - 1) / buffer_size * buffer_size
-                }
-            },
-            // b is always positive
+        // at 44100Hz sample rate (this could be even more relaxed:
+        // render_quantum_size is 2,9ms
+        // render_quantum_size * 4 (512) is 11,6ms
+        // render_quantum_size * 8 (1024) is 23,2ms
+        let buffer_size = match latency_hint {
+            AudioContextLatencyCategory::Interactive => render_quantum_size,
+            AudioContextLatencyCategory::Balanced => render_quantum_size * 4,
+            AudioContextLatencyCategory::Playback => render_quantum_size * 8,
+            // buffer_size is always positive and truncation is the desired behavior
             #[allow(clippy::cast_sign_loss)]
-            // truncation is the desired behavior
             #[allow(clippy::cast_possible_truncation)]
-            AudioContextLatencyCategory::Specific(t) => {
-                let b = t * f64::from(self.prefered.sample_rate.0);
-                (b as u32 + buffer_size - 1) / buffer_size * buffer_size
+            AudioContextLatencyCategory::Custom(latency) => {
+                if latency <= 0. {
+                    panic!(
+                        "RangeError - Invalid custom latency: {:?}, should be strictly positive",
+                        latency
+                    );
+                }
+
+                let buffer_size = latency as u32 * self.prefered.sample_rate.0;
+                buffer_size.next_power_of_two()
             }
         };
 
-        self.prefered.buffer_size = cpal::BufferSize::Fixed(calculated);
+        let clamped_buffer_size: u32 = match self.supported.buffer_size() {
+            SupportedBufferSize::Unknown => buffer_size,
+            // try to find the best power of two candidate in given range
+            SupportedBufferSize::Range { min, max } => {
+                let min = *min;
+                let max = *max;
+
+                if buffer_size < min {
+                    let next_power_of_two = min.next_power_of_two();
+
+                    if next_power_of_two <= max {
+                        next_power_of_two
+                    } else {
+                        min
+                    }
+                } else if buffer_size > max {
+                    let prev_power_of_two = max.next_power_of_two() / 2;
+
+                    if prev_power_of_two >= min {
+                        prev_power_of_two
+                    } else {
+                        max
+                    }
+                } else {
+                    buffer_size
+                }
+            }
+        };
+
+        self.prefered.buffer_size = cpal::BufferSize::Fixed(clamped_buffer_size);
     }
 
     /// builds `StreamConfigs`
@@ -379,8 +396,8 @@ pub(crate) fn build_output(
     let mut builder = StreamConfigsBuilder::new();
 
     // set specific sample rate if requested
-    if let Some(v) = options.sample_rate {
-        builder.with_sample_rate(v);
+    if let Some(sample_rate) = options.sample_rate {
+        builder.with_sample_rate(sample_rate);
     }
 
     // always try to set a decent buffer size


### PR DESCRIPTION
Hey, here are some changes regarding #173, to put more relaxed values for `Balanced` (512) and `Playback` (1024) latency hints. I think we could even multiply these by 2 but no strong opinion neither, it a bit a finger in the wind...

Also:
- refactored a bit `StreamConfigsBuilder::with_latency_hint` to favor power of two buffers sizes 
- renamed `AudioContextLatencyCategory::Specific` to `AudioContextLatencyCategory::Custom` which I find more clear (can revert that easily if you don't agree)

Some changes on the granular example too (with a proto lookahead scheduler!) so that timing is more precise and does not rely anymore on the underlying io buffer size.