### PR TITLE
Implement fast track for `AudioBufferSourceNode` when buffer is aligned on output

### DIFF
--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -462,6 +462,16 @@ impl AudioProcessor for AudioBufferSourceRenderer {
                 || current_time + block_duration > stop_time
             {
                 let buffer_time = self.render_state.buffer_time;
+                let end_index = if current_time + block_duration > stop_time
+                    || self.render_state.buffer_time + block_duration > duration
+                {
+                    let dt =
+                        (stop_time - current_time).min(duration - self.render_state.buffer_time);
+                    let end_buffer_time = self.render_state.buffer_time + dt;
+                    (end_buffer_time * sample_rate).round() as usize
+                } else {
+                    buffer.length()
+                };
                 let mut apply_offset = 0;
 
                 buffer
@@ -472,16 +482,6 @@ impl AudioProcessor for AudioBufferSourceRenderer {
                         // we need to recompute that for each channel
                         let buffer_channel = buffer_channel.as_slice();
                         let mut start_index = (buffer_time * sample_rate).round() as usize;
-                        let end_index = if current_time + block_duration > stop_time
-                            || self.render_state.buffer_time + block_duration > duration
-                        {
-                            let dt = (stop_time - current_time)
-                                .min(duration - self.render_state.buffer_time);
-                            let end_buffer_time = self.render_state.buffer_time + dt;
-                            (end_buffer_time * sample_rate).round() as usize
-                        } else {
-                            buffer.length()
-                        };
                         let mut offset = 0;
 
                         for (index, o) in output_channel.iter_mut().enumerate() {

--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -636,9 +636,7 @@ impl AudioProcessor for AudioBufferSourceRenderer {
         }
 
         // fill output according to computed positions
-        self.buffer
-            .as_ref()
-            .unwrap()
+        buffer
             .channels()
             .iter()
             .zip(output.channels_mut().iter_mut())
@@ -661,7 +659,7 @@ impl AudioProcessor for AudioBufferSourceRenderer {
                                     None => 0.,
                                 };
 
-                                (1. - k) * prev_sample + k * next_sample
+                                (1. - k).mul_add(prev_sample, k * next_sample)
                             }
                             None => 0.,
                         };

--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -682,8 +682,6 @@ mod tests {
 
     use super::*;
 
-    // fast track
-    // @todo: slow track
     #[test]
     fn test_playing_some_file() {
         let context = OfflineAudioContext::new(2, RENDER_QUANTUM_SIZE, 44_100.);
@@ -784,8 +782,6 @@ mod tests {
         assert_float_eq!(channel[..], expected[..], abs_all <= 0.);
     }
 
-    // fast track
-    // @todo: slow track
     #[test]
     fn test_sub_quantum_stop() {
         // fast track
@@ -833,8 +829,6 @@ mod tests {
         }
     }
 
-    // fast track
-    // @todo: slow track
     #[test]
     fn test_sub_sample_stop() {
         // fast track
@@ -1090,7 +1084,7 @@ mod tests {
     }
 
     #[test]
-    // just more readable for populating expected values
+    // just to make things more readable when populating expected values
     #[allow(clippy::erasing_op)]
     #[allow(clippy::identity_op)]
     fn test_fast_track_loop() {

--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -472,7 +472,7 @@ impl AudioProcessor for AudioBufferSourceRenderer {
                 } else {
                     buffer.length()
                 };
-                // in case of a loop point in the middle of the block, these value
+                // in case of a loop point in the middle of the block, this value
                 // will be used to recompute `self.render_state.buffer_time` according
                 // to the actual loop point.
                 let mut loop_point_index: Option<usize> = None;


### PR DESCRIPTION
Pretty happy with this one, and quite huge performance improvements :)

### before
```
+ id      | name                                                                     | duration (ms) | Speedup vs. realtime  | buffer.duration (s)
- 1       | Baseline (silence)                                                       | 29            | 4137.9x               | 120
- 2       | Simple source test without resampling (Mono)                             | 87            | 1379.3x               | 120
- 3       | Simple source test without resampling (Stereo)                           | 108           | 1111.1x               | 120
- 4       | Simple source test without resampling (Stereo and positionnal)           | 275           | 436.4x                | 120
- 5       | Simple source test with resampling (Mono)                                | 85            | 1411.8x               | 120
- 6       | Simple source test with resampling (Stereo)                              | 105           | 1142.9x               | 120
- 7       | Simple source test with resampling (Stereo and positionnal)              | 287           | 418.1x                | 120
- 8       | Upmix without resampling (Mono -> Stereo)                                | 97            | 1237.1x               | 120
- 9       | Downmix without resampling (Stereo -> Mono)                              | 95            | 1263.2x               | 120
- 10      | Simple mixing (100x same buffer) - be careful w/ volume here!            | 1694          | 17.7x                 | 30
- 11      | Simple mixing (100 different buffers) - be careful w/ volume here!       | 1730          | 17.3x                 | 30
- 12      | Simple mixing with gains                                                 | 399           | 300.8x                | 120
- 13      | Granular synthesis                                                       | 4313          | 1.7x                  | 7.5
- 14      | Synth (Sawtooth with Envelope)                                           | 6569          | 18.3x                 | 120
- 15      | Synth (Sawtooth with gain - no automation)                               | 5480          | 21.9x                 | 120
- 16      | Synth (Sawtooth without gain)                                            | 2753          | 43.6x                 | 120
- 17      | Substractive Synth                                                       | 569           | 210.9x                | 120
- 18      | Stereo panning                                                           | 175           | 685.7x                | 120
- 19      | Stereo panning with automation                                           | 167           | 718.6x                | 120
- 20      | Sawtooth with automation                                                 | 82            | 1463.4x               | 120
- 21      | Stereo source with delay                                                 | 249           | 481.9x                | 120
```

### after
```
+ id      | name                                                                     | duration (ms) | Speedup vs. realtime  | buffer.duration (s)
- 1       | Baseline (silence)                                                       | 26            | 4615.4x               | 120
- 2       | Simple source test without resampling (Mono)                             | 49            | 2449.0x               | 120
- 3       | Simple source test without resampling (Stereo)                           | 66            | 1818.2x               | 120
- 4       | Simple source test without resampling (Stereo and positionnal)           | 238           | 504.2x                | 120
- 5       | Simple source test with resampling (Mono)                                | 83            | 1445.8x               | 120
- 6       | Simple source test with resampling (Stereo)                              | 108           | 1111.1x               | 120
- 7       | Simple source test with resampling (Stereo and positionnal)              | 276           | 434.8x                | 120
- 8       | Upmix without resampling (Mono -> Stereo)                                | 54            | 2222.2x               | 120
- 9       | Downmix without resampling (Stereo -> Mono)                              | 69            | 1739.1x               | 120
- 10      | Simple mixing (100x same buffer) - be careful w/ volume here!            | 1715          | 17.5x                 | 30
- 11      | Simple mixing (100 different buffers) - be careful w/ volume here!       | 1741          | 17.2x                 | 30
- 12      | Simple mixing with gains                                                 | 409           | 293.4x                | 120
- 13      | Granular synthesis                                                       | 4148          | 1.8x                  | 7.5
- 14      | Synth (Sawtooth with Envelope)                                           | 5634          | 21.3x                 | 120
- 15      | Synth (Sawtooth with gain - no automation)                               | 4826          | 24.9x                 | 120
- 16      | Synth (Sawtooth without gain)                                            | 2501          | 48.0x                 | 120
- 17      | Substractive Synth                                                       | 547           | 219.4x                | 120
- 18      | Stereo panning                                                           | 132           | 909.1x                | 120
- 19      | Stereo panning with automation                                           | 135           | 888.9x                | 120
- 20      | Sawtooth with automation                                                 | 82            | 1463.4x               | 120
- 21      | Stereo source with delay                                                 | 192           | 625.0x                | 120
```

The only thing I didn't manage to do is to assert the correct path (slow or fast track) from the unit test. My idea was to declare some config variable in the unit test and check it in the code to fail if we are in the wrong path, but I actually don't know if its even possible... if you have any idea, it's welcome!

I think I've maybe found a bug with the loop in the slow track, I will check that later