### PR TITLE
Fix clamp of AudioParam

### DIFF
--- a/src/param.rs
+++ b/src/param.rs
@@ -972,8 +972,10 @@ impl AudioParamProcessor {
             return;
         }
 
-        // define if intrisic buffer can be considered be clean in next call
-        self.is_buffer_clean = self.event_timeline.is_empty() { true } else { false };
+        // Define if intrisic buffer can be considered be clean in next call.
+        // If the timeline is empty, we know the buffer will be filled with a
+        // constant value. @note: there could other valid cases
+        self.is_buffer_clean = self.event_timeline.is_empty();
 
         // populate the buffer for this block
         self.buffer.clear();

--- a/src/param.rs
+++ b/src/param.rs
@@ -729,8 +729,6 @@ impl AudioParamProcessor {
         // then the paramIntrinsicValue value will remain unchanged and stay at its
         // previous value until either the value attribute is directly set, or
         // automation events are added for the time range.
-        // let mut events_received = false;
-
         for event in self.receiver.try_iter() {
             // handle CancelScheduledValues events
             // cf. https://www.w3.org/TR/webaudio/#dom-audioparam-cancelscheduledvalues


### PR DESCRIPTION
Clamping is now done on the computed values after input is added

Really not sure this is the most elegant way, but that's the only one I found to both make the borrow checker happy and to be able to write some tests :)

