### PR TITLE
Ability to cancel event handler

### DIFF
--- a/examples/convolution.rs
+++ b/examples/convolution.rs
@@ -10,7 +10,7 @@ fn main() {
     let context = AudioContext::default();
 
     let cap = context.render_capacity();
-    cap.onupdate(|e| println!("{:?}", e));
+    cap.onupdate(Some(|e| println!("{:?}", e)));
     cap.start(AudioRenderCapacityOptions {
         update_interval: 1.,
     });

--- a/examples/convolution.rs
+++ b/examples/convolution.rs
@@ -10,7 +10,7 @@ fn main() {
     let context = AudioContext::default();
 
     let cap = context.render_capacity();
-    cap.onupdate(Some(|e| println!("{:?}", e)));
+    cap.set_onupdate(|e| println!("{:?}", e));
     cap.start(AudioRenderCapacityOptions {
         update_interval: 1.,
     });

--- a/examples/event_emitter.rs
+++ b/examples/event_emitter.rs
@@ -15,10 +15,9 @@ fn main() {
     src.connect(&audio_context.destination());
     src.set_buffer(buffer);
 
-    // @todo - should receive an event
-    src.onended(Some(|| {
+    src.set_onended(|| {
         println!("> Ended event triggered!");
-    }));
+    });
 
     let now = audio_context.current_time();
     src.start_at(now);

--- a/examples/event_emitter.rs
+++ b/examples/event_emitter.rs
@@ -16,9 +16,9 @@ fn main() {
     src.set_buffer(buffer);
 
     // @todo - should receive an event
-    src.onended(|| {
+    src.onended(Some(|| {
         println!("> Ended event triggered!");
-    });
+    }));
 
     let now = audio_context.current_time();
     src.start_at(now);

--- a/examples/sink_id.rs
+++ b/examples/sink_id.rs
@@ -31,7 +31,7 @@ fn main() {
     let context = AudioContext::new(options);
     println!("Playing beep for sink {:?}", context.sink_id());
 
-    context.onsinkchange(|| println!("sink change event"));
+    context.onsinkchange(Some(|| println!("sink change event")));
 
     // Create an oscillator node with sine (default) type
     let osc = context.create_oscillator();

--- a/examples/sink_id.rs
+++ b/examples/sink_id.rs
@@ -31,7 +31,7 @@ fn main() {
     let context = AudioContext::new(options);
     println!("Playing beep for sink {:?}", context.sink_id());
 
-    context.onsinkchange(Some(|| println!("sink change event")));
+    context.set_onsinkchange(|| println!("sink change event"));
 
     // Create an oscillator node with sine (default) type
     let osc = context.create_oscillator();

--- a/src/capacity.rs
+++ b/src/capacity.rs
@@ -172,16 +172,24 @@ impl AudioRenderCapacity {
     ///
     /// Only a single event handler is active at any time. Calling this method multiple times will
     /// override the previous event handler.
-    pub fn onupdate<F: FnMut(AudioRenderCapacityEvent) + Send + 'static>(&self, value: Option<F>) {
-        let callback = value.map(|mut f| {
-            let callback = move |event: Event| match event {
-                Event::RenderCapacity(payload) => f(payload),
-                _ => unreachable!(),
-            };
-            EventHandler::Multiple(Box::new(callback))
-        });
+    pub fn set_onupdate<F: FnMut(AudioRenderCapacityEvent) + Send + 'static>(
+        &self,
+        mut callback: F,
+    ) {
+        let callback = move |event: Event| match event {
+            Event::RenderCapacity(payload) => callback(payload),
+            _ => unreachable!(),
+        };
 
+        self.context.set_event_handler(
+            Event::RenderCapacity(Default::default()),
+            EventHandler::Multiple(Box::new(callback)),
+        );
+    }
+
+    /// Unset the EventHandler for [`AudioRenderCapacityEvent`].
+    pub fn clear_onupdate(&self) {
         self.context
-            .set_event_handler(Event::RenderCapacity(Default::default()), callback);
+            .clear_event_handler(Event::RenderCapacity(Default::default()));
     }
 }

--- a/src/capacity.rs
+++ b/src/capacity.rs
@@ -2,7 +2,7 @@ use crossbeam_channel::{Receiver, Sender};
 use std::sync::{Arc, Mutex};
 
 use crate::context::{BaseAudioContext, ConcreteBaseAudioContext};
-use crate::events::{Callback, Event};
+use crate::events::{Event, EventHandler};
 
 #[derive(Copy, Clone)]
 pub(crate) struct AudioRenderCapacityLoad {
@@ -170,8 +170,8 @@ impl AudioRenderCapacity {
 
     /// The EventHandler for [`AudioRenderCapacityEvent`].
     ///
-    /// Calling this function multiple times will accumulate all event handlers. It is currently
-    /// not possible to remove an event handler.
+    /// Only a single event handler is active at any time. Calling this method multiple times will
+    /// override the previous event handler.
     pub fn onupdate<F: FnMut(AudioRenderCapacityEvent) + Send + 'static>(&self, mut callback: F) {
         let callback = move |event: Event| match event {
             Event::RenderCapacity(payload) => callback(payload),
@@ -180,7 +180,7 @@ impl AudioRenderCapacity {
 
         self.context.register_event_handler(
             crate::events::Event::RenderCapacity(Default::default()),
-            Callback::Multiple(Box::new(callback)),
+            EventHandler::Multiple(Box::new(callback)),
         );
     }
 }

--- a/src/context/concrete_base.rs
+++ b/src/context/concrete_base.rs
@@ -412,7 +412,11 @@ impl ConcreteBaseAudioContext {
         self.inner.offline
     }
 
-    pub(crate) fn set_event_handler(&self, event: Event, callback: Option<EventHandler>) {
+    pub(crate) fn set_event_handler(&self, event: Event, callback: EventHandler) {
         self.inner.event_loop.set_handler(event, callback);
+    }
+
+    pub(crate) fn clear_event_handler(&self, event: Event) {
+        self.inner.event_loop.clear_handler(event);
     }
 }

--- a/src/context/concrete_base.rs
+++ b/src/context/concrete_base.rs
@@ -412,7 +412,7 @@ impl ConcreteBaseAudioContext {
         self.inner.offline
     }
 
-    pub(crate) fn register_event_handler(&self, event: Event, callback: EventHandler) {
-        self.inner.event_loop.add_handler(event, callback);
+    pub(crate) fn set_event_handler(&self, event: Event, callback: Option<EventHandler>) {
+        self.inner.event_loop.set_handler(event, callback);
     }
 }

--- a/src/context/concrete_base.rs
+++ b/src/context/concrete_base.rs
@@ -4,7 +4,7 @@ use crate::context::{
     AudioContextRegistration, AudioContextState, AudioNodeId, BaseAudioContext,
     DESTINATION_NODE_ID, LISTENER_NODE_ID, LISTENER_PARAM_IDS,
 };
-use crate::events::{Callback, Event, EventHandler, EventLoop};
+use crate::events::{Event, EventHandler, EventLoop};
 use crate::message::ControlMessage;
 use crate::node::{AudioDestinationNode, AudioNode, ChannelConfig, ChannelConfigOptions};
 use crate::param::{AudioParam, AudioParamEvent};
@@ -412,9 +412,7 @@ impl ConcreteBaseAudioContext {
         self.inner.offline
     }
 
-    pub(crate) fn register_event_handler(&self, event: Event, callback: Callback) {
-        self.inner
-            .event_loop
-            .add_handler(EventHandler { event, callback });
+    pub(crate) fn register_event_handler(&self, event: Event, callback: EventHandler) {
+        self.inner.event_loop.add_handler(event, callback);
     }
 }

--- a/src/context/concrete_base.rs
+++ b/src/context/concrete_base.rs
@@ -4,7 +4,7 @@ use crate::context::{
     AudioContextRegistration, AudioContextState, AudioNodeId, BaseAudioContext,
     DESTINATION_NODE_ID, LISTENER_NODE_ID, LISTENER_PARAM_IDS,
 };
-use crate::events::{Event, EventHandler, EventLoop};
+use crate::events::{Event, EventHandler, EventLoop, EventType};
 use crate::message::ControlMessage;
 use crate::node::{AudioDestinationNode, AudioNode, ChannelConfig, ChannelConfigOptions};
 use crate::param::{AudioParam, AudioParamEvent};
@@ -412,11 +412,11 @@ impl ConcreteBaseAudioContext {
         self.inner.offline
     }
 
-    pub(crate) fn set_event_handler(&self, event: Event, callback: EventHandler) {
+    pub(crate) fn set_event_handler(&self, event: EventType, callback: EventHandler) {
         self.inner.event_loop.set_handler(event, callback);
     }
 
-    pub(crate) fn clear_event_handler(&self, event: Event) {
+    pub(crate) fn clear_event_handler(&self, event: EventType) {
         self.inner.event_loop.clear_handler(event);
     }
 }

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -301,12 +301,14 @@ impl AudioContext {
     ///
     /// Only a single event handler is active at any time. Calling this method multiple times will
     /// override the previous event handler.
-    pub fn onsinkchange<F: FnMut() + Send + 'static>(&self, mut callback: F) {
-        let callback = move |_| callback();
-        self.base().register_event_handler(
-            crate::events::Event::SinkChanged,
-            EventHandler::Multiple(Box::new(callback)),
-        );
+    pub fn onsinkchange<F: FnMut() + Send + 'static>(&self, value: Option<F>) {
+        let callback = value.map(|mut f| {
+            let callback = move |_| f();
+            EventHandler::Multiple(Box::new(callback))
+        });
+
+        self.base()
+            .set_event_handler(crate::events::Event::SinkChanged, callback)
     }
 
     /// Suspends the progression of time in the audio context.

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -8,7 +8,7 @@ use crate::message::ControlMessage;
 use crate::node::{self, ChannelConfigOptions};
 use crate::AudioRenderCapacity;
 
-use crate::events::{Callback, Event};
+use crate::events::{Event, EventHandler};
 use std::error::Error;
 use std::sync::Mutex;
 
@@ -299,13 +299,13 @@ impl AudioContext {
 
     /// Register callback to run when the audio sink has changed
     ///
-    /// Calling this function multiple times will accumulate all event handlers. It is currently
-    /// not possible to remove an event handler.
+    /// Only a single event handler is active at any time. Calling this method multiple times will
+    /// override the previous event handler.
     pub fn onsinkchange<F: FnMut() + Send + 'static>(&self, mut callback: F) {
         let callback = move |_| callback();
         self.base().register_event_handler(
             crate::events::Event::SinkChanged,
-            Callback::Multiple(Box::new(callback)),
+            EventHandler::Multiple(Box::new(callback)),
         );
     }
 

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -301,14 +301,18 @@ impl AudioContext {
     ///
     /// Only a single event handler is active at any time. Calling this method multiple times will
     /// override the previous event handler.
-    pub fn onsinkchange<F: FnMut() + Send + 'static>(&self, value: Option<F>) {
-        let callback = value.map(|mut f| {
-            let callback = move |_| f();
-            EventHandler::Multiple(Box::new(callback))
-        });
+    pub fn set_onsinkchange<F: FnMut() + Send + 'static>(&self, mut callback: F) {
+        let callback = move |_| callback();
 
-        self.base()
-            .set_event_handler(crate::events::Event::SinkChanged, callback)
+        self.base().set_event_handler(
+            Event::SinkChanged,
+            EventHandler::Multiple(Box::new(callback)),
+        );
+    }
+
+    /// Unset the callback to run when the audio sink has changed
+    pub fn clear_onsinkchange(&self) {
+        self.base().clear_event_handler(Event::SinkChanged);
     }
 
     /// Suspends the progression of time in the audio context.

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -8,7 +8,7 @@ use crate::message::ControlMessage;
 use crate::node::{self, ChannelConfigOptions};
 use crate::AudioRenderCapacity;
 
-use crate::events::{Event, EventHandler};
+use crate::events::{Event, EventHandler, EventType};
 use std::error::Error;
 use std::sync::Mutex;
 
@@ -292,7 +292,7 @@ impl AudioContext {
         drop(backend_manager_guard);
 
         // trigger event when all the work is done
-        let _ = self.base.send_event(Event::SinkChanged);
+        let _ = self.base.send_event(Event::sink_changed());
 
         Ok(())
     }
@@ -305,14 +305,14 @@ impl AudioContext {
         let callback = move |_| callback();
 
         self.base().set_event_handler(
-            Event::SinkChanged,
+            EventType::SinkChanged,
             EventHandler::Multiple(Box::new(callback)),
         );
     }
 
     /// Unset the callback to run when the audio sink has changed
     pub fn clear_onsinkchange(&self) {
-        self.base().clear_event_handler(Event::SinkChanged);
+        self.base().clear_event_handler(EventType::SinkChanged);
     }
 
     /// Suspends the progression of time in the audio context.

--- a/src/events.rs
+++ b/src/events.rs
@@ -85,11 +85,11 @@ impl EventLoop {
         });
     }
 
-    pub fn set_handler(&self, event: Event, callback: Option<EventHandler>) {
-        let mut event_handlers = self.event_handlers.lock().unwrap();
-        match callback {
-            Some(callback) => event_handlers.insert(event, callback),
-            None => event_handlers.remove(&event),
-        };
+    pub fn set_handler(&self, event: Event, callback: EventHandler) {
+        self.event_handlers.lock().unwrap().insert(event, callback);
+    }
+
+    pub fn clear_handler(&self, event: Event) {
+        self.event_handlers.lock().unwrap().remove(&event);
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -85,7 +85,11 @@ impl EventLoop {
         });
     }
 
-    pub fn add_handler(&self, event: Event, callback: EventHandler) {
-        self.event_handlers.lock().unwrap().insert(event, callback);
+    pub fn set_handler(&self, event: Event, callback: Option<EventHandler>) {
+        let mut event_handlers = self.event_handlers.lock().unwrap();
+        match callback {
+            Some(callback) => event_handlers.insert(event, callback),
+            None => event_handlers.remove(&event),
+        };
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,13 +1,37 @@
 use crate::context::AudioNodeId;
 use crate::AudioRenderCapacityEvent;
-use crossbeam_channel::Receiver;
+
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
 use std::sync::{Arc, Mutex};
+
+use crossbeam_channel::Receiver;
 
 #[derive(Debug, Clone)]
 pub(crate) enum Event {
     Ended(AudioNodeId),
     SinkChanged,
     RenderCapacity(AudioRenderCapacityEvent),
+}
+
+/*
+ * Hack: derive custom PartialEq and Hash implementation for Event, ignoring the payload of the
+ * RenderCapacity variant.
+ *
+ * TODO, remove this hack and use a proper EventPayload enum alongside.
+ */
+
+impl Hash for Event {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match &self {
+            Event::Ended(id) => {
+                state.write_u8(0);
+                state.write_u64(id.0);
+            }
+            Event::SinkChanged => state.write_u8(1),
+            Event::RenderCapacity(_) => state.write_u8(2),
+        }
+    }
 }
 
 impl PartialEq for Event {
@@ -23,28 +47,16 @@ impl PartialEq for Event {
     }
 }
 
-pub(crate) enum Callback {
+impl Eq for Event {}
+
+pub(crate) enum EventHandler {
     Once(Box<dyn FnOnce(Event) + Send + 'static>),
     Multiple(Box<dyn FnMut(Event) + Send + 'static>),
 }
 
-impl Callback {
-    fn run(self, event: Event) {
-        match self {
-            Self::Once(f) => (f)(event),
-            Self::Multiple(mut f) => (f)(event),
-        }
-    }
-}
-
-pub(crate) struct EventHandler {
-    pub event: Event,
-    pub callback: Callback,
-}
-
 #[derive(Clone, Default)]
 pub(crate) struct EventLoop {
-    callbacks: Arc<Mutex<Vec<EventHandler>>>,
+    event_handlers: Arc<Mutex<HashMap<Event, EventHandler>>>,
 }
 
 impl EventLoop {
@@ -57,30 +69,23 @@ impl EventLoop {
 
         std::thread::spawn(move || loop {
             // this thread is dedicated to event handling so we can block
-            for message in event_channel.iter() {
-                let mut handlers = self_clone.callbacks.lock().unwrap();
-                // find EventHandlerInfos that matches messsage and execute callback
-
-                let mut i = 0;
-                while i < handlers.len() {
-                    let handler = &mut handlers[i];
-                    if handler.event != message {
-                        i += 1;
-                        continue;
-                    }
-                    if let Callback::Multiple(f) = &mut handler.callback {
-                        (f)(message.clone());
-                        i += 1;
-                    } else {
-                        let handler = handlers.remove(i);
-                        handler.callback.run(message.clone());
-                    }
+            for event in event_channel.iter() {
+                let mut handlers = self_clone.event_handlers.lock().unwrap();
+                if let Some(callback) = handlers.remove(&event) {
+                    match callback {
+                        EventHandler::Once(f) => (f)(event),
+                        EventHandler::Multiple(mut f) => {
+                            (f)(event.clone());
+                            handlers.insert(event, EventHandler::Multiple(f));
+                        }
+                    };
                 }
+                // handlers Mutex guard drops here
             }
         });
     }
 
-    pub fn add_handler(&self, handler: EventHandler) {
-        self.callbacks.lock().unwrap().push(handler)
+    pub fn add_handler(&self, event: Event, callback: EventHandler) {
+        self.event_handlers.lock().unwrap().insert(event, callback);
     }
 }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -46,7 +46,7 @@ pub use panner::*;
 mod stereo_panner;
 pub use stereo_panner::*;
 mod waveshaper;
-use crate::events::Callback;
+use crate::events::EventHandler;
 pub use waveshaper::*;
 
 pub(crate) const TABLE_LENGTH_USIZE: usize = 8192;
@@ -359,13 +359,13 @@ pub trait AudioScheduledSourceNode: AudioNode {
     /// determined by stop() is reached. For an [`AudioBufferSourceNode`], the event is also
     /// dispatched because the duration has been reached or if the entire buffer has been played.
     ///
-    /// Calling this function multiple times will accumulate all event handlers. It is currently
-    /// not possible to remove an event handler.
+    /// Only a single event handler is active at any time. Calling this method multiple times will
+    /// override the previous event handler.
     fn onended<F: FnOnce() + Send + 'static>(&self, callback: F) {
         let callback = |_| callback();
         self.context().register_event_handler(
             crate::events::Event::Ended(self.registration().id()),
-            Callback::Once(Box::new(callback)),
+            EventHandler::Once(Box::new(callback)),
         );
     }
 }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -362,6 +362,7 @@ pub trait AudioScheduledSourceNode: AudioNode {
     /// Calling this function multiple times will accumulate all event handlers. It is currently
     /// not possible to remove an event handler.
     fn onended<F: FnOnce() + Send + 'static>(&self, callback: F) {
+        let callback = |_| callback();
         self.context().register_event_handler(
             crate::events::Event::Ended(self.registration().id()),
             Callback::Once(Box::new(callback)),

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use crate::context::{AudioContextRegistration, ConcreteBaseAudioContext};
-use crate::events::Event;
+use crate::events::EventType;
 use crate::media::MediaStream;
 use crate::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum, RenderScope};
 
@@ -366,7 +366,7 @@ pub trait AudioScheduledSourceNode: AudioNode {
         let callback = move |_| callback();
 
         self.context().set_event_handler(
-            Event::Ended(self.registration().id()),
+            EventType::Ended(self.registration().id()),
             EventHandler::Once(Box::new(callback)),
         );
     }
@@ -374,7 +374,7 @@ pub trait AudioScheduledSourceNode: AudioNode {
     /// Unset the callback to run when the source node has stopped playing
     fn clear_onended(&self) {
         self.context()
-            .clear_event_handler(Event::Ended(self.registration().id()));
+            .clear_event_handler(EventType::Ended(self.registration().id()));
     }
 }
 

--- a/src/render/processor.rs
+++ b/src/render/processor.rs
@@ -28,7 +28,7 @@ pub struct RenderScope {
 impl RenderScope {
     pub(crate) fn send_ended_event(&self) {
         if let Some(sender) = self.event_sender.as_ref() {
-            let _ = sender.try_send(Event::Ended(self.node_id.get()));
+            let _ = sender.try_send(Event::ended(self.node_id.get()));
         }
     }
 }

--- a/tests/online.rs
+++ b/tests/online.rs
@@ -30,9 +30,9 @@ fn test_none_sink_id() {
 
     // changing sink_id to 'none' again should make no changes
     let sink_stable = &*Box::leak(Box::new(AtomicBool::new(true)));
-    context.onsinkchange(move || {
+    context.onsinkchange(Some(move || {
         sink_stable.store(false, Ordering::SeqCst);
-    });
+    }));
     context.set_sink_id_sync("none".into()).unwrap();
     assert_eq!(context.sink_id(), "none");
 

--- a/tests/online.rs
+++ b/tests/online.rs
@@ -30,9 +30,9 @@ fn test_none_sink_id() {
 
     // changing sink_id to 'none' again should make no changes
     let sink_stable = &*Box::leak(Box::new(AtomicBool::new(true)));
-    context.onsinkchange(Some(move || {
+    context.set_onsinkchange(move || {
         sink_stable.store(false, Ordering::SeqCst);
-    }));
+    });
     context.set_sink_id_sync("none".into()).unwrap();
     assert_eq!(context.sink_id(), "none");
 


### PR DESCRIPTION
FYI @b-ma  I wanted to share some quick work in progress.
There is a drawback for the API we came up with:
`pub fn onupdate<F: FnMut(AudioRenderCapacityEvent) + Send + 'static>(&self, value: Option<F>) {`
This makes it cumbersome to pass `None`, the compiler will complain:
```
43 |     cap.onupdate(None);
   |         ^^^^^^^^ cannot infer type of the type parameter `F` declared on the associated function `onupdate`
   |
help: consider specifying the generic argument
   |
43 |     cap.onupdate::<F>(None);
```
Which the user can fix by specifying:
`cap.onupdate(None::<fn(_)>);`

We should either make this very clear in the documentation, or come up with an alternative, such as:
```
pub fn onupdate_set<F: FnMut(AudioRenderCapacityEvent) + Send + 'static>(&self, value: F);
pub fn onupdate_clear<F: FnMut(AudioRenderCapacityEvent) + Send + 'static>(&self);
```