### PR TITLE
Prepare public API for variable render quantum size

### DIFF
--- a/examples/toy_webrtc.rs
+++ b/examples/toy_webrtc.rs
@@ -27,7 +27,7 @@ use std::net::UdpSocket;
 use web_audio_api::context::{AudioContext, BaseAudioContext};
 use web_audio_api::media::Microphone;
 use web_audio_api::node::AudioNode;
-use web_audio_api::{AudioBuffer, AudioBufferOptions, RENDER_QUANTUM_SIZE};
+use web_audio_api::{AudioBuffer, AudioBufferOptions};
 
 const MAX_UDP_SIZE: usize = 508;
 const SERVER_ADDR: &str = "0.0.0.0:1234";
@@ -127,7 +127,7 @@ impl Iterator for SocketStream {
                 // construct empty buffer
                 let options = AudioBufferOptions {
                     number_of_channels: 1,
-                    length: RENDER_QUANTUM_SIZE,
+                    length: 128,
                     sample_rate: self.sample_rate,
                 };
                 return Some(Ok(AudioBuffer::new(options)));

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -50,6 +50,22 @@ impl Default for AudioContextLatencyCategory {
     }
 }
 
+#[derive(Copy, Clone, Debug)]
+#[non_exhaustive]
+/// This allows users to ask for a particular render quantum size.
+///
+/// Currently, only the default value is available
+pub enum AudioContextRenderSizeCategory {
+    /// The default value of 128 frames
+    Default,
+}
+
+impl Default for AudioContextRenderSizeCategory {
+    fn default() -> Self {
+        Self::Default
+    }
+}
+
 /// Specify the playback configuration for the [`AudioContext`] constructor.
 ///
 /// All fields are optional and will default to the value best suited for interactive playback on
@@ -79,6 +95,9 @@ pub struct AudioContextOptions {
     /// - use `"none"` to process the audio graph without playing through an audio output device.
     /// - use `"sinkId"` to use the specified audio sink id, obtained with [`enumerate_devices`]
     pub sink_id: String,
+
+    /// Option to request a default, optimized or specific render quantum size. It is a hint that might not be honored.
+    pub render_size_hint: AudioContextRenderSizeCategory,
 }
 
 /// This interface represents an audio graph whose `AudioDestinationNode` is routed to a real-time
@@ -271,6 +290,7 @@ impl AudioContext {
             sample_rate: Some(self.sample_rate()),
             latency_hint: AudioContextLatencyCategory::default(), // todo reuse existing setting
             sink_id,
+            render_size_hint: AudioContextRenderSizeCategory::default(), // todo reuse existing setting
         };
         *backend_manager_guard = io::build_output(options, self.render_thread_init.clone());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 
 /// Render quantum size, the audio graph is rendered in blocks of RENDER_QUANTUM_SIZE samples
 /// see. <https://webaudio.github.io/web-audio-api/#render-quantum>
-pub const RENDER_QUANTUM_SIZE: usize = 128;
+pub(crate) const RENDER_QUANTUM_SIZE: usize = 128;
 
 /// Maximum number of channels for audio processing
 pub const MAX_CHANNELS: usize = 32;

--- a/src/node/dynamics_compressor.rs
+++ b/src/node/dynamics_compressor.rs
@@ -338,7 +338,7 @@ impl AudioProcessor for DynamicsCompressorRenderer {
             let mut max = f32::MIN;
 
             for channel in input.channels().iter() {
-                let sample = channel.as_slice()[i].abs();
+                let sample = channel[i].abs();
                 if sample > max {
                     max = sample;
                 }

--- a/src/node/media_stream_destination.rs
+++ b/src/node/media_stream_destination.rs
@@ -125,11 +125,7 @@ impl AudioProcessor for DestinationRenderer {
         let input = &inputs[0];
 
         // convert AudioRenderQuantum to AudioBuffer
-        let samples: Vec<_> = input
-            .channels()
-            .iter()
-            .map(|c| c.as_slice().to_vec())
-            .collect();
+        let samples: Vec<_> = input.channels().iter().map(|c| c.to_vec()).collect();
         let buffer = AudioBuffer::from(samples, scope.sample_rate);
 
         // clear previous entry if it was not consumed

--- a/src/node/panner.rs
+++ b/src/node/panner.rs
@@ -637,11 +637,8 @@ impl AudioProcessor for PannerRenderer {
                 projected_source = [0., 0., 1.];
             }
 
-            let output_interleaved = hrtf_state.process(
-                output.channel_data(0),
-                new_distance_gain,
-                projected_source,
-            );
+            let output_interleaved =
+                hrtf_state.process(output.channel_data(0), new_distance_gain, projected_source);
 
             let [left, right] = output.stereo_mut();
             output_interleaved

--- a/src/node/panner.rs
+++ b/src/node/panner.rs
@@ -638,7 +638,7 @@ impl AudioProcessor for PannerRenderer {
             }
 
             let output_interleaved = hrtf_state.process(
-                output.channel_data(0).as_slice(),
+                output.channel_data(0),
                 new_distance_gain,
                 projected_source,
             );

--- a/src/render/processor.rs
+++ b/src/render/processor.rs
@@ -100,9 +100,9 @@ impl<'a> AudioParamValues<'a> {
 
     /// Get the computed values for the given [`crate::param::AudioParam`]
     ///
-    /// For k-rate params or if the (a-rate) parameter is constant for this block, it will
-    /// provide a slice of length 1. In other cases, i.e. a-rate param with scheduled
-    /// automations it will provide a slice of length [`crate::RENDER_QUANTUM_SIZE`]
+    /// For k-rate params or if the (a-rate) parameter is constant for this block, it will provide
+    /// a slice of length 1. In other cases, i.e. a-rate param with scheduled automations it will
+    /// provide a slice of length equal to the render quantum size (default: 128)
     #[allow(clippy::missing_panics_doc)]
     pub fn get(&self, index: &AudioParamId) -> impl Deref<Target = [f32]> + '_ {
         DerefAudioRenderQuantumChannel(self.nodes.get(&index.into()).unwrap().borrow())

--- a/src/render/quantum.rs
+++ b/src/render/quantum.rs
@@ -169,7 +169,7 @@ impl std::ops::Drop for AudioRenderQuantumChannel {
 /// Render thread audio buffer, consisting of multiple channel buffers
 ///
 /// This is a  fixed length audio asset of `render_quantum_size` sample frames for block rendering,
-/// basically a matrix of `channels * AudioRenderQuantumChannel` cf.
+/// basically a list of [`AudioRenderQuantumChannel`]s cf.
 /// <https://webaudio.github.io/web-audio-api/#render-quantum>
 ///
 /// The `render_quantum_size` is equal to 128 by default, but in future versions it may be equal to
@@ -268,7 +268,10 @@ impl AudioRenderQuantum {
         &mut self.channels[..]
     }
 
-    pub(crate) fn is_silent(&self) -> bool {
+    /// `O(1)` check if this buffer is equal to the 'silence buffer'
+    ///
+    /// If this function returns false, it is still possible for all samples to be zero.
+    pub fn is_silent(&self) -> bool {
         !self.channels.iter().any(|channel| !channel.is_silent())
     }
 
@@ -518,6 +521,9 @@ impl AudioRenderQuantum {
     }
 
     /// Convert this buffer to silence
+    ///
+    /// `O(1)` operation to convert this buffer to the 'silence buffer' which will enable some
+    /// optimizations in the graph rendering.
     pub fn make_silent(&mut self) {
         let silence = self.channels[0].silence();
 

--- a/src/render/quantum.rs
+++ b/src/render/quantum.rs
@@ -111,12 +111,12 @@ impl AudioRenderQuantumChannel {
     /// `O(1)` check if this buffer is equal to the 'silence buffer'
     ///
     /// If this function returns false, it is still possible for all samples to be zero.
-    pub fn is_silent(&self) -> bool {
+    pub(crate) fn is_silent(&self) -> bool {
         Rc::ptr_eq(&self.data, &self.alloc.zeroes)
     }
 
     /// Sum two channels
-    pub fn add(&mut self, other: &Self) {
+    pub(crate) fn add(&mut self, other: &Self) {
         if self.is_silent() {
             *self = other.clone();
         } else if !other.is_silent() {
@@ -135,10 +135,10 @@ impl AudioRenderQuantumChannel {
 use std::ops::{Deref, DerefMut};
 
 impl Deref for AudioRenderQuantumChannel {
-    type Target = [f32; RENDER_QUANTUM_SIZE];
+    type Target = [f32];
 
     fn deref(&self) -> &Self::Target {
-        &self.data
+        self.data.as_slice()
     }
 }
 
@@ -262,7 +262,7 @@ impl AudioRenderQuantum {
         &mut self.channels[..]
     }
 
-    pub fn is_silent(&self) -> bool {
+    pub(crate) fn is_silent(&self) -> bool {
         !self.channels.iter().any(|channel| !channel.is_silent())
     }
 
@@ -639,7 +639,7 @@ mod tests {
                 assert_eq!(alloc.pool_size(), 2);
 
                 // but should be silent, even though a dirty buffer is taken
-                assert_float_eq!(&a_vals[..], &[0.; RENDER_QUANTUM_SIZE][..], abs_all <= 0.);
+                assert_float_eq!(a_vals, &[0.; RENDER_QUANTUM_SIZE][..], abs_all <= 0.);
 
                 // is_silent is a superficial ptr check
                 assert!(!a.is_silent());

--- a/src/render/quantum.rs
+++ b/src/render/quantum.rs
@@ -75,8 +75,11 @@ impl AllocInner {
 
 /// Render thread channel buffer
 ///
-/// Basically wraps a `Rc<[f32; RENDER_QUANTUM_SIZE]>`, which means it derefs to a (mutable) slice
+/// Basically wraps a `Rc<[f32; render_quantum_size]>`, which means it derefs to a (mutable) slice
 /// of `[f32]` sample values. Plus it has copy-on-write semantics, so it is cheap to clone.
+///
+/// The `render_quantum_size` is equal to 128 by default, but in future versions it may be equal to
+/// the hardware preferred render quantum size or any other value.
 ///
 /// # Usage
 ///
@@ -165,9 +168,12 @@ impl std::ops::Drop for AudioRenderQuantumChannel {
 
 /// Render thread audio buffer, consisting of multiple channel buffers
 ///
-/// Internal fixed length audio asset of `RENDER_QUANTUM_SIZE` sample frames for
-/// block rendering, basically a matrix of `channels * AudioRenderQuantumChannel`
-/// cf. <https://webaudio.github.io/web-audio-api/#render-quantum>
+/// This is a  fixed length audio asset of `render_quantum_size` sample frames for block rendering,
+/// basically a matrix of `channels * AudioRenderQuantumChannel` cf.
+/// <https://webaudio.github.io/web-audio-api/#render-quantum>
+///
+/// The `render_quantum_size` is equal to 128 by default, but in future versions it may be equal to
+/// the hardware preferred render quantum size or any other value.
 ///
 /// An `AudioRenderQuantum` has copy-on-write semantics, so it is cheap to clone.
 ///

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -1,7 +1,6 @@
 use web_audio_api::context::{AudioContextRegistration, BaseAudioContext, OfflineAudioContext};
 use web_audio_api::node::{AudioNode, ChannelConfig};
 use web_audio_api::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum, RenderScope};
-use web_audio_api::RENDER_QUANTUM_SIZE;
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -29,7 +28,7 @@ fn test_ordering_with_cycle_breakers(
         nodes.shuffle(&mut rng);
         edges.shuffle(&mut rng);
 
-        let context = OfflineAudioContext::new(1, RENDER_QUANTUM_SIZE, 44_100.);
+        let context = OfflineAudioContext::new(1, 128, 44_100.);
         let collect = Arc::new(Mutex::new(vec![]));
 
         let map: HashMap<_, _> = nodes

--- a/tests/offline.rs
+++ b/tests/offline.rs
@@ -4,7 +4,8 @@ use web_audio_api::context::OfflineAudioContext;
 use web_audio_api::node::{
     AudioNode, AudioScheduledSourceNode, OscillatorNode, OscillatorOptions, OscillatorType,
 };
-use web_audio_api::RENDER_QUANTUM_SIZE;
+
+const RENDER_QUANTUM_SIZE: usize = 128;
 
 #[test]
 fn test_offline_render() {


### PR DESCRIPTION
I think we have settled on most of the public API surface. However in preparation of #217  I think one more modification must be made: remove the constant `RENDER_QUANTUM_SIZE`. 

Relatest to #76 and #140

Might have performance impact. I will add more benchmarks