### PR TITLE
Specify output device at AudioContext creation

### DIFF
--- a/examples/resampling.rs
+++ b/examples/resampling.rs
@@ -1,7 +1,5 @@
 use std::fs::File;
-use web_audio_api::context::{
-    AudioContext, AudioContextLatencyCategory, AudioContextOptions, BaseAudioContext,
-};
+use web_audio_api::context::{AudioContext, AudioContextOptions, BaseAudioContext};
 use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 
 fn main() {
@@ -65,7 +63,7 @@ fn main() {
 
     let audio_context_38000 = AudioContext::new(AudioContextOptions {
         sample_rate: Some(38000.),
-        latency_hint: AudioContextLatencyCategory::Interactive,
+        ..AudioContextOptions::default()
     });
     let file_38000 = File::open("samples/sample-38000.wav").unwrap();
     let buffer_38000 = audio_context_38000
@@ -74,7 +72,7 @@ fn main() {
 
     let audio_context_44100 = AudioContext::new(AudioContextOptions {
         sample_rate: Some(44100.),
-        latency_hint: AudioContextLatencyCategory::Interactive,
+        ..AudioContextOptions::default()
     });
     let file_44100 = File::open("samples/sample-44100.wav").unwrap();
     let buffer_44100 = audio_context_44100
@@ -83,7 +81,7 @@ fn main() {
 
     let audio_context_48000 = AudioContext::new(AudioContextOptions {
         sample_rate: Some(48000.),
-        latency_hint: AudioContextLatencyCategory::Interactive,
+        ..AudioContextOptions::default()
     });
     let file_48000 = File::open("samples/sample-48000.wav").unwrap();
     let buffer_48000 = audio_context_48000

--- a/examples/sink_id.rs
+++ b/examples/sink_id.rs
@@ -12,8 +12,10 @@ fn main() {
     let sink_id = std::io::stdin().lines().next().unwrap().unwrap();
 
     // Create an audio context (default: stereo);
-    let mut options = AudioContextOptions::default();
-    options.sink_id = Some(sink_id);
+    let options = AudioContextOptions {
+        sink_id: Some(sink_id),
+        ..AudioContextOptions::default()
+    };
 
     let context = AudioContext::new(options);
     println!("Playing beep for sink {:?}", context.sink_id());

--- a/examples/sink_id.rs
+++ b/examples/sink_id.rs
@@ -16,6 +16,7 @@ fn main() {
     options.sink_id = Some(sink_id);
 
     let context = AudioContext::new(options);
+    println!("Playing beep for sink {:?}", context.sink_id());
 
     // Create an oscillator node with sine (default) type
     let osc = context.create_oscillator();

--- a/examples/sink_id.rs
+++ b/examples/sink_id.rs
@@ -1,17 +1,26 @@
-use web_audio_api::context::{AudioContext, BaseAudioContext};
+use web_audio_api::context::{AudioContext, AudioContextOptions, BaseAudioContext};
 use web_audio_api::enumerate_devices;
 use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 
 fn main() {
     env_logger::init();
 
-    dbg!(enumerate_devices());
+    let devices = enumerate_devices();
+    dbg!(devices);
+
+    println!("Choose output device, enter the 'device_id' and press <Enter>:");
+    let sink_id = std::io::stdin().lines().next().unwrap().unwrap();
 
     // Create an audio context (default: stereo);
-    let context = AudioContext::default();
+    let mut options = AudioContextOptions::default();
+    options.sink_id = Some(sink_id);
+
+    let context = AudioContext::new(options);
 
     // Create an oscillator node with sine (default) type
     let osc = context.create_oscillator();
     osc.connect(&context.destination());
     osc.start();
+
+    std::thread::sleep(std::time::Duration::from_secs(4));
 }

--- a/examples/sink_id.rs
+++ b/examples/sink_id.rs
@@ -1,0 +1,17 @@
+use web_audio_api::context::{AudioContext, BaseAudioContext};
+use web_audio_api::enumerate_devices;
+use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
+
+fn main() {
+    env_logger::init();
+
+    dbg!(enumerate_devices());
+
+    // Create an audio context (default: stereo);
+    let context = AudioContext::default();
+
+    // Create an oscillator node with sine (default) type
+    let osc = context.create_oscillator();
+    osc.connect(&context.destination());
+    osc.start();
+}

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -45,7 +45,7 @@ pub struct AudioContextOptions {
     pub latency_hint: AudioContextLatencyCategory,
     /// Sample rate of the audio Context and audio output hardware
     pub sample_rate: Option<f32>,
-    /// The identifier or associated information of the audio output device
+    /// The audio output device - use `None` for the default device
     pub sink_id: Option<String>,
 }
 
@@ -142,6 +142,13 @@ impl AudioContext {
     #[must_use]
     pub fn output_latency(&self) -> f64 {
         self.backend.output_latency()
+    }
+
+    /// Identifier or the information of the current audio output device.
+    ///
+    /// The initial value is `None`, which means the default audio output device.
+    pub fn sink_id(&self) -> Option<&str> {
+        self.backend.sink_id()
     }
 
     /// Suspends the progression of time in the audio context.

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -85,7 +85,7 @@ impl AudioContext {
     /// // Request a sample rate of 44.1 kHz and default latency (buffer size 128, if available)
     /// let opts = AudioContextOptions {
     ///     sample_rate: Some(44100.),
-    ///     latency_hint: AudioContextLatencyCategory::Interactive,
+    ///     ..AudioContextOptions::default()
     /// };
     ///
     /// // Setup the audio context that will emit to your speakers

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -45,6 +45,8 @@ pub struct AudioContextOptions {
     pub latency_hint: AudioContextLatencyCategory,
     /// Sample rate of the audio Context and audio output hardware
     pub sample_rate: Option<f32>,
+    /// The identifier or associated information of the audio output device
+    pub sink_id: Option<String>,
 }
 
 /// This interface represents an audio graph whose `AudioDestinationNode` is routed to a real-time

--- a/src/io/backend_cpal.rs
+++ b/src/io/backend_cpal.rs
@@ -75,6 +75,7 @@ pub struct CpalBackend {
     output_latency: Arc<AtomicF64>,
     sample_rate: f32,
     number_of_channels: usize,
+    sink_id: Option<String>,
 }
 
 impl AudioBackend for CpalBackend {
@@ -92,7 +93,7 @@ impl AudioBackend for CpalBackend {
         let host = cpal::default_host();
         log::info!("Host: {:?}", host.id());
 
-        let device = match options.sink_id {
+        let device = match &options.sink_id {
             None => host
                 .default_output_device()
                 .expect("no output device available"),
@@ -132,6 +133,7 @@ impl AudioBackend for CpalBackend {
             output_latency,
             sample_rate,
             number_of_channels,
+            sink_id: options.sink_id,
         };
 
         (backend, sender, cap_receiver)
@@ -216,6 +218,7 @@ impl AudioBackend for CpalBackend {
             output_latency: Arc::new(AtomicF64::new(0.)),
             sample_rate,
             number_of_channels,
+            sink_id: None,
         };
 
         (backend, receiver)
@@ -243,6 +246,10 @@ impl AudioBackend for CpalBackend {
 
     fn output_latency(&self) -> f64 {
         self.output_latency.load()
+    }
+
+    fn sink_id(&self) -> Option<&str> {
+        self.sink_id.as_deref()
     }
 
     fn boxed_clone(&self) -> Box<dyn AudioBackend> {

--- a/src/io/backend_cpal.rs
+++ b/src/io/backend_cpal.rs
@@ -13,7 +13,7 @@ use cpal::{
     Stream, StreamConfig, SupportedBufferSize,
 };
 
-use super::AudioBackend;
+use super::{AudioBackend, MediaDeviceInfo, MediaDeviceInfoKind};
 use crate::buffer::AudioBuffer;
 use crate::context::{AudioContextLatencyCategory, AudioContextOptions};
 use crate::media::MicrophoneRender;
@@ -231,6 +231,26 @@ impl AudioBackend for CpalBackend {
 
     fn boxed_clone(&self) -> Box<dyn AudioBackend> {
         Box::new(self.clone())
+    }
+
+    fn enumerate_devices() -> Vec<MediaDeviceInfo>
+    where
+        Self: Sized,
+    {
+        cpal::default_host()
+            .devices()
+            .unwrap()
+            .filter(|d| d.default_output_config().is_ok())
+            .enumerate()
+            .map(|(i, d)| {
+                MediaDeviceInfo::new(
+                    format!("{}", i + 1),
+                    None,
+                    MediaDeviceInfoKind::AudioOutput,
+                    d.name().unwrap(),
+                )
+            })
+            .collect()
     }
 }
 

--- a/src/io/backend_cubeb.rs
+++ b/src/io/backend_cubeb.rs
@@ -139,6 +139,7 @@ pub struct CubebBackend {
     stream: ThreadSafeClosableStream,
     sample_rate: f32,
     number_of_channels: usize,
+    sink_id: Option<String>,
 }
 
 impl AudioBackend for CubebBackend {
@@ -200,7 +201,7 @@ impl AudioBackend for CubebBackend {
             .ok()
             .unwrap_or(RENDER_QUANTUM_SIZE as u32);
         let buffer_size = buffer_size_req.max(min_latency);
-        let device_id = options.sink_id.and_then(|d| {
+        let device_id = options.sink_id.as_ref().and_then(|d| {
             Self::enumerate_devices()
                 .into_iter()
                 .find(|e| e.device_id() == d)
@@ -248,6 +249,7 @@ impl AudioBackend for CubebBackend {
             stream,
             number_of_channels,
             sample_rate,
+            sink_id: options.sink_id,
         };
 
         backend.resume();
@@ -327,6 +329,7 @@ impl AudioBackend for CubebBackend {
             stream: ThreadSafeClosableStream::new(stream),
             number_of_channels,
             sample_rate,
+            sink_id: None,
         };
 
         (backend, receiver)
@@ -354,6 +357,10 @@ impl AudioBackend for CubebBackend {
 
     fn output_latency(&self) -> f64 {
         self.stream.output_latency(self.sample_rate)
+    }
+
+    fn sink_id(&self) -> Option<&str> {
+        self.sink_id.as_deref()
     }
 
     fn boxed_clone(&self) -> Box<dyn AudioBackend> {

--- a/src/io/backend_cubeb.rs
+++ b/src/io/backend_cubeb.rs
@@ -10,7 +10,7 @@ use crate::message::ControlMessage;
 use crate::render::RenderThread;
 use crate::{AudioRenderCapacityLoad, RENDER_QUANTUM_SIZE};
 
-use cubeb::{Context, DeviceType, StereoFrame, Stream, StreamParams};
+use cubeb::{Context, DeviceId, DeviceType, StereoFrame, Stream, StreamParams};
 
 use crossbeam_channel::{Receiver, Sender};
 
@@ -99,13 +99,18 @@ fn init_output_backend<const N: usize>(
     ctx: &Context,
     params: StreamParams,
     buffer_size: u32,
+    device: Option<DeviceId>,
     mut renderer: RenderThread,
 ) -> ThreadSafeClosableStream {
     let mut builder = cubeb::StreamBuilder::<[f32; N]>::new();
 
+    match device {
+        None => builder.default_output(&params),
+        Some(devid) => builder.output(devid, &params),
+    };
+
     builder
         .name("Cubeb web_audio_api")
-        .default_output(&params)
         .latency(buffer_size)
         .data_callback(move |_input, output| {
             // `output` is `&mut [[f32; N]]`, a slice of slices.
@@ -195,41 +200,47 @@ impl AudioBackend for CubebBackend {
             .ok()
             .unwrap_or(RENDER_QUANTUM_SIZE as u32);
         let buffer_size = buffer_size_req.max(min_latency);
+        let device_id = options.sink_id.and_then(|d| {
+            Self::enumerate_devices()
+                .into_iter()
+                .find(|e| e.device_id() == d)
+                .map(|e| *e.device().downcast::<DeviceId>().unwrap())
+        });
 
         let stream = match number_of_channels {
             // so sorry, but I need to constify the non-const `number_of_channels`
-            1 => init_output_backend::<1>(&ctx, params, buffer_size, renderer),
-            2 => init_output_backend::<2>(&ctx, params, buffer_size, renderer),
-            3 => init_output_backend::<3>(&ctx, params, buffer_size, renderer),
-            4 => init_output_backend::<4>(&ctx, params, buffer_size, renderer),
-            5 => init_output_backend::<5>(&ctx, params, buffer_size, renderer),
-            6 => init_output_backend::<6>(&ctx, params, buffer_size, renderer),
-            7 => init_output_backend::<7>(&ctx, params, buffer_size, renderer),
-            8 => init_output_backend::<8>(&ctx, params, buffer_size, renderer),
-            9 => init_output_backend::<9>(&ctx, params, buffer_size, renderer),
-            10 => init_output_backend::<10>(&ctx, params, buffer_size, renderer),
-            11 => init_output_backend::<11>(&ctx, params, buffer_size, renderer),
-            12 => init_output_backend::<12>(&ctx, params, buffer_size, renderer),
-            13 => init_output_backend::<13>(&ctx, params, buffer_size, renderer),
-            14 => init_output_backend::<14>(&ctx, params, buffer_size, renderer),
-            15 => init_output_backend::<15>(&ctx, params, buffer_size, renderer),
-            16 => init_output_backend::<16>(&ctx, params, buffer_size, renderer),
-            17 => init_output_backend::<17>(&ctx, params, buffer_size, renderer),
-            18 => init_output_backend::<18>(&ctx, params, buffer_size, renderer),
-            19 => init_output_backend::<19>(&ctx, params, buffer_size, renderer),
-            20 => init_output_backend::<20>(&ctx, params, buffer_size, renderer),
-            21 => init_output_backend::<21>(&ctx, params, buffer_size, renderer),
-            22 => init_output_backend::<22>(&ctx, params, buffer_size, renderer),
-            23 => init_output_backend::<23>(&ctx, params, buffer_size, renderer),
-            24 => init_output_backend::<24>(&ctx, params, buffer_size, renderer),
-            25 => init_output_backend::<25>(&ctx, params, buffer_size, renderer),
-            26 => init_output_backend::<26>(&ctx, params, buffer_size, renderer),
-            27 => init_output_backend::<27>(&ctx, params, buffer_size, renderer),
-            28 => init_output_backend::<28>(&ctx, params, buffer_size, renderer),
-            29 => init_output_backend::<29>(&ctx, params, buffer_size, renderer),
-            30 => init_output_backend::<30>(&ctx, params, buffer_size, renderer),
-            31 => init_output_backend::<31>(&ctx, params, buffer_size, renderer),
-            32 => init_output_backend::<32>(&ctx, params, buffer_size, renderer),
+            1 => init_output_backend::<1>(&ctx, params, buffer_size, device_id, renderer),
+            2 => init_output_backend::<2>(&ctx, params, buffer_size, device_id, renderer),
+            3 => init_output_backend::<3>(&ctx, params, buffer_size, device_id, renderer),
+            4 => init_output_backend::<4>(&ctx, params, buffer_size, device_id, renderer),
+            5 => init_output_backend::<5>(&ctx, params, buffer_size, device_id, renderer),
+            6 => init_output_backend::<6>(&ctx, params, buffer_size, device_id, renderer),
+            7 => init_output_backend::<7>(&ctx, params, buffer_size, device_id, renderer),
+            8 => init_output_backend::<8>(&ctx, params, buffer_size, device_id, renderer),
+            9 => init_output_backend::<9>(&ctx, params, buffer_size, device_id, renderer),
+            10 => init_output_backend::<10>(&ctx, params, buffer_size, device_id, renderer),
+            11 => init_output_backend::<11>(&ctx, params, buffer_size, device_id, renderer),
+            12 => init_output_backend::<12>(&ctx, params, buffer_size, device_id, renderer),
+            13 => init_output_backend::<13>(&ctx, params, buffer_size, device_id, renderer),
+            14 => init_output_backend::<14>(&ctx, params, buffer_size, device_id, renderer),
+            15 => init_output_backend::<15>(&ctx, params, buffer_size, device_id, renderer),
+            16 => init_output_backend::<16>(&ctx, params, buffer_size, device_id, renderer),
+            17 => init_output_backend::<17>(&ctx, params, buffer_size, device_id, renderer),
+            18 => init_output_backend::<18>(&ctx, params, buffer_size, device_id, renderer),
+            19 => init_output_backend::<19>(&ctx, params, buffer_size, device_id, renderer),
+            20 => init_output_backend::<20>(&ctx, params, buffer_size, device_id, renderer),
+            21 => init_output_backend::<21>(&ctx, params, buffer_size, device_id, renderer),
+            22 => init_output_backend::<22>(&ctx, params, buffer_size, device_id, renderer),
+            23 => init_output_backend::<23>(&ctx, params, buffer_size, device_id, renderer),
+            24 => init_output_backend::<24>(&ctx, params, buffer_size, device_id, renderer),
+            25 => init_output_backend::<25>(&ctx, params, buffer_size, device_id, renderer),
+            26 => init_output_backend::<26>(&ctx, params, buffer_size, device_id, renderer),
+            27 => init_output_backend::<27>(&ctx, params, buffer_size, device_id, renderer),
+            28 => init_output_backend::<28>(&ctx, params, buffer_size, device_id, renderer),
+            29 => init_output_backend::<29>(&ctx, params, buffer_size, device_id, renderer),
+            30 => init_output_backend::<30>(&ctx, params, buffer_size, device_id, renderer),
+            31 => init_output_backend::<31>(&ctx, params, buffer_size, device_id, renderer),
+            32 => init_output_backend::<32>(&ctx, params, buffer_size, device_id, renderer),
             _ => unreachable!(),
         };
 
@@ -365,6 +376,7 @@ impl AudioBackend for CubebBackend {
                     d.group_id().map(str::to_string),
                     MediaDeviceInfoKind::AudioOutput,
                     d.friendly_name().unwrap().into(),
+                    Box::new(d.devid()),
                 )
             })
             .collect()

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -167,12 +167,13 @@ pub enum MediaDeviceInfoKind {
 }
 
 /// Describes a single media input or output device
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct MediaDeviceInfo {
     device_id: String,
     group_id: Option<String>,
     kind: MediaDeviceInfoKind,
     label: String,
+    device: Box<dyn std::any::Any>,
 }
 
 impl MediaDeviceInfo {
@@ -181,12 +182,14 @@ impl MediaDeviceInfo {
         group_id: Option<String>,
         kind: MediaDeviceInfoKind,
         label: String,
+        device: Box<dyn std::any::Any>,
     ) -> Self {
         Self {
             device_id,
             group_id,
             kind,
             label,
+            device,
         }
     }
 
@@ -211,5 +214,9 @@ impl MediaDeviceInfo {
     /// Friendly label describing this device
     pub fn label(&self) -> &str {
         &self.label
+    }
+
+    pub(crate) fn device(self) -> Box<dyn std::any::Any> {
+        self.device
     }
 }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -120,6 +120,9 @@ pub(crate) trait AudioBackend: Send + Sync + 'static {
     /// the listener can hear the sound.
     fn output_latency(&self) -> f64;
 
+    /// The audio output device - `None` means the default device
+    fn sink_id(&self) -> Option<&str>;
+
     /// Clone the stream reference
     fn boxed_clone(&self) -> Box<dyn AudioBackend>;
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -16,6 +16,24 @@ mod backend_cpal;
 #[cfg(feature = "cubeb")]
 mod backend_cubeb;
 
+/// List the available media output devices, such as speakers, headsets, loopbacks, etc
+///
+/// The media device_id can be used to specify the `sink_id` of the AudioContext
+pub fn enumerate_devices() -> Vec<MediaDeviceInfo> {
+    #[cfg(feature = "cubeb")]
+    {
+        backend_cubeb::CubebBackend::enumerate_devices()
+    }
+
+    #[cfg(all(not(feature = "cubeb"), feature = "cpal"))]
+    {
+        backend_cpal::CpalBackend::enumerate_devices()
+    }
+
+    #[cfg(all(not(feature = "cubeb"), not(feature = "cpal")))]
+    panic!("No audio backend available, enable the 'cpal' or 'cubeb' feature")
+}
+
 /// Set up an output stream (speakers) bases on the selected features (cubeb/cpal/none)
 pub(crate) fn build_output(
     options: AudioContextOptions,
@@ -104,6 +122,10 @@ pub(crate) trait AudioBackend: Send + Sync + 'static {
 
     /// Clone the stream reference
     fn boxed_clone(&self) -> Box<dyn AudioBackend>;
+
+    fn enumerate_devices() -> Vec<MediaDeviceInfo>
+    where
+        Self: Sized;
 }
 
 /// Calculate buffer size in frames for a given latency category
@@ -133,5 +155,61 @@ fn buffer_size_for_latency_category(
             let buffer_size = (latency * sample_rate as f64) as usize;
             buffer_size.next_power_of_two()
         }
+    }
+}
+
+/// Describes input/output type of a media device
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum MediaDeviceInfoKind {
+    VideoInput,
+    AudioInput,
+    AudioOutput,
+}
+
+/// Describes a single media input or output device
+#[derive(Clone, Debug)]
+pub struct MediaDeviceInfo {
+    device_id: String,
+    group_id: Option<String>,
+    kind: MediaDeviceInfoKind,
+    label: String,
+}
+
+impl MediaDeviceInfo {
+    pub(crate) fn new(
+        device_id: String,
+        group_id: Option<String>,
+        kind: MediaDeviceInfoKind,
+        label: String,
+    ) -> Self {
+        Self {
+            device_id,
+            group_id,
+            kind,
+            label,
+        }
+    }
+
+    /// Identifier for the represented device
+    ///
+    /// The current implementation is not stable across sessions so you should not persist this
+    /// value
+    pub fn device_id(&self) -> &str {
+        &self.device_id
+    }
+
+    /// Two devices have the same group identifier if they belong to the same physical device
+    pub fn group_id(&self) -> Option<&str> {
+        self.group_id.as_deref()
+    }
+
+    /// Enumerated value that is either "videoinput", "audioinput" or "audiooutput".
+    pub fn kind(&self) -> MediaDeviceInfoKind {
+        self.kind
+    }
+
+    /// Friendly label describing this device
+    pub fn label(&self) -> &str {
+        &self.label
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@ mod spatial;
 pub use spatial::AudioListener;
 
 mod io;
+pub use io::{enumerate_devices, MediaDeviceInfo, MediaDeviceInfoKind};
 
 mod analysis;
 mod message;

--- a/src/media/mic.rs
+++ b/src/media/mic.rs
@@ -40,7 +40,7 @@ use crossbeam_channel::{Receiver, TryRecvError};
 /// // Request an input sample rate of 44.1 kHz and default latency (buffer size 128, if available)
 /// let opts = AudioContextOptions {
 ///     sample_rate: Some(44100.),
-///     latency_hint: AudioContextLatencyCategory::Interactive,
+///     ..AudioContextOptions::default()
 /// };
 /// let mic = Microphone::new(opts);
 /// // or you can create Microphone with default options


### PR DESCRIPTION
This is the first of three PRs for #216 

1. Specify output device at AudioContext creation
2. Change output device for running AudioContext
3. Create AudioContext without output