### PR TITLE
Feature/set sink

### DIFF
--- a/examples/sink_id.rs
+++ b/examples/sink_id.rs
@@ -17,7 +17,7 @@ fn main() {
         ..AudioContextOptions::default()
     };
 
-    let context = AudioContext::new(options);
+    let mut context = AudioContext::new(options);
     println!("Playing beep for sink {:?}", context.sink_id());
 
     // Create an oscillator node with sine (default) type
@@ -25,5 +25,10 @@ fn main() {
     osc.connect(&context.destination());
     osc.start();
 
-    std::thread::sleep(std::time::Duration::from_secs(4));
+    loop {
+        println!("Choose output device, enter the 'device_id' and press <Enter>:");
+        let sink_id = std::io::stdin().lines().next().unwrap().unwrap();
+        context.set_sink_id(sink_id);
+        println!("Playing beep for sink {:?}", context.sink_id());
+    }
 }

--- a/examples/sink_id.rs
+++ b/examples/sink_id.rs
@@ -28,7 +28,7 @@ fn main() {
     loop {
         println!("Choose output device, enter the 'device_id' and press <Enter>:");
         let sink_id = std::io::stdin().lines().next().unwrap().unwrap();
-        context.set_sink_id_sync(sink_id);
+        context.set_sink_id_sync(sink_id).unwrap();
         println!("Playing beep for sink {:?}", context.sink_id());
     }
 }

--- a/examples/sink_id.rs
+++ b/examples/sink_id.rs
@@ -17,7 +17,7 @@ fn main() {
         ..AudioContextOptions::default()
     };
 
-    let mut context = AudioContext::new(options);
+    let context = AudioContext::new(options);
     println!("Playing beep for sink {:?}", context.sink_id());
 
     // Create an oscillator node with sine (default) type

--- a/examples/sink_id.rs
+++ b/examples/sink_id.rs
@@ -28,7 +28,7 @@ fn main() {
     loop {
         println!("Choose output device, enter the 'device_id' and press <Enter>:");
         let sink_id = std::io::stdin().lines().next().unwrap().unwrap();
-        context.set_sink_id(sink_id);
+        context.set_sink_id_sync(sink_id);
         println!("Playing beep for sink {:?}", context.sink_id());
     }
 }

--- a/src/context/concrete_base.rs
+++ b/src/context/concrete_base.rs
@@ -12,9 +12,9 @@ use crate::spatial::AudioListenerParams;
 
 use crate::AudioListener;
 
-use crossbeam_channel::Sender;
+use crossbeam_channel::{SendError, Sender};
 use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock, RwLockWriteGuard};
 
 /// The struct that corresponds to the Javascript `BaseAudioContext` object.
 ///
@@ -51,7 +51,7 @@ struct ConcreteBaseAudioContextInner {
     /// destination node's current channel count
     destination_channel_config: ChannelConfig,
     /// message channel from control to render thread
-    render_channel: Sender<ControlMessage>,
+    render_channel: RwLock<Sender<ControlMessage>>,
     /// control messages that cannot be sent immediately
     queued_messages: Mutex<Vec<ControlMessage>>,
     /// number of frames played
@@ -104,7 +104,7 @@ impl BaseAudioContext for ConcreteBaseAudioContext {
                 self.inner.queued_audio_listener_msgs.lock().unwrap();
             queued_audio_listener_msgs.push(message);
         } else {
-            self.inner.render_channel.send(message).unwrap();
+            self.send_control_msg(message).unwrap();
             self.resolve_queued_control_msgs(id);
         }
 
@@ -124,7 +124,7 @@ impl ConcreteBaseAudioContext {
         let base_inner = ConcreteBaseAudioContextInner {
             sample_rate,
             max_channel_count,
-            render_channel,
+            render_channel: RwLock::new(render_channel),
             queued_messages: Mutex::new(Vec::new()),
             node_id_inc: AtomicU64::new(0),
             destination_channel_config: ChannelConfigOptions::default().into(),
@@ -188,6 +188,17 @@ impl ConcreteBaseAudioContext {
         base
     }
 
+    pub(crate) fn send_control_msg(
+        &self,
+        msg: ControlMessage,
+    ) -> Result<(), SendError<ControlMessage>> {
+        self.inner.render_channel.read().unwrap().send(msg)
+    }
+
+    pub(crate) fn lock_control_msg_sender(&self) -> RwLockWriteGuard<Sender<ControlMessage>> {
+        self.inner.render_channel.write().unwrap()
+    }
+
     /// Inform render thread that the control thread `AudioNode` no langer has any handles
     pub(super) fn mark_node_dropped(&self, id: u64) {
         // do not drop magic nodes
@@ -199,7 +210,7 @@ impl ConcreteBaseAudioContext {
 
             // Sending the message will fail when the render thread has already shut down.
             // This is fine
-            let _r = self.inner.render_channel.send(message);
+            let _r = self.send_control_msg(message);
         }
     }
 
@@ -211,7 +222,7 @@ impl ConcreteBaseAudioContext {
 
         // Sending the message will fail when the render thread has already shut down.
         // This is fine
-        let _r = self.inner.render_channel.send(message);
+        let _r = self.send_control_msg(message);
     }
 
     /// `ChannelConfig` of the `AudioDestinationNode`
@@ -283,7 +294,7 @@ impl ConcreteBaseAudioContext {
         while i < queued.len() {
             if matches!(&queued[i], ControlMessage::ConnectNode {to, ..} if *to == id) {
                 let m = queued.remove(i);
-                self.inner.render_channel.send(m).unwrap();
+                self.send_control_msg(m).unwrap();
             } else {
                 i += 1;
             }
@@ -304,7 +315,7 @@ impl ConcreteBaseAudioContext {
             output,
             input,
         };
-        self.inner.render_channel.send(message).unwrap();
+        self.send_control_msg(message).unwrap();
     }
 
     /// Schedule a connection of an `AudioParam` to the `AudioNode` it belongs to
@@ -326,13 +337,13 @@ impl ConcreteBaseAudioContext {
             from: from.0,
             to: to.0,
         };
-        self.inner.render_channel.send(message).unwrap();
+        self.send_control_msg(message).unwrap();
     }
 
     /// Disconnects all outgoing connections from the audio node.
     pub(crate) fn disconnect(&self, from: &AudioNodeId) {
         let message = ControlMessage::DisconnectAll { from: from.0 };
-        self.inner.render_channel.send(message).unwrap();
+        self.send_control_msg(message).unwrap();
     }
 
     /// Pass an `AudioParam::AudioParamEvent` to the render thread
@@ -348,7 +359,7 @@ impl ConcreteBaseAudioContext {
             to: to.clone(),
             event,
         };
-        self.inner.render_channel.send(message).unwrap();
+        self.send_control_msg(message).unwrap();
     }
 
     /// Attach the 9 `AudioListener` coordinates to a `PannerNode`
@@ -370,7 +381,7 @@ impl ConcreteBaseAudioContext {
         let mut released = false;
         while let Some(message) = queued_audio_listener_msgs.pop() {
             // add the AudioListenerRenderer to the graph
-            self.inner.render_channel.send(message).unwrap();
+            self.send_control_msg(message).unwrap();
             released = true;
         }
 

--- a/src/context/offline.rs
+++ b/src/context/offline.rs
@@ -59,11 +59,16 @@ impl OfflineAudioContext {
     /// * `length` - length of the rendering audio buffer
     /// * `sample_rate` - output sample rate
     #[must_use]
+    #[allow(clippy::missing_panics_doc)]
     pub fn new(number_of_channels: usize, length: usize, sample_rate: f32) -> Self {
         assert_valid_sample_rate(sample_rate);
 
         // communication channel to the render thread
         let (sender, receiver) = crossbeam_channel::unbounded();
+
+        let graph = crate::render::graph::Graph::new();
+        let message = crate::message::ControlMessage::Startup { graph };
+        sender.send(message).unwrap();
 
         // track number of frames - synced from render thread to control thread
         let frames_played = Arc::new(AtomicU64::new(0));

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -184,6 +184,10 @@ impl AudioContext {
     /// is currently not implemented.
     #[allow(clippy::needless_collect, clippy::missing_panics_doc)]
     pub fn set_sink_id_sync(&self, sink_id: String) -> Result<(), Box<dyn Error>> {
+        if self.sink_id().as_deref() == Some(&sink_id) {
+            return Ok(()); // sink is already active
+        }
+
         if !crate::enumerate_devices()
             .into_iter()
             .any(|d| d.device_id() == sink_id)

--- a/src/message.rs
+++ b/src/message.rs
@@ -2,6 +2,7 @@
 
 use crate::node::ChannelConfig;
 use crate::param::AudioParamEvent;
+use crate::render::graph::Graph;
 use crate::render::AudioProcessor;
 
 use crossbeam_channel::Sender;
@@ -42,4 +43,10 @@ pub(crate) enum ControlMessage {
 
     /// Mark node as a cycle breaker (DelayNode only)
     MarkCycleBreaker { id: u64 },
+
+    /// Shut down and recycle the audio graph
+    Shutdown { sender: Sender<Graph> },
+
+    /// Start rendering with given audio graph
+    Startup { graph: Graph },
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -6,7 +6,7 @@ use std::fmt::Debug;
 pub(crate) struct NodeIndex(pub u64);
 
 // private mods
-mod graph;
+pub(crate) mod graph;
 
 // pub(crate) mods
 mod thread;


### PR DESCRIPTION
This is the second of three PRs for https://github.com/orottier/web-audio-api-rs/issues/216

1. #227 
2. Change output device for running AudioContext
3. Create AudioContext without output

You will notice a severe lack of tests for this complicated feature. That is because the functionality is only exposed in online `AudioContext` which need an actual audio backend. For now, because that will be changed in PR number 3.

You can test it with `cargo run --release --example sink_id` but notice that `cpal` only lists your default audio output, so you won't be able to switch from headphones to builtin speakers (on OSX). I added a virtual passthrough device to use for testing. Sad though. It is not really testable with backend `cubeb` because it suffers from segfaults when closing a stream. Known issue #187  :(