### PR TITLE
Replace `std::collections::HashMap` with `rustc_hash::FxHashMap`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ smallvec = "1.8"
 once_cell = "1.10"
 symphonia = { version = "0.5", default-features = false }
 creek = "0.2.1"
+rustc-hash = "1.1.0"
 
 [dev-dependencies]
 rand = "0.8"

--- a/src/render/graph.rs
+++ b/src/render/graph.rs
@@ -4,8 +4,8 @@ use super::{Alloc, AudioParamValues, AudioProcessor, AudioRenderQuantum, NodeInd
 use crate::node::ChannelConfig;
 use crate::render::RenderScope;
 
-use smallvec::{smallvec, SmallVec};
 use rustc_hash::FxHashMap;
+use smallvec::{smallvec, SmallVec};
 
 /// Connection between two audio nodes
 struct OutgoingEdge {

--- a/src/render/graph.rs
+++ b/src/render/graph.rs
@@ -1,12 +1,11 @@
 //! The audio graph topology and render algorithm
 
-use std::collections::HashMap;
-
 use super::{Alloc, AudioParamValues, AudioProcessor, AudioRenderQuantum, NodeIndex};
 use crate::node::ChannelConfig;
 use crate::render::RenderScope;
 
 use smallvec::{smallvec, SmallVec};
+use rustc_hash::FxHashMap;
 
 /// Connection between two audio nodes
 struct OutgoingEdge {
@@ -71,7 +70,7 @@ impl Node {
 /// The audio graph
 pub(crate) struct Graph {
     /// Processing Nodes
-    nodes: HashMap<NodeIndex, Node>,
+    nodes: FxHashMap<NodeIndex, Node>,
     /// Allocator for audio buffers
     alloc: Alloc,
 
@@ -88,7 +87,7 @@ pub(crate) struct Graph {
 impl Graph {
     pub fn new() -> Self {
         Graph {
-            nodes: HashMap::new(),
+            nodes: FxHashMap::default(),
             ordered: vec![],
             marked: vec![],
             marked_temp: vec![],

--- a/src/render/processor.rs
+++ b/src/render/processor.rs
@@ -6,7 +6,6 @@ use super::{graph::Node, AudioRenderQuantum, NodeIndex};
 
 use rustc_hash::FxHashMap;
 
-
 #[non_exhaustive] // we may want to add user-provided blobs to this later
 /// The execution context of all AudioProcessors in a given AudioContext
 ///

--- a/src/render/processor.rs
+++ b/src/render/processor.rs
@@ -1,10 +1,11 @@
 //! Audio processing code that runs on the audio rendering thread
 
-use std::collections::HashMap;
-
 use crate::context::AudioParamId;
 
 use super::{graph::Node, AudioRenderQuantum, NodeIndex};
+
+use rustc_hash::FxHashMap;
+
 
 #[non_exhaustive] // we may want to add user-provided blobs to this later
 /// The execution context of all AudioProcessors in a given AudioContext
@@ -58,11 +59,11 @@ pub trait AudioProcessor: Send {
 ///
 /// Provided to implementations of [`AudioProcessor`] in the render thread
 pub struct AudioParamValues<'a> {
-    nodes: &'a HashMap<NodeIndex, Node>,
+    nodes: &'a FxHashMap<NodeIndex, Node>,
 }
 
 impl<'a> AudioParamValues<'a> {
-    pub(crate) fn from(nodes: &'a HashMap<NodeIndex, Node>) -> Self {
+    pub(crate) fn from(nodes: &'a FxHashMap<NodeIndex, Node>) -> Self {
         Self { nodes }
     }
 


### PR DESCRIPTION
Basically everything is in the title. 

Not sure you want to merge this because of the new dependency (i.e. https://docs.rs/rustc-hash/1.1.0/rustc_hash/index.html) and so on. But I just wanted to test something as I saw in a flamegraph of the benchmarks that almost 20% of the time was spent in `graph.nodes.add()` and `graph.nodes.remove()` in `render()`. From what I see, it seems to produce an improvement of ~10% in benches that deal with many nodes, dividing by ~2 the time spent in `graph.nodes.add()` and `graph.nodes.remove()`.

If you have other ideas / plans on this point, let me know if I can help

(I think I have gone through all my ideas according to optimizations now... will try to start on the CompressorNode next week)