### PR TITLE
Refactor analyser node

### DIFF
--- a/examples/analyser.rs
+++ b/examples/analyser.rs
@@ -1,0 +1,22 @@
+use web_audio_api::context::{AudioContext, BaseAudioContext};
+use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
+
+fn main() {
+    let context = AudioContext::default();
+
+    let analyser = context.create_analyser();
+    analyser.connect(&context.destination());
+
+    let osc = context.create_oscillator();
+    osc.frequency().set_value(200.);
+    osc.connect(&analyser);
+    osc.start();
+
+    let mut bins = vec![0.; analyser.frequency_bin_count()];
+
+    loop {
+        analyser.get_float_frequency_data(&mut bins);
+        println!("{:?}", &bins[0..20]); // print 20 first bins
+        std::thread::sleep(std::time::Duration::from_millis(1000));
+    }
+}

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -275,7 +275,9 @@ impl Analyser {
         self.ring_buffer.read(&mut tmp, fft_size);
 
         dst.iter_mut().zip(tmp.iter()).for_each(|(o, i)| {
-            *o = (128. * (1. + i)) as u8;
+            let scaled = (128. * (1. + i));
+            let clamped = scaled.max(0).min(255);
+            *o = clamped as u8;
         });
     }
 

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -89,7 +89,7 @@ const RING_BUFFER_SIZE: usize = MAX_FFT_SIZE + RENDER_QUANTUM_SIZE;
 // single producer / multiple consumer ring buffer
 #[derive(Clone)]
 pub(crate) struct AnalyserRingBuffer {
-    buffer: Arc<Vec<AtomicF32>>,
+    buffer: Arc<[AtomicF32]>,
     write_index: Arc<AtomicUsize>,
 }
 
@@ -99,7 +99,7 @@ impl AnalyserRingBuffer {
         buffer.resize_with(RING_BUFFER_SIZE, || AtomicF32::new(0.));
 
         Self {
-            buffer: Arc::from(buffer),
+            buffer: buffer.into(),
             write_index: Arc::new(AtomicUsize::new(0)),
         }
     }

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -3,35 +3,12 @@
 //! These are used in the [`AnalyserNode`](crate::node::AnalyserNode)
 
 use std::f32::consts::PI;
-use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use realfft::{num_complex::Complex, RealFftPlanner};
 
-use crate::{RENDER_QUANTUM_SIZE};
-
-// @todo - modify AtomicF32 in `lib.rs` to expose Ordering
-#[derive(Debug)]
-struct AtomicF32 {
-    inner: AtomicU32,
-}
-
-impl AtomicF32 {
-    pub fn new(v: f32) -> Self {
-        Self {
-            inner: AtomicU32::new(u32::from_ne_bytes(v.to_ne_bytes())),
-        }
-    }
-
-    pub fn load(&self, ordering: Ordering) -> f32 {
-        f32::from_ne_bytes(self.inner.load(ordering).to_ne_bytes())
-    }
-
-    pub fn store(&self, v: f32, ordering: Ordering) {
-        self.inner
-            .store(u32::from_ne_bytes(v.to_ne_bytes()), ordering);
-    }
-}
+use crate::{RENDER_QUANTUM_SIZE, AtomicF32};
 
 /// Blackman window values iterator with alpha = 0.16
 pub fn generate_blackman(size: usize) -> impl Iterator<Item = f32> {

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -345,9 +345,10 @@ impl Analyser {
         last_fft_output
             .iter_mut()
             .zip(output.iter())
-            .for_each(|(p, c)| {
+            .for_each(|(o, c)| {
                 let norm = c.norm() * normalize_factor;
-                *p = smoothing_time_constant * *p + (1. - smoothing_time_constant) * norm;
+                let value = smoothing_time_constant * *o + (1. - smoothing_time_constant) * norm;
+                *o = if value.is_finite() { value } else { 0. };
             });
     }
 

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex};
 
 use realfft::{num_complex::Complex, RealFftPlanner};
 
-use crate::{RENDER_QUANTUM_SIZE, AtomicF32};
+use crate::{AtomicF32, RENDER_QUANTUM_SIZE};
 
 /// Blackman window values iterator with alpha = 0.16
 pub fn generate_blackman(size: usize) -> impl Iterator<Item = f32> {
@@ -41,7 +41,7 @@ fn assert_valid_fft_size(fft_size: usize) {
         );
     }
 
-    if fft_size < MIN_FFT_SIZE || fft_size > MAX_FFT_SIZE {
+    if !(MIN_FFT_SIZE..=MAX_FFT_SIZE).contains(&fft_size) {
         panic!(
             "IndexSizeError - Invalid fft size: {:?} is outside range [{:?}, {:?}]",
             fft_size, MIN_FFT_SIZE, MAX_FFT_SIZE
@@ -52,7 +52,7 @@ fn assert_valid_fft_size(fft_size: usize) {
 // [spec] If the value of this attribute is set to a value less than 0 or more
 // than 1, an IndexSizeError exception MUST be thrown.
 fn assert_valid_smoothing_time_constant(smoothing_time_constant: f64) {
-    if smoothing_time_constant < 0. || smoothing_time_constant > 1. {
+    if !(0. ..=1.).contains(&smoothing_time_constant) {
         panic!(
             "IndexSizeError - Invalid smoothing time constant: {:?} is outside range [0, 1]",
             smoothing_time_constant
@@ -278,7 +278,7 @@ impl Analyser {
 
         dst.iter_mut().zip(tmp.iter()).for_each(|(o, i)| {
             let scaled = 128. * (1. + i);
-            let clamped = scaled.max(0.).min(255.);
+            let clamped = scaled.clamp(0., 255.);
             *o = clamped as u8;
         });
     }
@@ -402,7 +402,7 @@ impl Analyser {
                 let db = 20. * b.log10();
                 // 𝑏[𝑘]=⌊255 / dB𝑚𝑎𝑥−dB𝑚𝑖𝑛 * (𝑌[𝑘]−dB𝑚𝑖𝑛)⌋
                 let scaled = 255. / (max_decibels - min_decibels) * (db - min_decibels);
-                let clamped = scaled.max(0.).min(255.);
+                let clamped = scaled.clamp(0., 255.);
                 *v = clamped as u8;
             });
     }

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -11,7 +11,7 @@ use realfft::{num_complex::Complex, RealFftPlanner};
 use crate::{AtomicF32, RENDER_QUANTUM_SIZE};
 
 /// Blackman window values iterator with alpha = 0.16
-pub fn generate_blackman(size: usize) -> impl Iterator<Item = f32> {
+fn generate_blackman(size: usize) -> impl Iterator<Item = f32> {
     let alpha = 0.16;
     let a0 = (1. - alpha) / 2.;
     let a1 = 1. / 2.;
@@ -82,7 +82,8 @@ fn assert_valid_max_decibels(max_decibels: f64, min_decibels: f64) {
     }
 }
 
-// as the queue is composed of AtomicF32 having only 1 render quantum of extra room should be enough
+// as the queue is composed of AtomicF32 having only 1 render quantum of extra
+// room should be enough
 const RING_BUFFER_SIZE: usize = MAX_FFT_SIZE + RENDER_QUANTUM_SIZE;
 
 // single producer / multiple consumer ring buffer
@@ -268,8 +269,6 @@ impl Analyser {
         self.ring_buffer.read(dst, fft_size);
     }
 
-    // we need to duplicate the `get_float_time_domain_data` to avoid creating
-    // an intermediate vector of floats
     pub fn get_byte_time_domain_data(&self, dst: &mut [u8]) {
         let fft_size = self.fft_size();
         let mut tmp = vec![0.; dst.len()];
@@ -400,7 +399,7 @@ impl Analyser {
             .zip(self.last_fft_output.iter())
             .for_each(|(v, b)| {
                 let db = 20. * b.log10();
-                // 𝑏[𝑘]=⌊255 / dB𝑚𝑎𝑥−dB𝑚𝑖𝑛 * (𝑌[𝑘]−dB𝑚𝑖𝑛)⌋
+                // 𝑏[𝑘] = ⌊255 / dB𝑚𝑎𝑥−dB𝑚𝑖𝑛 * (𝑌[𝑘]−dB𝑚𝑖𝑛)⌋
                 let scaled = 255. / (max_decibels - min_decibels) * (db - min_decibels);
                 let clamped = scaled.clamp(0., 255.);
                 *v = clamped as u8;

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -4,7 +4,7 @@
 
 use std::f32::consts::PI;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use realfft::{num_complex::Complex, RealFftPlanner};
 
@@ -158,7 +158,7 @@ pub(crate) struct Analyser {
     smoothing_time_constant: f64,
     min_decibels: f64,
     max_decibels: f64,
-    fft_planner: RealFftPlanner<f32>,
+    fft_planner: Mutex<RealFftPlanner<f32>>, // RealFftPlanner is not `Sync` on all platforms
     fft_input: Vec<f32>,
     fft_scratch: Vec<Complex<f32>>,
     fft_output: Vec<Complex<f32>>,
@@ -190,7 +190,7 @@ impl Analyser {
             smoothing_time_constant: DEFAULT_SMOOTHING_TIME_CONSTANT,
             min_decibels: DEFAULT_MIN_DECIBELS,
             max_decibels: DEFAULT_MAX_DECIBELS,
-            fft_planner,
+            fft_planner: Mutex::new(fft_planner),
             fft_input,
             fft_scratch,
             fft_output,
@@ -281,7 +281,7 @@ impl Analyser {
         let fft_size = self.fft_size();
         let smoothing_time_constant = self.smoothing_time_constant() as f32;
         // setup FFT planner and properly sized buffers
-        let r2c = self.fft_planner.plan_fft_forward(fft_size);
+        let r2c = self.fft_planner.lock().unwrap().plan_fft_forward(fft_size);
         let input = &mut self.fft_input[..fft_size];
         let output = &mut self.fft_output[..fft_size / 2 + 1];
         let scratch = &mut self.fft_scratch[..r2c.get_scratch_len()];

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -241,7 +241,7 @@ impl AudioContext {
         }
 
         if !is_valid_sink_id(&sink_id) {
-            Err(format!("NotFoundError: invalid sinkId {}", sink_id))?;
+            Err(format!("NotFoundError: invalid sinkId {sink_id}"))?;
         };
 
         let mut backend_manager_guard = self.backend_manager.lock().unwrap();

--- a/src/io/cubeb.rs
+++ b/src/io/cubeb.rs
@@ -124,7 +124,7 @@ fn init_output_backend<const N: usize>(
             output.len() as isize
         })
         .state_callback(|state| {
-            println!("stream state changed: {:?}", state);
+            println!("stream state changed: {state:?}");
         });
 
     let stream = builder.init(ctx).expect("Failed to create cubeb stream");
@@ -317,7 +317,7 @@ impl AudioBackendManager for CubebBackend {
                 input.len() as isize
             })
             .state_callback(|state| {
-                println!("stream state changed: {:?}", state);
+                println!("stream state changed: {state:?}");
             });
 
         let stream = builder.init(&ctx).expect("Failed to create cubeb stream");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,13 +80,11 @@ pub use io::{enumerate_devices, MediaDeviceInfo, MediaDeviceInfoKind};
 mod analysis;
 mod message;
 
-/// Atomic float 32, only `load` and `store` are supported, no arithmetics
 #[derive(Debug)]
-pub(crate) struct AtomicF32 {
+pub (crate) struct AtomicF32 {
     inner: AtomicU32,
 }
 
-// `swap()` is not implemented as `AtomicF32` is only used in `param.rs` for now
 impl AtomicF32 {
     pub fn new(v: f32) -> Self {
         Self {
@@ -94,13 +92,13 @@ impl AtomicF32 {
         }
     }
 
-    pub fn load(&self) -> f32 {
-        f32::from_ne_bytes(self.inner.load(Ordering::SeqCst).to_ne_bytes())
+    pub fn load(&self, ordering: Ordering) -> f32 {
+        f32::from_ne_bytes(self.inner.load(ordering).to_ne_bytes())
     }
 
-    pub fn store(&self, v: f32) {
+    pub fn store(&self, v: f32, ordering: Ordering) {
         self.inner
-            .store(u32::from_ne_bytes(v.to_ne_bytes()), Ordering::SeqCst)
+            .store(u32::from_ne_bytes(v.to_ne_bytes()), ordering);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ mod analysis;
 mod message;
 
 #[derive(Debug)]
-pub (crate) struct AtomicF32 {
+pub(crate) struct AtomicF32 {
     inner: AtomicU32,
 }
 

--- a/src/node/analyser.rs
+++ b/src/node/analyser.rs
@@ -1,4 +1,3 @@
-// use std::cell::RefCell;
 use std::sync::{Arc, RwLock};
 
 use crate::analysis::{
@@ -9,8 +8,6 @@ use crate::context::{AudioContextRegistration, BaseAudioContext};
 use crate::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum, RenderScope};
 
 use super::{AudioNode, ChannelConfig, ChannelConfigOptions, ChannelInterpretation};
-
-// use crossbeam_channel::{self, Receiver, Sender};
 
 /// Options for constructing an [`AnalyserNode`]
 // dictionary AnalyserOptions : AudioNodeOptions {

--- a/src/node/analyser.rs
+++ b/src/node/analyser.rs
@@ -301,7 +301,7 @@ impl AudioProcessor for AnalyserRenderer {
         let data = mono.channel_data(0).as_ref();
         self.ring_buffer.write(data);
 
-        // @todo - review
+        // no tail-time
         false
     }
 }

--- a/src/node/analyser.rs
+++ b/src/node/analyser.rs
@@ -1,5 +1,5 @@
-use std::cell::RefCell;
-use std::sync::{Arc};
+// use std::cell::RefCell;
+use std::sync::{Arc, RwLock};
 
 use crate::analysis::{Analyser, AnalyserRingBuffer};
 use crate::context::{AudioContextRegistration, BaseAudioContext};
@@ -42,7 +42,7 @@ pub struct AnalyserNode {
     registration: AudioContextRegistration,
     channel_config: ChannelConfig,
     // needed to make the AnalyserNode API immutable
-    analyser: RefCell<Analyser>,
+    analyser: Arc<RwLock<Analyser>>,
 }
 
 impl AudioNode for AnalyserNode {
@@ -82,7 +82,7 @@ impl AnalyserNode {
             let node = AnalyserNode {
                 registration,
                 channel_config: options.channel_config.into(),
-                analyser: RefCell::new(analyser),
+                analyser: Arc::new(RwLock::new(analyser)),
             };
 
             (node, Box::new(render))
@@ -91,7 +91,7 @@ impl AnalyserNode {
 
     /// The size of the FFT used for frequency-domain analysis (in sample-frames)
     pub fn fft_size(&self) -> usize {
-        self.analyser.borrow().fft_size()
+        self.analyser.read().unwrap().fft_size()
     }
 
     /// Set FFT size
@@ -100,14 +100,14 @@ impl AnalyserNode {
     ///
     /// This function panics if fft_size is not a power of two or not in the range [32, 32768]
     pub fn set_fft_size(&self, fft_size: usize) {
-        self.analyser.borrow_mut().set_fft_size(fft_size);
+        self.analyser.write().unwrap().set_fft_size(fft_size);
     }
 
     /// Time averaging parameter with the last analysis frame.
     /// A value from 0 -> 1 where 0 represents no time averaging with the last
     /// analysis frame. The default value is 0.8.
     pub fn smoothing_time_constant(&self) -> f64 {
-        self.analyser.borrow().smoothing_time_constant()
+        self.analyser.read().unwrap().smoothing_time_constant()
     }
 
     /// Set smoothing time constant
@@ -116,14 +116,14 @@ impl AnalyserNode {
     ///
     /// This function panics if the value is set to a value less than 0 or more than 1.
     pub fn set_smoothing_time_constant(&self, value: f64) {
-        self.analyser.borrow_mut().set_smoothing_time_constant(value);
+        self.analyser.write().unwrap().set_smoothing_time_constant(value);
     }
 
 
     /// Minimum power value in the scaling range for the FFT analysis data for
     /// conversion to unsigned byte values. The default value is -100.
     pub fn min_decibels(&self) -> f64 {
-        self.analyser.borrow().min_decibels()
+        self.analyser.read().unwrap().min_decibels()
     }
 
     /// Set min decibels
@@ -133,13 +133,13 @@ impl AnalyserNode {
     /// This function panics if the value is set to a value more than or equal
     /// to max decibels.
     pub fn set_min_decibels(&self, value: f64) {
-        self.analyser.borrow_mut().set_min_decibels(value);
+        self.analyser.write().unwrap().set_min_decibels(value);
     }
 
     /// Maximum power value in the scaling range for the FFT analysis data for
     /// conversion to unsigned byte values. The default value is -30.
     pub fn max_decibels(&self) -> f64 {
-        self.analyser.borrow().max_decibels()
+        self.analyser.read().unwrap().max_decibels()
     }
 
     /// Set max decibels
@@ -149,30 +149,30 @@ impl AnalyserNode {
     /// This function panics if the value is set to a value less than or equal
     /// to min decibels.
     pub fn set_max_decibels(&self, value: f64) {
-        self.analyser.borrow_mut().set_max_decibels(value);
+        self.analyser.write().unwrap().set_max_decibels(value);
     }
 
     /// Number of bins in the FFT results, is half the FFT size
     pub fn frequency_bin_count(&self) -> usize {
-        self.analyser.borrow().frequency_bin_count()
+        self.analyser.read().unwrap().frequency_bin_count()
     }
 
     /// Copies the current time domain data (waveform data) into the provided buffer
     pub fn get_float_time_domain_data(&self, buffer: &mut [f32]) {
-        self.analyser.borrow_mut().get_float_time_domain_data(buffer);
+        self.analyser.write().unwrap().get_float_time_domain_data(buffer);
     }
 
     pub fn get_byte_time_domain_data(&self, buffer: &mut [u8]) {
-        self.analyser.borrow_mut().get_byte_time_domain_data(buffer);
+        self.analyser.write().unwrap().get_byte_time_domain_data(buffer);
     }
 
     /// Copies the current frequency data into the provided buffer
     pub fn get_float_frequency_data(&self, buffer: &mut [f32]) {
-        self.analyser.borrow_mut().get_float_frequency_data(buffer);
+        self.analyser.write().unwrap().get_float_frequency_data(buffer);
     }
 
     pub fn get_byte_frequency_data(&self, buffer: &mut [u8]) {
-        self.analyser.borrow_mut().get_byte_frequency_data(buffer);
+        self.analyser.write().unwrap().get_byte_frequency_data(buffer);
     }
 }
 

--- a/src/node/analyser.rs
+++ b/src/node/analyser.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, RwLock};
+use std::sync::RwLock;
 
 use crate::analysis::{
     Analyser, AnalyserRingBuffer, DEFAULT_FFT_SIZE, DEFAULT_MAX_DECIBELS, DEFAULT_MIN_DECIBELS,
@@ -83,7 +83,7 @@ pub struct AnalyserNode {
     registration: AudioContextRegistration,
     channel_config: ChannelConfig,
     // RwLock is needed to make the AnalyserNode API immutable
-    analyser: Arc<RwLock<Analyser>>,
+    analyser: RwLock<Analyser>,
 }
 
 impl AudioNode for AnalyserNode {
@@ -125,7 +125,7 @@ impl AnalyserNode {
             let node = AnalyserNode {
                 registration,
                 channel_config: options.channel_config.into(),
-                analyser: Arc::new(RwLock::new(analyser)),
+                analyser: RwLock::new(analyser),
             };
 
             (node, Box::new(render))
@@ -275,7 +275,7 @@ impl AnalyserNode {
 }
 
 struct AnalyserRenderer {
-    ring_buffer: Arc<AnalyserRingBuffer>,
+    ring_buffer: AnalyserRingBuffer,
 }
 
 impl AudioProcessor for AnalyserRenderer {

--- a/src/node/analyser.rs
+++ b/src/node/analyser.rs
@@ -164,7 +164,7 @@ impl AnalyserNode {
         self.analyser.read().unwrap().frequency_bin_count()
     }
 
-    /// Copies the current time domain data into the provided buffer
+    /// Copy the current time domain data as f32 values into the provided buffer
     pub fn get_float_time_domain_data(&self, buffer: &mut [f32]) {
         self.analyser
             .write()
@@ -172,6 +172,7 @@ impl AnalyserNode {
             .get_float_time_domain_data(buffer);
     }
 
+    /// Copy the current time domain data as u8 values into the provided buffer
     pub fn get_byte_time_domain_data(&self, buffer: &mut [u8]) {
         self.analyser
             .write()
@@ -179,19 +180,23 @@ impl AnalyserNode {
             .get_byte_time_domain_data(buffer);
     }
 
-    /// Copies the current frequency data into the provided buffer
+    /// Copy the current frequency data into the provided buffer
     pub fn get_float_frequency_data(&self, buffer: &mut [f32]) {
+        let current_time = self.registration.context().current_time();
         self.analyser
             .write()
             .unwrap()
-            .get_float_frequency_data(buffer);
+            .get_float_frequency_data(buffer, current_time);
     }
 
+    /// Copy the current frequency data scaled between min_decibels and
+    /// max_decibels into the provided buffer
     pub fn get_byte_frequency_data(&self, buffer: &mut [u8]) {
+        let current_time = self.registration.context().current_time();
         self.analyser
             .write()
             .unwrap()
-            .get_byte_frequency_data(buffer);
+            .get_byte_frequency_data(buffer, current_time);
     }
 }
 

--- a/src/node/dynamics_compressor.rs
+++ b/src/node/dynamics_compressor.rs
@@ -1,5 +1,5 @@
-use std::sync::atomic::{Ordering};
-use std::sync::{Arc};
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
 
 use crate::context::{AudioContextRegistration, AudioParamId, BaseAudioContext};
 use crate::param::{AudioParam, AudioParamDescriptor};

--- a/src/node/dynamics_compressor.rs
+++ b/src/node/dynamics_compressor.rs
@@ -1,4 +1,5 @@
-use std::sync::Arc;
+use std::sync::atomic::{Ordering};
+use std::sync::{Arc};
 
 use crate::context::{AudioContextRegistration, AudioParamId, BaseAudioContext};
 use crate::param::{AudioParam, AudioParamDescriptor};
@@ -240,7 +241,7 @@ impl DynamicsCompressorNode {
     }
 
     pub fn reduction(&self) -> f32 {
-        self.reduction.load()
+        self.reduction.load(Ordering::SeqCst)
     }
 }
 
@@ -385,7 +386,7 @@ impl AudioProcessor for DynamicsCompressorRenderer {
         // update prev_detector_value for next block
         self.prev_detector_value = prev_detector_value;
         // update reduction shared w/ main thread
-        self.reduction.store(reduction_gain);
+        self.reduction.store(reduction_gain, Ordering::SeqCst);
 
         // store input in delay line
         self.ring_buffer[self.ring_index] = input;

--- a/src/node/iir_filter.rs
+++ b/src/node/iir_filter.rs
@@ -539,7 +539,6 @@ mod tests {
                 context.start_rendering_sync()
             };
 
-            println!("{:?}", filter_type);
             assert_float_eq!(
                 biquad_res.get_channel_data(0),
                 iir_res.get_channel_data(0),
@@ -776,7 +775,6 @@ mod tests {
                 (mags, phases)
             };
 
-            println!("{:?}", filter_type);
             assert_float_eq!(biquad_response.0, iir_response.0, abs_all <= 1e-6);
             assert_float_eq!(biquad_response.1, iir_response.1, abs_all <= 1e-6);
         }

--- a/src/param.rs
+++ b/src/param.rs
@@ -304,7 +304,7 @@ impl AudioParam {
     //      test_exponential_ramp_a_rate_multiple_blocks
     //      test_exponential_ramp_k_rate_multiple_blocks
     pub fn value(&self) -> f32 {
-        self.current_value.load()
+        self.current_value.load(Ordering::SeqCst)
     }
 
     /// Set the value of the `AudioParam`.
@@ -320,8 +320,8 @@ impl AudioParam {
     // cf. https://www.w3.org/TR/webaudio/#dom-audioparam-value
     pub fn set_value(&self, value: f32) -> &Self {
         // current_value should always be clamped
-        self.current_value
-            .store(value.clamp(self.min_value, self.max_value));
+        let clamped = value.clamp(self.min_value, self.max_value);
+        self.current_value.store(clamped, Ordering::SeqCst);
 
         // this event is meant to update param intrisic value before any calculation
         // is done, will behave as SetValueAtTime with `time == block_timestamp`
@@ -987,7 +987,7 @@ impl AudioParamProcessor {
         // Set [[current value]] to the value of paramIntrinsicValue at the
         // beginning of this render quantum.
         let clamped = self.intrisic_value.clamp(self.min_value, self.max_value);
-        self.current_value.store(clamped);
+        self.current_value.store(clamped, Ordering::SeqCst);
 
         // clear the buffer for this block
         self.buffer.clear();


### PR DESCRIPTION
Hey,

This is quite a big PR regarding the AnalyserNode and what we discussed in #253:
- use a thread-safe buffering queue (`Arc<AtomicF32>`) to ship audio data from audio thread to control thread
- all computations (FFT) are now done in control thread
- implement missing methods
- follow spec according to recomputation of FFT if in same render quantum, etc.
- added a very simple example (`analyser`) to complete the quite complex `mic_playback` one

I'm not completely sure that what have done for thread safety (i.e. moving the node to a different thread as you have done in the `mic_playback` example) is the cleanest / simplest possible way, but it builds and seems to work quite well. But any case having your thoughts on this point would be nice.

Let me know what you think