### PR TITLE
MediaStreamConstraints for getUserMedia

### DIFF
--- a/examples/change_state.rs
+++ b/examples/change_state.rs
@@ -1,12 +1,13 @@
 use web_audio_api::context::{AudioContext, BaseAudioContext};
 use web_audio_api::media_devices;
+use web_audio_api::media_devices::MediaStreamConstraints;
 use web_audio_api::node::AudioNode;
 
 fn main() {
     env_logger::init();
     let context = AudioContext::default();
 
-    let mic = media_devices::get_user_media();
+    let mic = media_devices::get_user_media(MediaStreamConstraints::Audio);
     // register as media element in the audio context
     let background = context.create_media_stream_source(&mic);
     // connect the node to the destination node (speakers)

--- a/examples/change_state.rs
+++ b/examples/change_state.rs
@@ -7,7 +7,7 @@ fn main() {
     env_logger::init();
     let context = AudioContext::default();
 
-    let mic = media_devices::get_user_media(MediaStreamConstraints::Audio);
+    let mic = media_devices::get_user_media_sync(MediaStreamConstraints::Audio);
     // register as media element in the audio context
     let background = context.create_media_stream_source(&mic);
     // connect the node to the destination node (speakers)

--- a/examples/microphone.rs
+++ b/examples/microphone.rs
@@ -30,8 +30,8 @@ fn main() {
     let context = AudioContext::default();
     let mut constraints = MediaTrackConstraints::default();
     constraints.device_id = sink_id;
-    let mic =
-        media_devices::get_user_media(MediaStreamConstraints::AudioWithConstraints(constraints));
+    let stream_constraints = MediaStreamConstraints::AudioWithConstraints(constraints);
+    let mic = media_devices::get_user_media_sync(stream_constraints);
 
     // create media stream source node with mic stream
     let stream_source = context.create_media_stream_source(&mic);

--- a/examples/microphone.rs
+++ b/examples/microphone.rs
@@ -1,11 +1,12 @@
 use web_audio_api::context::{AudioContext, BaseAudioContext};
 use web_audio_api::media_devices;
+use web_audio_api::media_devices::MediaStreamConstraints;
 use web_audio_api::node::AudioNode;
 
 fn main() {
     env_logger::init();
     let context = AudioContext::default();
-    let mic = media_devices::get_user_media();
+    let mic = media_devices::get_user_media(MediaStreamConstraints::Audio);
 
     // create media stream source node with mic stream
     let stream_source = context.create_media_stream_source(&mic);

--- a/examples/toy_webrtc.rs
+++ b/examples/toy_webrtc.rs
@@ -167,7 +167,7 @@ fn run_client() -> std::io::Result<()> {
     stream_in.connect(&context.destination());
 
     // leg 2: record mic input and ship to server
-    let mic = media_devices::get_user_media(MediaStreamConstraints::Audio);
+    let mic = media_devices::get_user_media_sync(MediaStreamConstraints::Audio);
     let stream_in = context.create_media_stream_source(&mic);
     let stream_out = context.create_media_stream_destination();
     stream_out.set_channel_count(1); // force mono

--- a/examples/toy_webrtc.rs
+++ b/examples/toy_webrtc.rs
@@ -26,6 +26,7 @@ use std::net::UdpSocket;
 
 use web_audio_api::context::{AudioContext, BaseAudioContext};
 use web_audio_api::media_devices;
+use web_audio_api::media_devices::MediaStreamConstraints;
 use web_audio_api::media_streams::MediaStreamTrack;
 use web_audio_api::node::AudioNode;
 use web_audio_api::{AudioBuffer, AudioBufferOptions};
@@ -166,7 +167,7 @@ fn run_client() -> std::io::Result<()> {
     stream_in.connect(&context.destination());
 
     // leg 2: record mic input and ship to server
-    let mic = media_devices::get_user_media();
+    let mic = media_devices::get_user_media(MediaStreamConstraints::Audio);
     let stream_in = context.create_media_stream_source(&mic);
     let stream_out = context.create_media_stream_destination();
     stream_out.set_channel_count(1); // force mono

--- a/src/io/cubeb.rs
+++ b/src/io/cubeb.rs
@@ -155,6 +155,7 @@ impl AudioBackendManager for CubebBackend {
 
         // Set up cubeb context
         let ctx = Context::init(None, None).unwrap();
+        log::info!("Audio Output Host: cubeb {:?}", ctx.backend_id());
 
         // Use user requested sample rate, or else the device preferred one
         let device_sample_rate = ctx.preferred_sample_rate().map(|v| v as f32).ok();
@@ -199,7 +200,7 @@ impl AudioBackendManager for CubebBackend {
             .unwrap_or(RENDER_QUANTUM_SIZE as u32);
         let buffer_size = buffer_size_req.max(min_latency);
 
-        let device_id = if options.sink_id.is_empty() {
+        let device = if options.sink_id.is_empty() {
             None
         } else {
             Self::enumerate_devices()
@@ -210,38 +211,38 @@ impl AudioBackendManager for CubebBackend {
 
         let stream = match number_of_channels {
             // so sorry, but I need to constify the non-const `number_of_channels`
-            1 => init_output_backend::<1>(&ctx, params, buffer_size, device_id, renderer),
-            2 => init_output_backend::<2>(&ctx, params, buffer_size, device_id, renderer),
-            3 => init_output_backend::<3>(&ctx, params, buffer_size, device_id, renderer),
-            4 => init_output_backend::<4>(&ctx, params, buffer_size, device_id, renderer),
-            5 => init_output_backend::<5>(&ctx, params, buffer_size, device_id, renderer),
-            6 => init_output_backend::<6>(&ctx, params, buffer_size, device_id, renderer),
-            7 => init_output_backend::<7>(&ctx, params, buffer_size, device_id, renderer),
-            8 => init_output_backend::<8>(&ctx, params, buffer_size, device_id, renderer),
-            9 => init_output_backend::<9>(&ctx, params, buffer_size, device_id, renderer),
-            10 => init_output_backend::<10>(&ctx, params, buffer_size, device_id, renderer),
-            11 => init_output_backend::<11>(&ctx, params, buffer_size, device_id, renderer),
-            12 => init_output_backend::<12>(&ctx, params, buffer_size, device_id, renderer),
-            13 => init_output_backend::<13>(&ctx, params, buffer_size, device_id, renderer),
-            14 => init_output_backend::<14>(&ctx, params, buffer_size, device_id, renderer),
-            15 => init_output_backend::<15>(&ctx, params, buffer_size, device_id, renderer),
-            16 => init_output_backend::<16>(&ctx, params, buffer_size, device_id, renderer),
-            17 => init_output_backend::<17>(&ctx, params, buffer_size, device_id, renderer),
-            18 => init_output_backend::<18>(&ctx, params, buffer_size, device_id, renderer),
-            19 => init_output_backend::<19>(&ctx, params, buffer_size, device_id, renderer),
-            20 => init_output_backend::<20>(&ctx, params, buffer_size, device_id, renderer),
-            21 => init_output_backend::<21>(&ctx, params, buffer_size, device_id, renderer),
-            22 => init_output_backend::<22>(&ctx, params, buffer_size, device_id, renderer),
-            23 => init_output_backend::<23>(&ctx, params, buffer_size, device_id, renderer),
-            24 => init_output_backend::<24>(&ctx, params, buffer_size, device_id, renderer),
-            25 => init_output_backend::<25>(&ctx, params, buffer_size, device_id, renderer),
-            26 => init_output_backend::<26>(&ctx, params, buffer_size, device_id, renderer),
-            27 => init_output_backend::<27>(&ctx, params, buffer_size, device_id, renderer),
-            28 => init_output_backend::<28>(&ctx, params, buffer_size, device_id, renderer),
-            29 => init_output_backend::<29>(&ctx, params, buffer_size, device_id, renderer),
-            30 => init_output_backend::<30>(&ctx, params, buffer_size, device_id, renderer),
-            31 => init_output_backend::<31>(&ctx, params, buffer_size, device_id, renderer),
-            32 => init_output_backend::<32>(&ctx, params, buffer_size, device_id, renderer),
+            1 => init_output_backend::<1>(&ctx, params, buffer_size, device, renderer),
+            2 => init_output_backend::<2>(&ctx, params, buffer_size, device, renderer),
+            3 => init_output_backend::<3>(&ctx, params, buffer_size, device, renderer),
+            4 => init_output_backend::<4>(&ctx, params, buffer_size, device, renderer),
+            5 => init_output_backend::<5>(&ctx, params, buffer_size, device, renderer),
+            6 => init_output_backend::<6>(&ctx, params, buffer_size, device, renderer),
+            7 => init_output_backend::<7>(&ctx, params, buffer_size, device, renderer),
+            8 => init_output_backend::<8>(&ctx, params, buffer_size, device, renderer),
+            9 => init_output_backend::<9>(&ctx, params, buffer_size, device, renderer),
+            10 => init_output_backend::<10>(&ctx, params, buffer_size, device, renderer),
+            11 => init_output_backend::<11>(&ctx, params, buffer_size, device, renderer),
+            12 => init_output_backend::<12>(&ctx, params, buffer_size, device, renderer),
+            13 => init_output_backend::<13>(&ctx, params, buffer_size, device, renderer),
+            14 => init_output_backend::<14>(&ctx, params, buffer_size, device, renderer),
+            15 => init_output_backend::<15>(&ctx, params, buffer_size, device, renderer),
+            16 => init_output_backend::<16>(&ctx, params, buffer_size, device, renderer),
+            17 => init_output_backend::<17>(&ctx, params, buffer_size, device, renderer),
+            18 => init_output_backend::<18>(&ctx, params, buffer_size, device, renderer),
+            19 => init_output_backend::<19>(&ctx, params, buffer_size, device, renderer),
+            20 => init_output_backend::<20>(&ctx, params, buffer_size, device, renderer),
+            21 => init_output_backend::<21>(&ctx, params, buffer_size, device, renderer),
+            22 => init_output_backend::<22>(&ctx, params, buffer_size, device, renderer),
+            23 => init_output_backend::<23>(&ctx, params, buffer_size, device, renderer),
+            24 => init_output_backend::<24>(&ctx, params, buffer_size, device, renderer),
+            25 => init_output_backend::<25>(&ctx, params, buffer_size, device, renderer),
+            26 => init_output_backend::<26>(&ctx, params, buffer_size, device, renderer),
+            27 => init_output_backend::<27>(&ctx, params, buffer_size, device, renderer),
+            28 => init_output_backend::<28>(&ctx, params, buffer_size, device, renderer),
+            29 => init_output_backend::<29>(&ctx, params, buffer_size, device, renderer),
+            30 => init_output_backend::<30>(&ctx, params, buffer_size, device, renderer),
+            31 => init_output_backend::<31>(&ctx, params, buffer_size, device, renderer),
+            32 => init_output_backend::<32>(&ctx, params, buffer_size, device, renderer),
             _ => unreachable!(),
         };
 
@@ -270,6 +271,7 @@ impl AudioBackendManager for CubebBackend {
 
         // Set up cubeb context
         let ctx = Context::init(None, None).unwrap();
+        log::info!("Audio Input Host: cubeb {:?}", ctx.backend_id());
 
         // Use user requested sample rate, or else the device preferred one
         let device_sample_rate = ctx.preferred_sample_rate().map(|v| v as f32).ok();
@@ -296,15 +298,29 @@ impl AudioBackendManager for CubebBackend {
             .unwrap_or(RENDER_QUANTUM_SIZE as u32);
         let buffer_size = buffer_size_req.max(min_latency);
 
+        let device = if options.sink_id.is_empty() {
+            None
+        } else {
+            Self::enumerate_devices()
+                .into_iter()
+                .find(|e| e.device_id() == options.sink_id)
+                .map(|e| *e.device().downcast::<DeviceId>().unwrap())
+        };
+
         let smoothing = 3; // todo, use buffering to smooth frame drops
         let (sender, receiver) = crossbeam_channel::bounded(smoothing);
         let renderer = MicrophoneRender::new(number_of_channels, sample_rate, sender);
 
         // Microphone input is always assumed STEREO (TODO)
         let mut builder = cubeb::StreamBuilder::<StereoFrame<f32>>::new();
+
+        match device {
+            None => builder.default_input(&params),
+            Some(devid) => builder.input(devid, &params),
+        };
+
         builder
             .name("Cubeb web_audio_api (mono)")
-            .default_input(&params)
             .latency(buffer_size)
             .data_callback(move |input, _output| {
                 let mut tmp = [0.; RENDER_QUANTUM_SIZE * 2];
@@ -329,7 +345,7 @@ impl AudioBackendManager for CubebBackend {
             stream: ThreadSafeClosableStream::new(stream),
             number_of_channels,
             sample_rate,
-            sink_id: "".into(),
+            sink_id: options.sink_id,
         };
 
         (backend, receiver)

--- a/src/media_devices/mod.rs
+++ b/src/media_devices/mod.rs
@@ -90,7 +90,7 @@ impl MediaDeviceInfo {
 }
 
 /// Dictionary used to instruct what sort of tracks to include in the [`MediaStream`] returned by
-/// [`get_user_media`]
+/// [`get_user_media_sync`]
 pub enum MediaStreamConstraints {
     Audio,
     AudioWithConstraints(MediaTrackConstraints),
@@ -143,6 +143,9 @@ impl From<MediaTrackConstraints> for AudioContextOptions {
 /// kept alive and emit audio buffers. Call the `close()` method if you want to stop the media
 /// input and release all system resources.
 ///
+/// This function operates synchronously, which may be undesirable on the control thread. An async
+/// version is currently not implemented.
+///
 /// # Example
 ///
 /// ```no_run
@@ -153,7 +156,7 @@ impl From<MediaTrackConstraints> for AudioContextOptions {
 /// use web_audio_api::node::AudioNode;
 ///
 /// let context = AudioContext::default();
-/// let mic = media_devices::get_user_media(MediaStreamConstraints::Audio);
+/// let mic = media_devices::get_user_media_sync(MediaStreamConstraints::Audio);
 ///
 /// // register as media element in the audio context
 /// let background = context.create_media_stream_source(&mic);
@@ -164,8 +167,7 @@ impl From<MediaTrackConstraints> for AudioContextOptions {
 /// // enjoy listening
 /// std::thread::sleep(std::time::Duration::from_secs(4));
 /// ```
-// TODO, return Promise?
-pub fn get_user_media(constraints: MediaStreamConstraints) -> MediaStream {
+pub fn get_user_media_sync(constraints: MediaStreamConstraints) -> MediaStream {
     let options = match constraints {
         MediaStreamConstraints::Audio => AudioContextOptions::default(),
         MediaStreamConstraints::AudioWithConstraints(cs) => cs.into(),


### PR DESCRIPTION
Seems to work on my device, however some caveats 
1. microphone input is not buffered so some frames are lost (about a single chunk of 128 frames every second on my device). This introduces some crackling. You can see this when you run `RUST_LOG=debug cargo run --release --example microphone`
2. our cubeb input implementation only supports stereo microphone input. Not sure how I can fix that.. The whole cubeb implementation is experimental anyway #187 
3. when selecting a non-default sink-id, closing the media track does not actually suspend the microphone. I suspect this is a `cpal` bug https://github.com/RustAudio/cpal/issues/771

1 and 2 are not related to this PR by the way.
In any case I think we can merge this despite the caveats.
Let me know how it works for you!