### PR TITLE
Fix issue with AudioBufferSourceNode playback rate and detune

### DIFF
--- a/examples/audio_buffer_source_pitching.rs
+++ b/examples/audio_buffer_source_pitching.rs
@@ -1,0 +1,51 @@
+use std::f32::consts::PI;
+
+use web_audio_api::context::{AudioContext, BaseAudioContext};
+use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
+
+fn main() {
+    let context = AudioContext::default();
+
+    // create a 1 second buffer filled with a sine at 200Hz
+    println!("> Play sine at 440Hz in AudioBufferSourceNode");
+
+    let length = context.sample_rate() as usize;
+    let sample_rate = context.sample_rate();
+    let mut buffer = context.create_buffer(1, length, sample_rate);
+    let mut sine = vec![];
+
+    for i in 0..length {
+        let phase = i as f32 / length as f32 * 2. * PI * 440.;
+        sine.push(phase.sin());
+    }
+
+    buffer.copy_to_channel(&sine, 0);
+
+    // play the buffer in a loop
+    let src = context.create_buffer_source();
+    src.set_buffer(buffer.clone());
+    src.connect(&context.destination());
+    src.start();
+
+    std::thread::sleep(std::time::Duration::from_millis(2000));
+
+    println!("> Play sine at 440Hz w/ playback rate at 0.5");
+
+    let src = context.create_buffer_source();
+    src.set_buffer(buffer.clone());
+    src.playback_rate().set_value(0.5);
+    src.connect(&context.destination());
+    src.start();
+
+    std::thread::sleep(std::time::Duration::from_millis(3000));
+
+    println!("> Play sine at 440Hz w/ detune at -1200.");
+
+    let src = context.create_buffer_source();
+    src.set_buffer(buffer.clone());
+    src.detune().set_value(-1200.);
+    src.connect(&context.destination());
+    src.start();
+
+    std::thread::sleep(std::time::Duration::from_millis(3000));
+}

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -42,6 +42,7 @@ pub(crate) struct AudioNodeId(pub u64);
 /// Unique identifier for audio params.
 ///
 /// Store these in your `AudioProcessor` to get access to `AudioParam` values.
+#[derive(Debug)]
 pub struct AudioParamId(u64);
 
 // bit contrived, but for type safety only the context mod can access the inner u64

--- a/src/media_devices/mod.rs
+++ b/src/media_devices/mod.rs
@@ -20,7 +20,6 @@ use crate::media_streams::MediaStream;
 /// assert_eq!(devices[0].kind(), MediaDeviceInfoKind::AudioOutput);
 /// assert_eq!(devices[0].label(), "Macbook Pro Builtin Speakers");
 /// ```
-
 pub fn enumerate_devices() -> Vec<MediaDeviceInfo> {
     crate::io::enumerate_devices()
 }

--- a/src/media_devices/mod.rs
+++ b/src/media_devices/mod.rs
@@ -20,6 +20,7 @@ use crate::media_streams::MediaStream;
 /// assert_eq!(devices[0].kind(), MediaDeviceInfoKind::AudioOutput);
 /// assert_eq!(devices[0].label(), "Macbook Pro Builtin Speakers");
 /// ```
+
 pub fn enumerate_devices() -> Vec<MediaDeviceInfo> {
     crate::io::enumerate_devices()
 }

--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -384,7 +384,8 @@ impl AudioProcessor for AudioBufferSourceRenderer {
             Some(b) => b,
         };
 
-        // compute compound parameter at k-rate
+        // compute compound parameter at k-rate, these parameters have constraints
+        // https://webaudio.github.io/web-audio-api/#audioparam-automation-rate-constraints
         let detune = params.get(&self.detune)[0];
         let playback_rate = params.get(&self.playback_rate)[0];
         let computed_playback_rate = (playback_rate * (detune / 1200.).exp2()) as f64;
@@ -460,8 +461,18 @@ impl AudioProcessor for AudioBufferSourceRenderer {
             self.render_state.is_aligned = true;
         }
 
+        // these two case imply resampling
+        if sampling_ratio != 1. || computed_playback_rate != 1. {
+            self.render_state.is_aligned = false;
+        }
+
+        // If loop points are not aligned on sample, they can imply resampling.
+        // For now we just consider that we can go fast track if loop points are
+        // bound to the buffer boundaries.
+        //
         // by default loop_end is 0., see AudioBufferSourceOptions
-        if loop_start != 0. || loop_end != 0. || sampling_ratio != 1. {
+        // but loop_start = 0 && loop_end = buffer.duration should go to fast track
+        if loop_start != 0. || (loop_end != 0. && loop_end != duration) {
             self.render_state.is_aligned = false;
         }
 
@@ -960,6 +971,84 @@ mod tests {
 
             assert_float_eq!(channel[..], expected[..], abs_all <= 1e-6);
         });
+    }
+
+    #[test]
+    fn test_playback_rate() {
+        let sample_rate = 44100;
+        let context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
+
+        let mut buffer = context.create_buffer(1, sample_rate, sample_rate as f32);
+        let mut sine = vec![];
+
+        // 1 Hz sine
+        for i in 0..sample_rate {
+            let phase = i as f32 / sample_rate as f32 * 2. * PI;
+            let sample = phase.sin();
+            sine.push(sample);
+        }
+
+        buffer.copy_to_channel(&sine[..], 0);
+
+        let src = context.create_buffer_source();
+        src.connect(&context.destination());
+        src.set_buffer(buffer);
+        src.playback_rate.set_value(0.5);
+        src.start();
+
+        let result = context.start_rendering_sync();
+        let channel = result.get_channel_data(0);
+
+        // 1Hz sine at audio context sample rate
+        let mut expected = vec![];
+
+        // 0.5 Hz sine
+        for i in 0..sample_rate {
+            let phase = i as f32 / sample_rate as f32 * PI;
+            let sample = phase.sin();
+            expected.push(sample);
+        }
+
+        assert_float_eq!(channel[..], expected[..], abs_all <= 1e-6);
+    }
+
+    #[test]
+    fn test_detune() {
+        let sample_rate = 44100;
+        let context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
+
+        let mut buffer = context.create_buffer(1, sample_rate, sample_rate as f32);
+        let mut sine = vec![];
+
+        // 1 Hz sine
+        for i in 0..sample_rate {
+            let phase = i as f32 / sample_rate as f32 * 2. * PI;
+            let sample = phase.sin();
+            sine.push(sample);
+        }
+
+        buffer.copy_to_channel(&sine[..], 0);
+
+        let src = context.create_buffer_source();
+        src.connect(&context.destination());
+        src.set_buffer(buffer);
+        src.detune.set_value(-1200.);
+        src.start();
+
+        let result = context.start_rendering_sync();
+        let channel = result.get_channel_data(0);
+
+        // 1Hz sine at audio context sample rate
+        let mut expected = vec![];
+
+        // 0.5 Hz sine
+        for i in 0..sample_rate {
+            let phase = i as f32 / sample_rate as f32 * PI;
+            let sample = phase.sin();
+            expected.push(sample);
+        }
+
+        assert_float_eq!(channel[..], expected[..], abs_all <= 1e-6);
     }
 
     #[test]

--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -999,10 +999,9 @@ mod tests {
         let result = context.start_rendering_sync();
         let channel = result.get_channel_data(0);
 
-        // 1Hz sine at audio context sample rate
+        // 0.5 Hz sine
         let mut expected = vec![];
 
-        // 0.5 Hz sine
         for i in 0..sample_rate {
             let phase = i as f32 / sample_rate as f32 * PI;
             let sample = phase.sin();
@@ -1038,10 +1037,9 @@ mod tests {
         let result = context.start_rendering_sync();
         let channel = result.get_channel_data(0);
 
-        // 1Hz sine at audio context sample rate
+        // 0.5 Hz sine
         let mut expected = vec![];
 
-        // 0.5 Hz sine
         for i in 0..sample_rate {
             let phase = i as f32 / sample_rate as f32 * PI;
             let sample = phase.sin();


### PR DESCRIPTION
This fix an issue with `AudioBufferSourceNode::playback_rate` and `AudioBufferSourceNode::detune` that were wrongly going into fast track in some cases and were therefore not applied.