### PR TITLE
Dedicated path for `GainNode` if param is length 1

### DIFF
--- a/src/node/dynamics_compressor.rs
+++ b/src/node/dynamics_compressor.rs
@@ -502,7 +502,7 @@ mod tests {
 
     #[test]
     fn test_db_to_lin() {
-        assert_float_eq!(db_to_lin(0.), 1., abs <= 1e-8);
+        assert_float_eq!(db_to_lin(0.), 1., abs <= 0.);
         assert_float_eq!(db_to_lin(-20.), 0.1, abs <= 1e-8);
         assert_float_eq!(db_to_lin(-40.), 0.01, abs <= 1e-8);
         assert_float_eq!(db_to_lin(-60.), 0.001, abs <= 1e-8);

--- a/src/node/gain.rs
+++ b/src/node/gain.rs
@@ -113,12 +113,20 @@ impl AudioProcessor for GainRenderer {
 
         *output = input.clone();
 
-        output.modify_channels(|channel| {
-            channel
-                .iter_mut()
-                .zip(gain.iter().cycle())
-                .for_each(|(o, g)| *o *= g);
-        });
+        if gain.len() == 1 {
+            let g = gain[0];
+
+            output.channels_mut().iter_mut().for_each(|channel| {
+                channel.iter_mut().for_each(|o| *o *= g);
+            });
+        } else {
+            output.channels_mut().iter_mut().for_each(|channel| {
+                channel
+                    .iter_mut()
+                    .zip(gain.iter().cycle())
+                    .for_each(|(o, g)| *o *= g);
+            });
+        }
 
         false
     }

--- a/src/node/gain.rs
+++ b/src/node/gain.rs
@@ -101,11 +101,20 @@ impl AudioProcessor for GainRenderer {
 
         let gain = params.get(&self.gain);
 
+        // very fast track for mute or pass-through
         if gain.len() == 1 {
-            if gain[0] == 0. {
+            // 1e-6 is -120 dB when close to 0 and ±8.283506e-6 dB when close to 1
+            // very probably small enough to not be audible
+            let threshold = 1e-6;
+
+            let diff_to_zero = gain[0].abs();
+            if diff_to_zero <= threshold {
                 output.make_silent();
                 return false;
-            } else if gain[0] == 1. {
+            }
+
+            let diff_to_one = (1. - gain[0]).abs();
+            if diff_to_one <= threshold {
                 *output = input.clone();
                 return false;
             }


### PR DESCRIPTION
Really nothing fancy, but interestingly improves the "mixing with gains" bench

#### before

```
Simple mixing with gains                                                 | 347           | 345.8x                | 120
```

#### after

```
Simple mixing with gains                                                 | 282           | 425.5x                | 120
```