### PR TITLE
Fix CI post message

### DIFF
--- a/.github/workflows/post-pr-result.yml
+++ b/.github/workflows/post-pr-result.yml
@@ -1,0 +1,59 @@
+name: Comment on the pull request
+
+# read-write repo token
+# access to secrets
+#
+# untrusted code should not be compiled or executed in this script
+# see https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+on:
+  workflow_run:
+    workflows: ["Rust"]
+    types:
+      - completed
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    if: >
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: 'Download artifact'
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            const artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            const matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr"
+            })[0];
+            const download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            const fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+      - run: unzip pr.zip
+
+      - name: 'Write result in PR'
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const issue_number = Number(fs.readFileSync('./pr_number.txt'));
+            const iai_feature = fs.readFileSync('bench.txt', { encoding:'utf8', flag:'r' });
+
+            const message = 'Benchmark result:\n\n' + iai_feature;
+
+            await github.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+              body: message,
+            });

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,7 @@
 name: Rust
 
+# read-only repo token
+# no access to secrets
 on:
   push:
     branches: [ main ]
@@ -65,22 +67,21 @@ jobs:
     - name: Run bench against baseline
       run: cargo bench | sed '0,/^test result:/d' | tee bench.txt
 
-    - name: Write result in PR
-      uses: actions/github-script@v5
-      with:
-        script: |
-          const fs = require('fs');
+    ## Save results
+    ## see https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+    - name: Save PR number and bench results
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/pr_number.txt
+          mv bench.txt ./pr/bench.txt
+      - uses: actions/upload-artifact@v2
+        with:
+          name: pr
+          path: pr/
 
-          // read the output file
-          const iai_feature = fs.readFileSync("bench.txt", {encoding:'utf8', flag:'r'});
 
-          // form message
-          const message = 'Benchmark result:\n\n' + iai_feature;
 
-          // post comment
-          github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: message
-          })
+
+
+
+

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,13 +70,14 @@ jobs:
     ## Save results
     ## see https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
     - name: Save PR number and bench results
-        run: |
-          mkdir -p ./pr
-          echo ${{ github.event.number }} > ./pr/pr_number.txt
-      - uses: actions/upload-artifact@v2
-        with:
-          name: pr
-          path: pr/
+      run: |
+        mkdir -p ./pr
+        echo ${{ github.event.number }} > ./pr/pr_number.txt
+        mv bench.txt ./pr/bench.txt
+    - uses: actions/upload-artifact@v2
+      with:
+        name: pr
+        path: pr/
 
 
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,7 +73,6 @@ jobs:
         run: |
           mkdir -p ./pr
           echo ${{ github.event.number }} > ./pr/pr_number.txt
-          mv bench.txt ./pr/bench.txt
       - uses: actions/upload-artifact@v2
         with:
           name: pr


### PR DESCRIPTION
I did that based on https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

I couldn't test the post of the message itself, because the second job was not triggered for some reason on my repo (maybe it must be in main branch I don't really know...), but the artifact has been correctly created as you can see there https://github.com/b-ma/web-audio-api-rs/pull/1/checks

As the second script is very mostly a copy/paste from the github article I guess it should work properly (or a least don't be far).