### PR TITLE
Refactor: rename enumerate_devices to enumerate_devices_sync

### DIFF
--- a/examples/microphone.rs
+++ b/examples/microphone.rs
@@ -1,6 +1,6 @@
 use web_audio_api::context::{AudioContext, BaseAudioContext};
 use web_audio_api::media_devices;
-use web_audio_api::media_devices::{enumerate_devices, MediaDeviceInfo, MediaDeviceInfoKind};
+use web_audio_api::media_devices::{enumerate_devices_sync, MediaDeviceInfo, MediaDeviceInfoKind};
 use web_audio_api::media_devices::{MediaStreamConstraints, MediaTrackConstraints};
 use web_audio_api::node::AudioNode;
 
@@ -18,7 +18,7 @@ fn ask_sink_id() -> Option<String> {
 fn main() {
     env_logger::init();
 
-    let devices = enumerate_devices();
+    let devices = enumerate_devices_sync();
     let input_devices: Vec<MediaDeviceInfo> = devices
         .into_iter()
         .filter(|d| d.kind() == MediaDeviceInfoKind::AudioInput)

--- a/examples/sink_id.rs
+++ b/examples/sink_id.rs
@@ -1,5 +1,5 @@
 use web_audio_api::context::{AudioContext, AudioContextOptions, BaseAudioContext};
-use web_audio_api::media_devices::{enumerate_devices, MediaDeviceInfo, MediaDeviceInfoKind};
+use web_audio_api::media_devices::{enumerate_devices_sync, MediaDeviceInfo, MediaDeviceInfoKind};
 use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 
 fn ask_sink_id() -> String {
@@ -17,7 +17,7 @@ fn ask_sink_id() -> String {
 fn main() {
     env_logger::init();
 
-    let devices = enumerate_devices();
+    let devices = enumerate_devices_sync();
     let output_devices: Vec<MediaDeviceInfo> = devices
         .into_iter()
         .filter(|d| d.kind() == MediaDeviceInfoKind::AudioOutput)

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -5,7 +5,7 @@ use std::sync::Mutex;
 use crate::context::{AudioContextState, BaseAudioContext, ConcreteBaseAudioContext};
 use crate::events::{EventDispatch, EventHandler, EventType};
 use crate::io::{self, AudioBackendManager, ControlThreadInit, RenderThreadInit};
-use crate::media_devices::enumerate_devices;
+use crate::media_devices::enumerate_devices_sync;
 use crate::media_streams::{MediaStream, MediaStreamTrack};
 use crate::message::ControlMessage;
 use crate::node::{self, ChannelConfigOptions};
@@ -14,12 +14,12 @@ use crate::{AudioRenderCapacity, Event};
 
 /// Check if the provided sink_id is available for playback
 ///
-/// It should be "", "none" or a valid `sinkId` returned from [`enumerate_devices`]
+/// It should be "", "none" or a valid `sinkId` returned from [`enumerate_devices_sync`]
 fn is_valid_sink_id(sink_id: &str) -> bool {
     if sink_id.is_empty() || sink_id == "none" {
         true
     } else {
-        enumerate_devices()
+        enumerate_devices_sync()
             .into_iter()
             .any(|d| d.device_id() == sink_id)
     }
@@ -92,7 +92,7 @@ pub struct AudioContextOptions {
     /// The audio output device
     /// - use `""` for the default audio output device
     /// - use `"none"` to process the audio graph without playing through an audio output device.
-    /// - use `"sinkId"` to use the specified audio sink id, obtained with [`enumerate_devices`]
+    /// - use `"sinkId"` to use the specified audio sink id, obtained with [`enumerate_devices_sync`]
     pub sink_id: String,
 
     /// Option to request a default, optimized or specific render quantum size. It is a hint that might not be honored.
@@ -227,7 +227,7 @@ impl AudioContext {
 
     /// Update the current audio output device.
     ///
-    /// The provided `sink_id` string must match a device name `enumerate_devices`.
+    /// The provided `sink_id` string must match a device name `enumerate_devices_sync`.
     ///
     /// Supplying `"none"` for the `sink_id` will process the audio graph without playing through an
     /// audio output device.

--- a/src/io/cpal.rs
+++ b/src/io/cpal.rs
@@ -95,7 +95,7 @@ impl AudioBackendManager for CpalBackend {
             host.default_output_device()
                 .expect("no output device available")
         } else {
-            Self::enumerate_devices()
+            Self::enumerate_devices_sync()
                 .into_iter()
                 .find(|e| e.device_id() == options.sink_id)
                 .map(|e| *e.device().downcast::<cpal::Device>().unwrap())
@@ -213,7 +213,7 @@ impl AudioBackendManager for CpalBackend {
             host.default_input_device()
                 .expect("no input device available")
         } else {
-            Self::enumerate_devices()
+            Self::enumerate_devices_sync()
                 .into_iter()
                 .find(|e| e.device_id() == options.sink_id)
                 .map(|e| *e.device().downcast::<cpal::Device>().unwrap())
@@ -335,7 +335,7 @@ impl AudioBackendManager for CpalBackend {
         Box::new(self.clone())
     }
 
-    fn enumerate_devices() -> Vec<MediaDeviceInfo>
+    fn enumerate_devices_sync() -> Vec<MediaDeviceInfo>
     where
         Self: Sized,
     {

--- a/src/io/cubeb.rs
+++ b/src/io/cubeb.rs
@@ -203,7 +203,7 @@ impl AudioBackendManager for CubebBackend {
         let device = if options.sink_id.is_empty() {
             None
         } else {
-            Self::enumerate_devices()
+            Self::enumerate_devices_sync()
                 .into_iter()
                 .find(|e| e.device_id() == options.sink_id)
                 .map(|e| *e.device().downcast::<DeviceId>().unwrap())
@@ -301,7 +301,7 @@ impl AudioBackendManager for CubebBackend {
         let device = if options.sink_id.is_empty() {
             None
         } else {
-            Self::enumerate_devices()
+            Self::enumerate_devices_sync()
                 .into_iter()
                 .find(|e| e.device_id() == options.sink_id)
                 .map(|e| *e.device().downcast::<DeviceId>().unwrap())
@@ -383,7 +383,7 @@ impl AudioBackendManager for CubebBackend {
         Box::new(self.clone())
     }
 
-    fn enumerate_devices() -> Vec<MediaDeviceInfo>
+    fn enumerate_devices_sync() -> Vec<MediaDeviceInfo>
     where
         Self: Sized,
     {

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -161,7 +161,7 @@ pub(crate) trait AudioBackendManager: Send + Sync + 'static {
     /// Clone the stream reference
     fn boxed_clone(&self) -> Box<dyn AudioBackendManager>;
 
-    fn enumerate_devices() -> Vec<MediaDeviceInfo>
+    fn enumerate_devices_sync() -> Vec<MediaDeviceInfo>
     where
         Self: Sized;
 }
@@ -196,15 +196,15 @@ fn buffer_size_for_latency_category(
     }
 }
 
-pub(crate) fn enumerate_devices() -> Vec<MediaDeviceInfo> {
+pub(crate) fn enumerate_devices_sync() -> Vec<MediaDeviceInfo> {
     #[cfg(feature = "cubeb")]
     {
-        crate::io::cubeb::CubebBackend::enumerate_devices()
+        crate::io::cubeb::CubebBackend::enumerate_devices_sync()
     }
 
     #[cfg(all(not(feature = "cubeb"), feature = "cpal"))]
     {
-        crate::io::cpal::CpalBackend::enumerate_devices()
+        crate::io::cpal::CpalBackend::enumerate_devices_sync()
     }
 
     #[cfg(all(not(feature = "cubeb"), not(feature = "cpal")))]

--- a/src/io/none.rs
+++ b/src/io/none.rs
@@ -160,7 +160,7 @@ impl AudioBackendManager for NoneBackend {
         Box::new(self.clone())
     }
 
-    fn enumerate_devices() -> Vec<MediaDeviceInfo>
+    fn enumerate_devices_sync() -> Vec<MediaDeviceInfo>
     where
         Self: Sized,
     {

--- a/src/media_devices/mod.rs
+++ b/src/media_devices/mod.rs
@@ -12,16 +12,16 @@ use crate::media_streams::MediaStream;
 /// The media device_id can be used to specify the [`sink_id` of the `AudioContext`](crate::context::AudioContextOptions::sink_id)
 ///
 /// ```no_run
-/// use web_audio_api::media_devices::{enumerate_devices, MediaDeviceInfoKind};
+/// use web_audio_api::media_devices::{enumerate_devices_sync, MediaDeviceInfoKind};
 ///
-/// let devices = enumerate_devices();
+/// let devices = enumerate_devices_sync();
 /// assert_eq!(devices[0].device_id(), "1");
 /// assert_eq!(devices[0].group_id(), None);
 /// assert_eq!(devices[0].kind(), MediaDeviceInfoKind::AudioOutput);
 /// assert_eq!(devices[0].label(), "Macbook Pro Builtin Speakers");
 /// ```
-pub fn enumerate_devices() -> Vec<MediaDeviceInfo> {
-    crate::io::enumerate_devices()
+pub fn enumerate_devices_sync() -> Vec<MediaDeviceInfo> {
+    crate::io::enumerate_devices_sync()
 }
 
 /// Describes input/output type of a media device
@@ -34,7 +34,7 @@ pub enum MediaDeviceInfoKind {
 
 /// Describes a single media input or output device
 ///
-/// Call [`enumerate_devices`] to obtain a list of devices for your hardware.
+/// Call [`enumerate_devices_sync`] to obtain a list of devices for your hardware.
 #[derive(Debug)]
 pub struct MediaDeviceInfo {
     device_id: String,


### PR DESCRIPTION
Fixes #273 for consistency as `enumerateDevices` is supposed to be async https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/enumerateDevices