### PR TITLE
Offline context rendering

### DIFF
--- a/examples/benchmarks.rs
+++ b/examples/benchmarks.rs
@@ -97,7 +97,7 @@ fn main() {
     {
         let name = "Baseline (silence)";
 
-        let context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
+        let context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
 
         benchmark(&mut stdout, name, context, &mut results);
     }
@@ -241,7 +241,7 @@ fn main() {
 
         let adjusted_duration = DURATION / 4;
         let context =
-            OfflineAudioContext::new(1, adjusted_duration * sample_rate as usize, sample_rate);
+            OfflineAudioContext::new(2, adjusted_duration * sample_rate as usize, sample_rate);
 
         for _ in 0..100 {
             let source = context.create_buffer_source();
@@ -260,7 +260,7 @@ fn main() {
 
         let adjusted_duration = DURATION / 4;
         let context =
-            OfflineAudioContext::new(1, adjusted_duration * sample_rate as usize, sample_rate);
+            OfflineAudioContext::new(2, adjusted_duration * sample_rate as usize, sample_rate);
         let reference = get_buffer(&sources, 38000., 1);
         let channel_data = reference.get_channel_data(0);
 
@@ -281,7 +281,7 @@ fn main() {
     {
         let name = "Simple mixing with gains";
 
-        let context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+        let context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
 
         let gain = context.create_gain();
         gain.connect(&context.destination());
@@ -369,11 +369,7 @@ fn main() {
         let mut offset = 0.;
         let mut rng = rand::thread_rng();
 
-        // @todo - make a PR
-        // - problem w/ env.gain().set_value_at_time(0., offset);
-        // - variables are badly named, but just follow the source here
-
-        // this 1500 sources...
+        // this ~1500 sources...
         while offset < adjusted_duration {
             let env = context.create_gain();
             env.connect(&context.destination());
@@ -424,9 +420,9 @@ fn main() {
             env.gain().set_value_at_time(0.5, offset);
             env.gain().set_target_at_time(0., offset + 0.01, 0.1);
             osc.start_at(offset);
-            osc.stop_at(offset + 1.); // why not 0.1 ?
+            osc.stop_at(offset + 1.);
 
-            offset += 140. / 60. / 4.; // 140 bpm (?)
+            offset += 140. / 60. / 4.;
         }
 
         benchmark(&mut stdout, name, context, &mut results);
@@ -450,9 +446,9 @@ fn main() {
             osc.set_type(OscillatorType::Sawtooth);
             osc.frequency().set_value(110.);
             osc.start_at(offset);
-            osc.stop_at(offset + 1.); // why not 0.1 ?
+            osc.stop_at(offset + 1.);
 
-            offset += 140. / 60. / 4.; // 140 bpm (?)
+            offset += 140. / 60. / 4.;
         }
 
         benchmark(&mut stdout, name, context, &mut results);
@@ -473,9 +469,9 @@ fn main() {
             osc.set_type(OscillatorType::Sawtooth);
             osc.frequency().set_value(110.);
             osc.start_at(offset);
-            osc.stop_at(offset + 1.); // why not 0.1 ?
+            osc.stop_at(offset + 1.);
 
-            offset += 140. / 60. / 4.; // 140 bpm (?)
+            offset += 140. / 60. / 4.;
         }
 
         benchmark(&mut stdout, name, context, &mut results);
@@ -512,7 +508,7 @@ fn main() {
             filter.frequency().set_value_at_time(0., offset);
             filter.frequency().set_target_at_time(3500., offset, 0.03);
 
-            offset += 140. / 60. / 16.; // 140 bpm (?)
+            offset += 140. / 60. / 16.;
         }
 
         benchmark(&mut stdout, name, context, &mut results);
@@ -560,7 +556,7 @@ fn main() {
     {
         let name = "Sawtooth with automation";
 
-        let context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
+        let context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
 
         let osc = context.create_oscillator();
         osc.connect(&context.destination());

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,7 +1,6 @@
 //! General purpose audio signal data structures
 use std::sync::Arc;
 
-use crate::render::AudioRenderQuantum;
 use crate::{
     assert_valid_channel_number, assert_valid_number_of_channels, assert_valid_sample_rate,
 };
@@ -283,21 +282,6 @@ impl AudioBuffer {
             .for_each(|(channel, other_channel)| {
                 let cur_channel_data = Arc::make_mut(&mut channel.data);
                 cur_channel_data.extend(other_channel.as_slice());
-            })
-    }
-
-    /// Extends an AudioBuffer with an [`AudioRenderQuantum`]
-    ///
-    /// This assumes the sample_rate matches. No up/down-mixing is performed
-    pub(crate) fn extend_alloc(&mut self, other: &AudioRenderQuantum) {
-        assert_eq!(self.number_of_channels(), other.number_of_channels());
-
-        self.channels_mut()
-            .iter_mut()
-            .zip(other.channels())
-            .for_each(|(channel, other_channel)| {
-                let cur_channel_data = Arc::make_mut(&mut channel.data);
-                cur_channel_data.extend_from_slice(&other_channel[..]);
             })
     }
 

--- a/src/context/offline.rs
+++ b/src/context/offline.rs
@@ -2,10 +2,10 @@
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
+use crate::assert_valid_sample_rate;
 use crate::buffer::AudioBuffer;
 use crate::context::{BaseAudioContext, ConcreteBaseAudioContext};
 use crate::render::RenderThread;
-use crate::{assert_valid_sample_rate, RENDER_QUANTUM_SIZE};
 
 /// The `OfflineAudioContext` doesn't render the audio to the device hardware; instead, it generates
 /// it, as fast as it can, and outputs the result to an `AudioBuffer`.
@@ -106,15 +106,7 @@ impl OfflineAudioContext {
     /// This function will block the current thread and returns the rendered `AudioBuffer`
     /// synchronously. An async version is currently not implemented.
     pub fn start_rendering_sync(self) -> AudioBuffer {
-        // make buffer_size always a multiple of RENDER_QUANTUM_SIZE, so we can still render piecewise with
-        // the desired number of frames.
-        let buffer_size =
-            (self.length + RENDER_QUANTUM_SIZE - 1) / RENDER_QUANTUM_SIZE * RENDER_QUANTUM_SIZE;
-
-        let mut buffer = self.renderer.render_audiobuffer(buffer_size);
-        buffer.split_off(self.length);
-
-        buffer
+        self.renderer.render_audiobuffer(self.length)
     }
 
     /// get the length of rendering audio buffer

--- a/src/context/offline.rs
+++ b/src/context/offline.rs
@@ -111,10 +111,10 @@ impl OfflineAudioContext {
         let buffer_size =
             (self.length + RENDER_QUANTUM_SIZE - 1) / RENDER_QUANTUM_SIZE * RENDER_QUANTUM_SIZE;
 
-        let mut buf = self.renderer.render_audiobuffer(buffer_size);
-        let _split = buf.split_off(self.length);
+        let mut buffer = self.renderer.render_audiobuffer(buffer_size);
+        buffer.split_off(self.length);
 
-        buf
+        buffer
     }
 
     /// get the length of rendering audio buffer

--- a/src/render/thread.rs
+++ b/src/render/thread.rs
@@ -128,23 +128,24 @@ impl RenderThread {
 
     // render method of the OfflineAudioContext
     pub fn render_audiobuffer(mut self, length: usize) -> AudioBuffer {
-        // assert input was properly sized
-        // make buffer_size always a multiple of RENDER_QUANTUM_SIZE, so we can still render piecewise with
-        // the desired number of frames.
-        let buffer_size =
-            (length + RENDER_QUANTUM_SIZE - 1) / RENDER_QUANTUM_SIZE * RENDER_QUANTUM_SIZE;
+        // make buffer_size always a multiple of RENDER_QUANTUM_SIZE, so we can
+        // still render piecewise with the desired number of frames.
+        // let buffer_size =
+            // (length + RENDER_QUANTUM_SIZE - 1) / RENDER_QUANTUM_SIZE * RENDER_QUANTUM_SIZE;
 
-        debug_assert_eq!(buffer_size % RENDER_QUANTUM_SIZE, 0);
+        // debug_assert_eq!(buffer_size % RENDER_QUANTUM_SIZE, 0);
+        let num_frames = (length + RENDER_QUANTUM_SIZE - 1) / RENDER_QUANTUM_SIZE;
 
         let options = AudioBufferOptions {
             number_of_channels: self.number_of_channels,
-            length: buffer_size,
+            length,
             sample_rate: self.sample_rate,
         };
 
         let mut buffer = AudioBuffer::new(options);
 
-        for _ in 0..buffer_size / RENDER_QUANTUM_SIZE {
+        // for _ in 0..buffer_size / RENDER_QUANTUM_SIZE {
+        for _ in 0..num_frames {
             // handle addition/removal of nodes/edges
             self.handle_control_messages();
 

--- a/src/render/thread.rs
+++ b/src/render/thread.rs
@@ -3,7 +3,6 @@
 use std::cell::Cell;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use std::thread;
 use std::time::Instant;
 
 use crossbeam_channel::{Receiver, Sender};
@@ -127,7 +126,10 @@ impl RenderThread {
         }
     }
 
-    // render method of the OfflineAudioContext
+    // Render method of the `OfflineAudioContext::start_redering_sync`
+    // This method is not spec compliant and obviously marked as synchronous, so we
+    // don't launch a thread.
+    //
     // cf. https://webaudio.github.io/web-audio-api/#dom-offlineaudiocontext-startrendering
     pub fn render_audiobuffer(mut self, length: usize) -> AudioBuffer {
         let options = AudioBufferOptions {
@@ -139,45 +141,39 @@ impl RenderThread {
         let mut buffer = AudioBuffer::new(options);
         let num_frames = (length + RENDER_QUANTUM_SIZE - 1) / RENDER_QUANTUM_SIZE;
 
-        // [spec] To begin offline rendering, the following steps MUST happen on
-        // a rendering thread that is created for the occasion.
-        let handle = thread::spawn(move || {
-            for _ in 0..num_frames {
-                // handle addition/removal of nodes/edges
-                self.handle_control_messages();
+        for _ in 0..num_frames {
+            // handle addition/removal of nodes/edges
+            self.handle_control_messages();
 
-                // update time
-                let current_frame = self
-                    .frames_played
-                    .fetch_add(RENDER_QUANTUM_SIZE as u64, Ordering::SeqCst);
-                let current_time = current_frame as f64 / self.sample_rate as f64;
+            // update time
+            let current_frame = self
+                .frames_played
+                .fetch_add(RENDER_QUANTUM_SIZE as u64, Ordering::SeqCst);
+            let current_time = current_frame as f64 / self.sample_rate as f64;
 
-                let scope = RenderScope {
-                    current_frame,
-                    current_time,
-                    sample_rate: self.sample_rate,
-                    event_sender: self.event_sender.clone(),
-                    node_id: Cell::new(AudioNodeId(0)), // placeholder value
-                };
+            let scope = RenderScope {
+                current_frame,
+                current_time,
+                sample_rate: self.sample_rate,
+                event_sender: self.event_sender.clone(),
+                node_id: Cell::new(AudioNodeId(0)), // placeholder value
+            };
 
-                // render audio graph
-                let rendered = self.graph.as_mut().unwrap().render(&scope);
+            // render audio graph
+            let rendered = self.graph.as_mut().unwrap().render(&scope);
 
-                rendered.channels().iter().enumerate().for_each(
-                    |(channel_number, rendered_channel)| {
-                        buffer.copy_to_channel_with_offset(
-                            rendered_channel,
-                            channel_number,
-                            current_frame as usize,
-                        );
-                    },
-                );
-            }
+            rendered.channels().iter().enumerate().for_each(
+                |(channel_number, rendered_channel)| {
+                    buffer.copy_to_channel_with_offset(
+                        rendered_channel,
+                        channel_number,
+                        current_frame as usize,
+                    );
+                },
+            );
+        }
 
-            buffer
-        });
-
-        handle.join().unwrap()
+        buffer
     }
 
     pub fn render<S: FromSample<f32> + Clone>(&mut self, buffer: &mut [S]) {

--- a/src/render/thread.rs
+++ b/src/render/thread.rs
@@ -128,14 +128,6 @@ impl RenderThread {
 
     // render method of the OfflineAudioContext
     pub fn render_audiobuffer(mut self, length: usize) -> AudioBuffer {
-        // make buffer_size always a multiple of RENDER_QUANTUM_SIZE, so we can
-        // still render piecewise with the desired number of frames.
-        // let buffer_size =
-            // (length + RENDER_QUANTUM_SIZE - 1) / RENDER_QUANTUM_SIZE * RENDER_QUANTUM_SIZE;
-
-        // debug_assert_eq!(buffer_size % RENDER_QUANTUM_SIZE, 0);
-        let num_frames = (length + RENDER_QUANTUM_SIZE - 1) / RENDER_QUANTUM_SIZE;
-
         let options = AudioBufferOptions {
             number_of_channels: self.number_of_channels,
             length,
@@ -143,8 +135,8 @@ impl RenderThread {
         };
 
         let mut buffer = AudioBuffer::new(options);
+        let num_frames = (length + RENDER_QUANTUM_SIZE - 1) / RENDER_QUANTUM_SIZE;
 
-        // for _ in 0..buffer_size / RENDER_QUANTUM_SIZE {
         for _ in 0..num_frames {
             // handle addition/removal of nodes/edges
             self.handle_control_messages();
@@ -176,8 +168,6 @@ impl RenderThread {
                 },
             );
         }
-
-        buffer.split_off(length);
 
         buffer
     }


### PR DESCRIPTION
Hey, 

Here is small fix / refactor for the offline context rendering, mainly:
- Allocate the final `AudioBuffer` all at once instead of make it grow on each render quantum
- Perform rendering in a dedicated thread (which is required by the spec)

Does not make huge difference on benchmarks, but I can see an improvement of ~10-15% in the baseline, for the other ones it fall into noise I guess. But in any case it seems more logical to do like this.

Let me know what you think!