### PR TITLE
Perf `BiquadFilter`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,7 +82,7 @@ jobs:
     - name: Copy over benchmarks from PR branch
       run: git checkout - -- benches/my_benchmark.rs
     - name: Revert when benches do not compile on main
-      run: cargo check --benches || git checkout main -- benches/my_benchmark.rs
+      run: cargo check --benches --no-default-features || git checkout main -- benches/my_benchmark.rs
     - name: Run benchmarks for main branch
       run: cargo bench --no-default-features
     - name: Checkout PR branch

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -79,14 +79,14 @@ jobs:
       run: sudo apt-get install valgrind
     - name: Checkout main branch
       run: git checkout main
-    - name: Run benchmarks for main branch
-      run: cargo bench --no-default-features
-    - name: Checkout PR branch
-      run: git checkout -
     - name: Copy over benchmarks from PR branch
       run: git checkout - -- benches/my_benchmark.rs
     - name: Revert when benches do not compile on main
       run: cargo check --benches || git checkout main -- benches/my_benchmark.rs
+    - name: Run benchmarks for main branch
+      run: cargo bench --no-default-features
+    - name: Checkout PR branch
+      run: git checkout -
     - name: Run bench against baseline
       run: cargo bench --no-default-features | sed '0,/^test result:/d' | tee bench.txt
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -83,6 +83,8 @@ jobs:
       run: cargo bench --no-default-features
     - name: Checkout PR branch
       run: git checkout -
+    - name: Copy over benchmarks from PR branch
+      run: git checkout - -- benches/my_benchmark.rs
     - name: Run bench against baseline
       run: cargo bench --no-default-features | sed '0,/^test result:/d' | tee bench.txt
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -85,6 +85,8 @@ jobs:
       run: git checkout -
     - name: Copy over benchmarks from PR branch
       run: git checkout - -- benches/my_benchmark.rs
+    - name: Revert when benches do not compile on main
+      run: cargo check --benches || git checkout main -- benches/my_benchmark.rs
     - name: Run bench against baseline
       run: cargo bench --no-default-features | sed '0,/^test result:/d' | tee bench.txt
 

--- a/benches/my_benchmark.rs
+++ b/benches/my_benchmark.rs
@@ -98,8 +98,8 @@ pub fn bench_buffer_src_biquad() {
     let buffer = ctx.decode_audio_data_sync(file).unwrap();
 
     // Create an biquad filter node (defaults to low pass)
-    let biquad = context.create_biquad_filter();
-    biquad.connect(&context.destination());
+    let biquad = ctx.create_biquad_filter();
+    biquad.connect(&ctx.destination());
     biquad.frequency().set_value(200.);
 
     // Play buffer and pipe to filter

--- a/benches/my_benchmark.rs
+++ b/benches/my_benchmark.rs
@@ -118,4 +118,5 @@ iai::main!(
     bench_sine_gain_delay,
     bench_buffer_src,
     bench_buffer_src_iir,
+    bench_buffer_src_biquad,
 );

--- a/benches/my_benchmark.rs
+++ b/benches/my_benchmark.rs
@@ -92,6 +92,25 @@ pub fn bench_buffer_src_iir() {
     assert_eq!(ctx.start_rendering_sync().length(), 48000);
 }
 
+pub fn bench_buffer_src_biquad() {
+    let ctx = OfflineAudioContext::new(2, black_box(48000), 48000.);
+    let file = std::fs::File::open("samples/think-stereo-48000.wav").unwrap();
+    let buffer = ctx.decode_audio_data_sync(file).unwrap();
+
+    // Create an biquad filter node (defaults to low pass)
+    let biquad = context.create_biquad_filter();
+    biquad.connect(&context.destination());
+    biquad.frequency().set_value(200.);
+
+    // Play buffer and pipe to filter
+    let src = ctx.create_buffer_source();
+    src.connect(&biquad);
+    src.set_buffer(buffer);
+    src.start();
+
+    assert_eq!(ctx.start_rendering_sync().length(), 48000);
+}
+
 iai::main!(
     bench_ctor,
     bench_sine,

--- a/examples/benchmarks.rs
+++ b/examples/benchmarks.rs
@@ -581,7 +581,7 @@ fn main() {
 
         let context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
 
-        // Create an biquad filter node (defaults to low pass)
+        // Create a biquad filter node (defaults to low pass)
         let biquad = context.create_biquad_filter();
         biquad.connect(&context.destination());
         biquad.frequency().set_value(200.);

--- a/examples/benchmarks.rs
+++ b/examples/benchmarks.rs
@@ -576,6 +576,26 @@ fn main() {
         benchmark(&mut stdout, name, context, &mut results);
     }
 
+    {
+        let name = "Biquad filter";
+
+        let context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
+
+        // Create an biquad filter node (defaults to low pass)
+        let biquad = context.create_biquad_filter();
+        biquad.connect(&context.destination());
+        biquad.frequency().set_value(200.);
+
+        let src = context.create_buffer_source();
+        let buffer = get_buffer(&sources, sample_rate, 2);
+        src.connect(&biquad);
+        src.set_buffer(buffer);
+        src.set_loop(true);
+        src.start();
+
+        benchmark(&mut stdout, name, context, &mut results);
+    }
+
     write!(
         stdout,
         "{}{}> All done!\r\n\r\n",

--- a/src/node/biquad_filter.rs
+++ b/src/node/biquad_filter.rs
@@ -614,7 +614,7 @@ impl AudioProcessor for BiquadFilterRenderer {
 
         let mut coefs_list = [coef; RENDER_QUANTUM_SIZE];
         // if one of the params has a length of RENDER_QUANTUM_SIZE, we need
-        // to compute the coefs for each sample
+        // to compute the coefs for each frame
         if frequency.len() != 1
             || detune.len() != 1
             || q.len() != 1

--- a/src/node/biquad_filter.rs
+++ b/src/node/biquad_filter.rs
@@ -615,11 +615,7 @@ impl AudioProcessor for BiquadFilterRenderer {
         let mut coefs_list = [coef; RENDER_QUANTUM_SIZE];
         // if one of the params has a length of RENDER_QUANTUM_SIZE, we need
         // to compute the coefs for each frame
-        if frequency.len() != 1
-            || detune.len() != 1
-            || q.len() != 1
-            || gain.len() != 1
-        {
+        if frequency.len() != 1 || detune.len() != 1 || q.len() != 1 || gain.len() != 1 {
             coefs_list
                 .iter_mut()
                 .zip(frequency.iter().cycle())
@@ -646,7 +642,8 @@ impl AudioProcessor for BiquadFilterRenderer {
             let mut y1 = self.y1[channel_number];
             let mut y2 = self.y2[channel_number];
 
-            output_channel.iter_mut()
+            output_channel
+                .iter_mut()
                 .zip(input_channel.iter())
                 .zip(coefs_list.iter())
                 .for_each(|((o, &i), c)| {

--- a/src/node/biquad_filter.rs
+++ b/src/node/biquad_filter.rs
@@ -622,6 +622,7 @@ impl AudioProcessor for BiquadFilterRenderer {
                 .zip(detune.iter().cycle())
                 .zip(q.iter().cycle())
                 .zip(gain.iter().cycle())
+                .skip(1)
                 .for_each(|((((coefs, &f), &d), &q), &g)| {
                     let computed_freq = get_computed_freq(f, d);
                     *coefs = calculate_coefs(

--- a/src/node/biquad_filter.rs
+++ b/src/node/biquad_filter.rs
@@ -601,12 +601,12 @@ impl AudioProcessor for BiquadFilterRenderer {
         let detune = params.get(&self.detune);
         let q = params.get(&self.q);
         let gain = params.get(&self.gain);
-
+        let sample_rate_f64 = f64::from(sample_rate);
         // compute first coef and fill the coef list with this value
         let computed_freq = get_computed_freq(frequency[0], detune[0]);
         let coef = calculate_coefs(
             type_,
-            f64::from(sample_rate),
+            sample_rate_f64,
             f64::from(computed_freq),
             f64::from(gain[0]),
             f64::from(q[0]),
@@ -630,7 +630,7 @@ impl AudioProcessor for BiquadFilterRenderer {
                     let computed_freq = get_computed_freq(f, d);
                     *coefs = calculate_coefs(
                         type_,
-                        f64::from(sample_rate),
+                        sample_rate_f64,
                         f64::from(computed_freq),
                         f64::from(g),
                         f64::from(q),
@@ -646,11 +646,10 @@ impl AudioProcessor for BiquadFilterRenderer {
             let mut y1 = self.y1[channel_number];
             let mut y2 = self.y2[channel_number];
 
-            input_channel
-                .iter()
-                .zip(output_channel.iter_mut())
+            output_channel.iter_mut()
+                .zip(input_channel.iter())
                 .zip(coefs_list.iter())
-                .for_each(|((&i, o), c)| {
+                .for_each(|((o, &i), c)| {
                     // 𝑎0𝑦(𝑛)+𝑎1𝑦(𝑛−1)+𝑎2𝑦(𝑛−2)=𝑏0𝑥(𝑛)+𝑏1𝑥(𝑛−1)+𝑏2𝑥(𝑛−2)
                     // as all coefs are normalized against 𝑎0, we get
                     // 𝑦(𝑛) = 𝑏0𝑥(𝑛) + 𝑏1𝑥(𝑛−1) + 𝑏2𝑥(𝑛−2) - 𝑎1𝑦(𝑛−1) - 𝑎2𝑦(𝑛−2)


### PR DESCRIPTION
Just a few changes to handle more cleanly the `param.len()`, I also removed the subnormal check (~50% of the perf improvements) to be consistent with the IIR Filter and added some simple dedicated benches

### before

```
Biquad filter                                                            | 141           | 851.1x                | 120
```

### after

```
Biquad filter                                                            | 95            | 1263.2x               | 120
```
