### PR TITLE
Improved DelayNode performance

### DIFF
--- a/src/node/delay.rs
+++ b/src/node/delay.rs
@@ -432,13 +432,6 @@ impl AudioProcessor for DelayReader {
         let number_of_channels = ring_buffer[0].number_of_channels();
         output.set_number_of_channels(number_of_channels);
 
-        let sample_rate = scope.sample_rate as f64;
-        let dt = 1. / sample_rate;
-        let quantum_duration = RENDER_QUANTUM_SIZE as f64 * dt;
-
-        // compute all playback infos for this block
-        let delay = params.get(&self.delay_time);
-
         if !self.in_cycle {
             // check the latest written frame by the delay writer
             let latest_frame_written = self.latest_frame_written.load(Ordering::SeqCst);
@@ -448,6 +441,11 @@ impl AudioProcessor for DelayReader {
             // https://github.com/orottier/web-audio-api-rs/pull/198#discussion_r945326200
         }
 
+        // compute all playback infos for this block
+        let delay = params.get(&self.delay_time);
+        let sample_rate = scope.sample_rate as f64;
+        let dt = 1. / sample_rate;
+        let quantum_duration = RENDER_QUANTUM_SIZE as f64 * dt;
         let ring_size = ring_buffer.len() as i32;
         let ring_index = self.index as i32;
         let mut playback_infos = [PlaybackInfo::default(); RENDER_QUANTUM_SIZE];

--- a/src/node/delay.rs
+++ b/src/node/delay.rs
@@ -35,8 +35,6 @@ impl Default for DelayOptions {
 struct PlaybackInfo {
     prev_block_index: usize,
     prev_frame_index: usize,
-    // next_block_index: usize,
-    // next_frame_index: usize,
     k: f32,
 }
 
@@ -536,6 +534,8 @@ impl AudioProcessor for DelayReader {
                     }
 
                     // update pointer to channel_data if needed
+                    // @note: most of the time the step is not necessary but can
+                    // be in case of an automotation with increasing delay time
                     if block_index != prev_block_index {
                         block_index = prev_block_index;
                         channel_data = ring_buffer[block_index].channel_data(channel_number);


### PR DESCRIPTION
Hey,

Some tweaking with the `DelayNode`, this is based on the varying param size stuff (along with other improvements) so let's keep it as a draft until we finish with #205 (the real payload is on the last commit  6d23ce0). Quite happy with the result:

#### before

```
Stereo source with delay                                                 | 204           | 588.2x                | 120
```

#### after

```
Stereo source with delay                                                 | 114           | 1052.6x               | 120
```