### PR TITLE
refactor: replace for loop with iter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ vecmath = "1.0"
 
 [dev-dependencies]
 alloc_counter = "0.0.4"
+criterion = "0.4.0"
 env_logger = "0.10"
 iai = "0.1.1"
 rand = "0.8"

--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -504,27 +504,30 @@ impl AudioProcessor for AudioBufferSourceRenderer {
                         let mut start_index = (buffer_time * sample_rate).round() as usize;
                         let mut offset = 0;
 
-                        for (index, o) in output_channel.iter_mut().enumerate() {
-                            let mut buffer_index = start_index + index - offset;
+                        output_channel
+                            .iter_mut()
+                            .enumerate()
+                            .for_each(|(index, o)| {
+                                let mut buffer_index = start_index + index - offset;
 
-                            *o = if buffer_index < end_index {
-                                buffer_channel[buffer_index]
-                            } else {
-                                if loop_ && buffer_index == end_index {
-                                    loop_point_index = Some(index);
-                                    // reset values for the rest of the block
-                                    start_index = 0;
-                                    offset = index;
-                                    buffer_index = 0;
-                                }
-
-                                if loop_ {
+                                *o = if buffer_index < end_index {
                                     buffer_channel[buffer_index]
                                 } else {
-                                    0.
-                                }
-                            };
-                        }
+                                    if loop_ && buffer_index == end_index {
+                                        loop_point_index = Some(index);
+                                        // reset values for the rest of the block
+                                        start_index = 0;
+                                        offset = index;
+                                        buffer_index = 0;
+                                    }
+
+                                    if loop_ {
+                                        buffer_channel[buffer_index]
+                                    } else {
+                                        0.
+                                    }
+                                };
+                            });
                     });
 
                 if let Some(loop_point_index) = loop_point_index {


### PR DESCRIPTION
Hey,

A simple (and quite unexpected) perf improvement, just replacing a for loop with iter

## before

```
- 5       | Simple source test with resampling (Mono)                                | 77            | 1558.4x               | 120
- 6       | Simple source test with resampling (Stereo)                              | 102           | 1176.5x               | 120
- 7       | Simple source test with resampling (Stereo and positionnal)              | 148           | 810.8x                | 120
````

## after

```
- 5       | Simple source test with resampling (Mono)                                | 63.559        | 1888.0x               | 120
- 6       | Simple source test with resampling (Stereo)                              | 85.878        | 1397.3x               | 120
- 7       | Simple source test with resampling (Stereo and positionnal)              | 134.003       | 895.5x                | 120
```