### PR TITLE
AudioContext.onsinkchange + some fixes on event handling

### DIFF
--- a/examples/event_emitter.rs
+++ b/examples/event_emitter.rs
@@ -17,7 +17,7 @@ fn main() {
 
     // @todo - should receive an event
     src.onended(|| {
-        println!("> Ended event trigerred!");
+        println!("> Ended event triggered!");
     });
 
     let now = audio_context.current_time();

--- a/examples/sink_id.rs
+++ b/examples/sink_id.rs
@@ -31,6 +31,8 @@ fn main() {
     let context = AudioContext::new(options);
     println!("Playing beep for sink {:?}", context.sink_id());
 
+    context.onsinkchange(|| println!("sink change event"));
+
     // Create an oscillator node with sine (default) type
     let osc = context.create_oscillator();
     osc.connect(&context.destination());

--- a/src/capacity.rs
+++ b/src/capacity.rs
@@ -170,7 +170,10 @@ impl AudioRenderCapacity {
         }
     }
 
-    /// An EventHandler for [`AudioRenderCapacityEvent`].
+    /// The EventHandler for [`AudioRenderCapacityEvent`].
+    ///
+    /// Only a single event handler is active at any time. Calling this method multiple times will
+    /// disable the previous event handlers.
     #[allow(clippy::missing_panics_doc)]
     pub fn onupdate<F: FnMut(AudioRenderCapacityEvent) + Send + 'static>(&self, callback: F) {
         *self.callback.lock().unwrap() = Some(Box::new(callback));

--- a/src/context/concrete_base.rs
+++ b/src/context/concrete_base.rs
@@ -4,7 +4,7 @@ use crate::context::{
     AudioContextRegistration, AudioContextState, AudioNodeId, BaseAudioContext,
     DESTINATION_NODE_ID, LISTENER_NODE_ID, LISTENER_PARAM_IDS,
 };
-use crate::events::{EventHandler, EventLoop, EventType, TriggerEventMessage};
+use crate::events::{Callback, EventHandler, EventLoop, EventType, TriggerEventMessage};
 use crate::message::ControlMessage;
 use crate::node::{AudioDestinationNode, AudioNode, ChannelConfig, ChannelConfigOptions};
 use crate::param::{AudioParam, AudioParamEvent};
@@ -402,7 +402,7 @@ impl ConcreteBaseAudioContext {
         &self,
         node: &dyn AudioNode,
         event_type: EventType,
-        callback: Box<dyn FnMut() + Send + 'static>,
+        callback: Callback,
     ) {
         self.inner.event_loop.add_handler(EventHandler {
             node_id: node.registration().id(),

--- a/src/context/concrete_base.rs
+++ b/src/context/concrete_base.rs
@@ -4,7 +4,7 @@ use crate::context::{
     AudioContextRegistration, AudioContextState, AudioNodeId, BaseAudioContext,
     DESTINATION_NODE_ID, LISTENER_NODE_ID, LISTENER_PARAM_IDS,
 };
-use crate::events::{Callback, EventHandler, EventLoop, EventType, TriggerEventMessage};
+use crate::events::{Callback, Event, EventHandler, EventLoop};
 use crate::message::ControlMessage;
 use crate::node::{AudioDestinationNode, AudioNode, ChannelConfig, ChannelConfigOptions};
 use crate::param::{AudioParam, AudioParamEvent};
@@ -122,7 +122,7 @@ impl ConcreteBaseAudioContext {
         max_channel_count: usize,
         frames_played: Arc<AtomicU64>,
         render_channel: Sender<ControlMessage>,
-        event_channel: Option<Receiver<TriggerEventMessage>>,
+        event_channel: Option<Receiver<Event>>,
         offline: bool,
     ) -> Self {
         let event_loop = EventLoop::new();
@@ -398,16 +398,9 @@ impl ConcreteBaseAudioContext {
         self.inner.offline
     }
 
-    pub(crate) fn register_event_handler(
-        &self,
-        node: &dyn AudioNode,
-        event_type: EventType,
-        callback: Callback,
-    ) {
-        self.inner.event_loop.add_handler(EventHandler {
-            node_id: node.registration().id(),
-            event_type,
-            callback,
-        });
+    pub(crate) fn register_event_handler(&self, event: Event, callback: Callback) {
+        self.inner
+            .event_loop
+            .add_handler(EventHandler { event, callback });
     }
 }

--- a/src/context/concrete_base.rs
+++ b/src/context/concrete_base.rs
@@ -198,9 +198,9 @@ impl ConcreteBaseAudioContext {
             std::thread::spawn(move || loop {
                 // (?) this thread is dedicated to event so we can block
                 if let Ok(message) = event_channel.recv() {
-                    let handlers = event_handlers.lock().unwrap();
+                    let mut handlers = event_handlers.lock().unwrap();
                     // find EventHandlerInfos that match messsage
-                    if let Some(infos) = handlers.iter().find(|item| {
+                    if let Some(infos) = handlers.iter_mut().find(|item| {
                         item.node_id == message.node_id && item.event_type == message.event_type
                     }) {
                         (infos.callback)();
@@ -414,7 +414,7 @@ impl ConcreteBaseAudioContext {
         &self,
         node: &dyn AudioNode,
         event_type: EventType,
-        callback: Box<dyn Fn() + Send + Sync + 'static>,
+        callback: Box<dyn FnMut() + Send + 'static>,
     ) {
         let handler = EventHandler {
             node_id: node.registration().id(),

--- a/src/context/concrete_base.rs
+++ b/src/context/concrete_base.rs
@@ -4,7 +4,7 @@ use crate::context::{
     AudioContextRegistration, AudioContextState, AudioNodeId, BaseAudioContext,
     DESTINATION_NODE_ID, LISTENER_NODE_ID, LISTENER_PARAM_IDS,
 };
-use crate::events::{EventHandler, EventType, TriggerEventMessage};
+use crate::events::{EventHandler, EventLoop, EventType, TriggerEventMessage};
 use crate::message::ControlMessage;
 use crate::node::{AudioDestinationNode, AudioNode, ChannelConfig, ChannelConfigOptions};
 use crate::param::{AudioParam, AudioParamEvent};
@@ -66,7 +66,7 @@ struct ConcreteBaseAudioContextInner {
     /// Describes the current state of the `ConcreteBaseAudioContext`
     state: AtomicU8,
     /// Stores the event handlers
-    event_handlers: Arc<Mutex<Vec<EventHandler>>>,
+    event_loop: EventLoop,
 }
 
 impl BaseAudioContext for ConcreteBaseAudioContext {
@@ -125,6 +125,8 @@ impl ConcreteBaseAudioContext {
         event_channel: Option<Receiver<TriggerEventMessage>>,
         offline: bool,
     ) -> Self {
+        let event_loop = EventLoop::new();
+
         let base_inner = ConcreteBaseAudioContextInner {
             sample_rate,
             max_channel_count,
@@ -137,7 +139,7 @@ impl ConcreteBaseAudioContext {
             listener_params: None,
             offline,
             state: AtomicU8::new(AudioContextState::Suspended as u8),
-            event_handlers: Arc::new(Mutex::new(Vec::new())),
+            event_loop: event_loop.clone(),
         };
         let base = Self {
             inner: Arc::new(base_inner),
@@ -193,21 +195,7 @@ impl ConcreteBaseAudioContext {
         // (?) only for online context
         if let Some(event_channel) = event_channel {
             // init event loop
-            let event_handlers = base.inner.event_handlers.clone();
-
-            std::thread::spawn(move || loop {
-                // (?) this thread is dedicated to event so we can block
-                if let Ok(message) = event_channel.recv() {
-                    let mut handlers = event_handlers.lock().unwrap();
-                    // find EventHandlerInfos that match messsage
-                    if let Some(infos) = handlers.iter_mut().find(|item| {
-                        item.node_id == message.node_id && item.event_type == message.event_type
-                    }) {
-                        (infos.callback)();
-                    }
-                    // execute event_handler.callback
-                }
-            });
+            event_loop.run(event_channel);
         }
 
         base
@@ -416,11 +404,10 @@ impl ConcreteBaseAudioContext {
         event_type: EventType,
         callback: Box<dyn FnMut() + Send + 'static>,
     ) {
-        let handler = EventHandler {
+        self.inner.event_loop.add_handler(EventHandler {
             node_id: node.registration().id(),
             event_type,
             callback,
-        };
-        self.inner.event_handlers.lock().unwrap().push(handler);
+        });
     }
 }

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -311,6 +311,10 @@ impl AudioContext {
         Ok(())
     }
 
+    /// Register callback to run when the audio sink has changed
+    ///
+    /// Calling this function multiple times will accumulate all event handlers. It is currently
+    /// not possible to remove an event handler.
     pub fn onsinkchange<F: FnMut() + Send + 'static>(&self, callback: F) {
         self.base().register_event_handler(
             crate::events::Event::SinkChanged,

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,4 +1,6 @@
 use crate::context::AudioNodeId;
+use crossbeam_channel::Receiver;
+use std::sync::{Arc, Mutex};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub(crate) enum EventType {
@@ -19,4 +21,37 @@ pub(crate) struct TriggerEventMessage {
     // could be Option w/ None meaning the node is dropped on the render thread
     // and listeners can be cleared
     pub event_type: EventType,
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct EventLoop {
+    callbacks: Arc<Mutex<Vec<EventHandler>>>,
+}
+
+impl EventLoop {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn run(&self, event_channel: Receiver<TriggerEventMessage>) {
+        let self_clone = self.clone();
+
+        std::thread::spawn(move || loop {
+            // this thread is dedicated to event handling so we can block
+            for message in event_channel.iter() {
+                let mut handlers = self_clone.callbacks.lock().unwrap();
+                // find EventHandlerInfos that matches messsage and execute callback
+                handlers
+                    .iter_mut()
+                    .filter(|item| {
+                        item.node_id == message.node_id && item.event_type == message.event_type
+                    })
+                    .for_each(|handler| (handler.callback)())
+            }
+        });
+    }
+
+    pub fn add_handler(&self, handler: EventHandler) {
+        self.callbacks.lock().unwrap().push(handler)
+    }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -9,7 +9,7 @@ pub(crate) struct EventHandler {
     // could be optional meaning that its a context event (cf. onSinkChange, onStateChange, etc.)
     pub node_id: AudioNodeId,
     pub event_type: EventType,
-    pub callback: Box<dyn Fn() + Send + Sync + 'static>,
+    pub callback: Box<dyn FnMut() + Send + 'static>,
 }
 
 #[derive(Debug)]

--- a/src/events.rs
+++ b/src/events.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, Mutex};
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub(crate) enum Event {
     Ended(AudioNodeId),
+    SinkChanged,
 }
 
 pub(crate) enum Callback {
@@ -54,6 +55,7 @@ impl EventLoop {
                     }
                     if let Callback::Multiple(f) = &mut handler.callback {
                         (f)();
+                        i += 1;
                     } else {
                         let handler = handlers.remove(i);
                         handler.callback.run();

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -7,7 +7,7 @@ use crossbeam_channel::{Receiver, Sender};
 
 use crate::buffer::AudioBuffer;
 use crate::context::{AudioContextLatencyCategory, AudioContextOptions};
-use crate::events::TriggerEventMessage;
+use crate::events::Event;
 use crate::message::ControlMessage;
 use crate::{AudioRenderCapacityLoad, RENDER_QUANTUM_SIZE};
 
@@ -52,7 +52,7 @@ pub(crate) struct ControlThreadInit {
     pub frames_played: Arc<AtomicU64>,
     pub ctrl_msg_send: Sender<ControlMessage>,
     pub load_value_recv: Receiver<AudioRenderCapacityLoad>,
-    pub event_recv: Receiver<TriggerEventMessage>,
+    pub event_recv: Receiver<Event>,
 }
 
 #[derive(Clone, Debug)]
@@ -60,7 +60,7 @@ pub(crate) struct RenderThreadInit {
     pub frames_played: Arc<AtomicU64>,
     pub ctrl_msg_recv: Receiver<ControlMessage>,
     pub load_value_send: Sender<AudioRenderCapacityLoad>,
-    pub event_send: Sender<TriggerEventMessage>,
+    pub event_send: Sender<Event>,
 }
 
 pub(crate) fn thread_init() -> (ControlThreadInit, RenderThreadInit) {

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -52,6 +52,7 @@ pub(crate) struct ControlThreadInit {
     pub frames_played: Arc<AtomicU64>,
     pub ctrl_msg_send: Sender<ControlMessage>,
     pub load_value_recv: Receiver<AudioRenderCapacityLoad>,
+    pub event_send: Sender<Event>,
     pub event_recv: Receiver<Event>,
 }
 
@@ -71,13 +72,13 @@ pub(crate) fn thread_init() -> (ControlThreadInit, RenderThreadInit) {
     // communication channel for render load values
     let (load_value_send, load_value_recv) = crossbeam_channel::bounded(1);
     // communication channel for events for render thread to control thread
-    // (?) fixed sized to prevent allocating memory in render thread
-    let (event_send, event_recv) = crossbeam_channel::bounded(64);
+    let (event_send, event_recv) = crossbeam_channel::unbounded();
 
     let control_thread_init = ControlThreadInit {
         frames_played: frames_played.clone(),
         ctrl_msg_send,
         load_value_recv,
+        event_send: event_send.clone(),
         event_recv,
     };
 

--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -5,7 +5,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use crate::buffer::AudioBuffer;
 use crate::context::{AudioContextRegistration, AudioParamId, BaseAudioContext};
 use crate::control::Controller;
-use crate::events::EventType;
 use crate::param::{AudioParam, AudioParamDescriptor, AutomationRate};
 use crate::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum, RenderScope};
 use crate::RENDER_QUANTUM_SIZE;
@@ -409,7 +408,7 @@ impl AudioProcessor for AudioBufferSourceRenderer {
             // @note: we need this check because this is called a until the program
             // ends, such as if the node was never removed from the graph
             if !self.ended_triggered {
-                scope.send_event(EventType::Ended);
+                scope.send_ended_event();
                 self.ended_triggered = true;
             }
             return false;
@@ -420,7 +419,7 @@ impl AudioProcessor for AudioBufferSourceRenderer {
             if computed_playback_rate > 0. && self.render_state.buffer_time >= buffer_duration {
                 output.make_silent(); // also converts to mono
                 if !self.ended_triggered {
-                    scope.send_event(EventType::Ended);
+                    scope.send_ended_event();
                     self.ended_triggered = true;
                 }
                 return false;
@@ -429,7 +428,7 @@ impl AudioProcessor for AudioBufferSourceRenderer {
             if computed_playback_rate < 0. && self.render_state.buffer_time < 0. {
                 output.make_silent(); // also converts to mono
                 if !self.ended_triggered {
-                    scope.send_event(EventType::Ended);
+                    scope.send_ended_event();
                     self.ended_triggered = true;
                 }
                 return false;

--- a/src/node/constant_source.rs
+++ b/src/node/constant_source.rs
@@ -1,6 +1,5 @@
 use crate::context::{AudioContextRegistration, AudioParamId, BaseAudioContext};
 use crate::control::Scheduler;
-use crate::events::EventType;
 use crate::param::{AudioParam, AudioParamDescriptor, AutomationRate};
 use crate::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum, RenderScope};
 use crate::RENDER_QUANTUM_SIZE;
@@ -194,7 +193,7 @@ impl AudioProcessor for ConstantSourceRenderer {
             // @note: we need this check because this is called a until the program
             // ends, such as if the node was never removed from the graph
             if !self.ended_triggered {
-                scope.send_event(EventType::Ended);
+                scope.send_ended_event();
                 self.ended_triggered = true;
             }
         }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -46,6 +46,7 @@ pub use panner::*;
 mod stereo_panner;
 pub use stereo_panner::*;
 mod waveshaper;
+use crate::events::Callback;
 pub use waveshaper::*;
 
 pub(crate) const TABLE_LENGTH_USIZE: usize = 8192;
@@ -360,14 +361,14 @@ pub trait AudioScheduledSourceNode: AudioNode {
     ///
     /// Calling this function multiple times will accumulate all event handlers. It is currently
     /// not possible to remove an event handler.
-    fn onended<F: FnMut() + Send + 'static>(&self, callback: F)
+    fn onended<F: FnOnce() + Send + 'static>(&self, callback: F)
     where
         Self: Sized,
     {
         self.context().register_event_handler(
             self,
             crate::events::EventType::Ended,
-            Box::new(callback),
+            Callback::Once(Box::new(callback)),
         );
     }
 }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -361,13 +361,9 @@ pub trait AudioScheduledSourceNode: AudioNode {
     ///
     /// Calling this function multiple times will accumulate all event handlers. It is currently
     /// not possible to remove an event handler.
-    fn onended<F: FnOnce() + Send + 'static>(&self, callback: F)
-    where
-        Self: Sized,
-    {
+    fn onended<F: FnOnce() + Send + 'static>(&self, callback: F) {
         self.context().register_event_handler(
-            self,
-            crate::events::EventType::Ended,
+            crate::events::Event::Ended(self.registration().id()),
             Callback::Once(Box::new(callback)),
         );
     }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -357,7 +357,11 @@ pub trait AudioScheduledSourceNode: AudioNode {
     /// For all [`AudioScheduledSourceNode`]s, the ended event is dispatched when the stop time
     /// determined by stop() is reached. For an [`AudioBufferSourceNode`], the event is also
     /// dispatched because the duration has been reached or if the entire buffer has been played.
-    fn onended<F: Fn() + Send + Sync + 'static>(&self, callback: F)
+    ///
+    /// Multiple event handlers can be active at any time. Calling this function multiple times
+    /// will accumulate all event handlers. It is currently not possible to remove an event
+    /// handler.
+    fn onended<F: FnMut() + Send + 'static>(&self, callback: F)
     where
         Self: Sized,
     {

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -358,9 +358,8 @@ pub trait AudioScheduledSourceNode: AudioNode {
     /// determined by stop() is reached. For an [`AudioBufferSourceNode`], the event is also
     /// dispatched because the duration has been reached or if the entire buffer has been played.
     ///
-    /// Multiple event handlers can be active at any time. Calling this function multiple times
-    /// will accumulate all event handlers. It is currently not possible to remove an event
-    /// handler.
+    /// Calling this function multiple times will accumulate all event handlers. It is currently
+    /// not possible to remove an event handler.
     fn onended<F: FnMut() + Send + 'static>(&self, callback: F)
     where
         Self: Sized,

--- a/src/node/oscillator.rs
+++ b/src/node/oscillator.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 
 use crate::context::{AudioContextRegistration, AudioParamId, BaseAudioContext};
 use crate::control::Scheduler;
-use crate::events::EventType;
 use crate::param::{AudioParam, AudioParamDescriptor, AutomationRate};
 use crate::periodic_wave::PeriodicWave;
 use crate::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum, RenderScope};
@@ -366,7 +365,7 @@ impl AudioProcessor for OscillatorRenderer {
             // @note: we need this check because this is called a until the program
             // ends, such as if the node was never removed from the graph
             if !self.ended_triggered {
-                scope.send_event(EventType::Ended);
+                scope.send_ended_event();
                 self.ended_triggered = true;
             }
 

--- a/src/render/processor.rs
+++ b/src/render/processor.rs
@@ -1,6 +1,6 @@
 //! Audio processing code that runs on the audio rendering thread
 use crate::context::{AudioNodeId, AudioParamId};
-use crate::events::{EventType, TriggerEventMessage};
+use crate::events::Event;
 use crate::RENDER_QUANTUM_SIZE;
 
 use super::{graph::Node, AudioRenderQuantum};
@@ -22,17 +22,13 @@ pub struct RenderScope {
     pub sample_rate: f32,
 
     pub(crate) node_id: Cell<AudioNodeId>,
-    pub(crate) event_sender: Option<Sender<TriggerEventMessage>>,
+    pub(crate) event_sender: Option<Sender<Event>>,
 }
 
 impl RenderScope {
-    pub(crate) fn send_event(&self, event_type: EventType) {
+    pub(crate) fn send_ended_event(&self) {
         if let Some(sender) = self.event_sender.as_ref() {
-            let message = TriggerEventMessage {
-                node_id: self.node_id.get(),
-                event_type,
-            };
-            let _ = sender.try_send(message);
+            let _ = sender.try_send(Event::Ended(self.node_id.get()));
         }
     }
 }

--- a/src/render/thread.rs
+++ b/src/render/thread.rs
@@ -10,7 +10,7 @@ use crossbeam_channel::{Receiver, Sender};
 use super::AudioRenderQuantum;
 use crate::buffer::{AudioBuffer, AudioBufferOptions};
 use crate::context::AudioNodeId;
-use crate::events::TriggerEventMessage;
+use crate::events::Event;
 use crate::message::ControlMessage;
 use crate::node::ChannelInterpretation;
 use crate::render::RenderScope;
@@ -27,7 +27,7 @@ pub(crate) struct RenderThread {
     receiver: Option<Receiver<ControlMessage>>,
     buffer_offset: Option<(usize, AudioRenderQuantum)>,
     load_value_sender: Option<Sender<AudioRenderCapacityLoad>>,
-    event_sender: Option<Sender<TriggerEventMessage>>,
+    event_sender: Option<Sender<Event>>,
 }
 
 // SAFETY:
@@ -48,7 +48,7 @@ impl RenderThread {
         receiver: Receiver<ControlMessage>,
         frames_played: Arc<AtomicU64>,
         load_value_sender: Option<Sender<AudioRenderCapacityLoad>>,
-        event_sender: Option<Sender<TriggerEventMessage>>,
+        event_sender: Option<Sender<Event>>,
     ) -> Self {
         Self {
             graph: None,

--- a/tests/online.rs
+++ b/tests/online.rs
@@ -1,10 +1,13 @@
-/// Test for the online AudioContext
-///
-/// Our CI runner has no sound card enabled so these tests are 'compile time checks' only, we
-/// cannot run them.
+//! Test for the online AudioContext
+//!
+//! Our CI runner has no sound card enabled so these tests are 'compile time checks' and checks
+//! using the 'none' audio backend.
+
 use web_audio_api::context::{
     AudioContext, AudioContextOptions, AudioContextState, BaseAudioContext,
 };
+
+use std::sync::atomic::{AtomicBool, Ordering};
 
 fn require_send_sync_static<T: Send + Sync + 'static>(_: T) {}
 
@@ -23,11 +26,15 @@ fn test_none_sink_id() {
 
     // construct with 'none' sink_id
     let context = AudioContext::new(options);
-    assert!(context.sink_id() == "none");
+    assert_eq!(context.sink_id(), "none");
 
     // changing sink_id to 'none' again should make no changes
+    let sink_stable = &*Box::leak(Box::new(AtomicBool::new(true)));
+    context.onsinkchange(move || {
+        sink_stable.store(false, Ordering::SeqCst);
+    });
     context.set_sink_id_sync("none".into()).unwrap();
-    assert!(context.sink_id() == "none");
+    assert_eq!(context.sink_id(), "none");
 
     context.suspend_sync();
     assert_eq!(context.state(), AudioContextState::Suspended);
@@ -37,4 +44,6 @@ fn test_none_sink_id() {
 
     context.close_sync();
     assert_eq!(context.state(), AudioContextState::Closed);
+
+    assert!(sink_stable.load(Ordering::SeqCst));
 }


### PR DESCRIPTION
- implement onsinkchange, add test, use in sink_id example
- refactor event thread code into an EventLoop
- drop event handlers of type Ended when they have run
- use Fn for 1-time event handlers, FnMut for handlers that can run multiple times
- set state to Suspended for AudioContext while we change the sink id