### PR TITLE
Simplify and align AtomicF32/F64 with std::sync::atomic

### DIFF
--- a/src/control.rs
+++ b/src/control.rs
@@ -23,24 +23,24 @@ impl Scheduler {
 
     /// Retrieve playback start value
     pub fn get_start_at(&self) -> f64 {
-        self.start.load()
+        self.start.load(Ordering::SeqCst)
     }
 
     /// Schedule playback start at this timestamp
     pub fn start_at(&self, start: f64) {
         // todo panic on invalid values, or when already called
-        self.start.store(start);
+        self.start.store(start, Ordering::SeqCst);
     }
 
     /// Retrieve playback stop value
     pub fn get_stop_at(&self) -> f64 {
-        self.stop.load()
+        self.stop.load(Ordering::SeqCst)
     }
 
     /// Stop playback at this timestamp
     pub fn stop_at(&self, stop: f64) {
         // todo panic on invalid values, or when already called
-        self.stop.store(stop);
+        self.stop.store(stop, Ordering::SeqCst);
     }
 }
 
@@ -87,35 +87,35 @@ impl Controller {
     }
 
     pub fn loop_start(&self) -> f64 {
-        self.loop_start.load()
+        self.loop_start.load(Ordering::SeqCst)
     }
 
     pub fn set_loop_start(&self, loop_start: f64) {
-        self.loop_start.store(loop_start);
+        self.loop_start.store(loop_start, Ordering::SeqCst);
     }
 
     pub fn loop_end(&self) -> f64 {
-        self.loop_end.load()
+        self.loop_end.load(Ordering::SeqCst)
     }
 
     pub fn set_loop_end(&self, loop_end: f64) {
-        self.loop_end.store(loop_end);
+        self.loop_end.store(loop_end, Ordering::SeqCst);
     }
 
     pub fn offset(&self) -> f64 {
-        self.offset.load()
+        self.offset.load(Ordering::SeqCst)
     }
 
     pub fn set_offset(&self, offset: f64) {
-        self.offset.store(offset);
+        self.offset.store(offset, Ordering::SeqCst);
     }
 
     pub fn duration(&self) -> f64 {
-        self.duration.load()
+        self.duration.load(Ordering::SeqCst)
     }
 
     pub fn set_duration(&self, duration: f64) {
-        self.duration.store(duration)
+        self.duration.store(duration, Ordering::SeqCst)
     }
 }
 

--- a/src/io/cpal.rs
+++ b/src/io/cpal.rs
@@ -1,4 +1,5 @@
 //! Audio IO management API
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -365,7 +366,7 @@ impl AudioBackendManager for CpalBackend {
     }
 
     fn output_latency(&self) -> f64 {
-        self.output_latency.load()
+        self.output_latency.load(Ordering::SeqCst)
     }
 
     fn sink_id(&self) -> &str {
@@ -454,7 +455,7 @@ fn spawn_output_stream(
             config,
             move |d: &mut [f32], i: &OutputCallbackInfo| {
                 render.render(d);
-                output_latency.store(latency_in_seconds(i));
+                output_latency.store(latency_in_seconds(i), Ordering::SeqCst);
             },
             err_fn,
             None,
@@ -463,7 +464,7 @@ fn spawn_output_stream(
             config,
             move |d: &mut [f64], i: &OutputCallbackInfo| {
                 render.render(d);
-                output_latency.store(latency_in_seconds(i));
+                output_latency.store(latency_in_seconds(i), Ordering::SeqCst);
             },
             err_fn,
             None,
@@ -472,7 +473,7 @@ fn spawn_output_stream(
             config,
             move |d: &mut [u8], i: &OutputCallbackInfo| {
                 render.render(d);
-                output_latency.store(latency_in_seconds(i));
+                output_latency.store(latency_in_seconds(i), Ordering::SeqCst);
             },
             err_fn,
             None,
@@ -481,7 +482,7 @@ fn spawn_output_stream(
             config,
             move |d: &mut [u16], i: &OutputCallbackInfo| {
                 render.render(d);
-                output_latency.store(latency_in_seconds(i));
+                output_latency.store(latency_in_seconds(i), Ordering::SeqCst);
             },
             err_fn,
             None,
@@ -490,7 +491,7 @@ fn spawn_output_stream(
             config,
             move |d: &mut [u32], i: &OutputCallbackInfo| {
                 render.render(d);
-                output_latency.store(latency_in_seconds(i));
+                output_latency.store(latency_in_seconds(i), Ordering::SeqCst);
             },
             err_fn,
             None,
@@ -499,7 +500,7 @@ fn spawn_output_stream(
             config,
             move |d: &mut [u64], i: &OutputCallbackInfo| {
                 render.render(d);
-                output_latency.store(latency_in_seconds(i));
+                output_latency.store(latency_in_seconds(i), Ordering::SeqCst);
             },
             err_fn,
             None,
@@ -508,7 +509,7 @@ fn spawn_output_stream(
             config,
             move |d: &mut [i8], i: &OutputCallbackInfo| {
                 render.render(d);
-                output_latency.store(latency_in_seconds(i));
+                output_latency.store(latency_in_seconds(i), Ordering::SeqCst);
             },
             err_fn,
             None,
@@ -517,7 +518,7 @@ fn spawn_output_stream(
             config,
             move |d: &mut [i16], i: &OutputCallbackInfo| {
                 render.render(d);
-                output_latency.store(latency_in_seconds(i));
+                output_latency.store(latency_in_seconds(i), Ordering::SeqCst);
             },
             err_fn,
             None,
@@ -526,7 +527,7 @@ fn spawn_output_stream(
             config,
             move |d: &mut [i32], i: &OutputCallbackInfo| {
                 render.render(d);
-                output_latency.store(latency_in_seconds(i));
+                output_latency.store(latency_in_seconds(i), Ordering::SeqCst);
             },
             err_fn,
             None,
@@ -535,7 +536,7 @@ fn spawn_output_stream(
             config,
             move |d: &mut [i64], i: &OutputCallbackInfo| {
                 render.render(d);
-                output_latency.store(latency_in_seconds(i));
+                output_latency.store(latency_in_seconds(i), Ordering::SeqCst);
             },
             err_fn,
             None,

--- a/src/node/panner.rs
+++ b/src/node/panner.rs
@@ -462,51 +462,51 @@ impl PannerNode {
     }
 
     pub fn ref_distance(&self) -> f64 {
-        self.ref_distance.load()
+        self.ref_distance.load(Ordering::SeqCst)
     }
 
     pub fn set_ref_distance(&self, value: f64) {
-        self.ref_distance.store(value);
+        self.ref_distance.store(value, Ordering::SeqCst);
     }
 
     pub fn max_distance(&self) -> f64 {
-        self.max_distance.load()
+        self.max_distance.load(Ordering::SeqCst)
     }
 
     pub fn set_max_distance(&self, value: f64) {
-        self.max_distance.store(value);
+        self.max_distance.store(value, Ordering::SeqCst);
     }
 
     pub fn rolloff_factor(&self) -> f64 {
-        self.rolloff_factor.load()
+        self.rolloff_factor.load(Ordering::SeqCst)
     }
 
     pub fn set_rolloff_factor(&self, value: f64) {
-        self.rolloff_factor.store(value);
+        self.rolloff_factor.store(value, Ordering::SeqCst);
     }
 
     pub fn cone_inner_angle(&self) -> f64 {
-        self.cone_inner_angle.load()
+        self.cone_inner_angle.load(Ordering::SeqCst)
     }
 
     pub fn set_cone_inner_angle(&self, value: f64) {
-        self.cone_inner_angle.store(value);
+        self.cone_inner_angle.store(value, Ordering::SeqCst);
     }
 
     pub fn cone_outer_angle(&self) -> f64 {
-        self.cone_outer_angle.load()
+        self.cone_outer_angle.load(Ordering::SeqCst)
     }
 
     pub fn set_cone_outer_angle(&self, value: f64) {
-        self.cone_outer_angle.store(value);
+        self.cone_outer_angle.store(value, Ordering::SeqCst);
     }
 
     pub fn cone_outer_gain(&self) -> f64 {
-        self.cone_outer_gain.load()
+        self.cone_outer_gain.load(Ordering::SeqCst)
     }
 
     pub fn set_cone_outer_gain(&self, value: f64) {
-        self.cone_outer_gain.store(value);
+        self.cone_outer_gain.store(value, Ordering::SeqCst);
     }
 
     pub fn panning_model(&self) -> PanningModelType {
@@ -771,12 +771,12 @@ impl PannerRenderer {
         source_orientation: [f32; 3],
         listener_position: [f32; 3],
     ) -> f32 {
-        let abs_inner_angle = self.cone_inner_angle.load().abs() as f32 / 2.;
-        let abs_outer_angle = self.cone_outer_angle.load().abs() as f32 / 2.;
+        let abs_inner_angle = self.cone_inner_angle.load(Ordering::SeqCst).abs() as f32 / 2.;
+        let abs_outer_angle = self.cone_outer_angle.load(Ordering::SeqCst).abs() as f32 / 2.;
         if abs_inner_angle >= 180. && abs_outer_angle >= 180. {
             1. // no cone specified
         } else {
-            let cone_outer_gain = self.cone_outer_gain.load() as f32;
+            let cone_outer_gain = self.cone_outer_gain.load(Ordering::SeqCst) as f32;
 
             let abs_angle =
                 crate::spatial::angle(source_position, source_orientation, listener_position);
@@ -795,13 +795,13 @@ impl PannerRenderer {
 
     fn dist_gain(&self, source_position: [f32; 3], listener_position: [f32; 3]) -> f32 {
         let distance_model = self.distance_model.load(Ordering::SeqCst).into();
-        let ref_distance = self.ref_distance.load();
-        let rolloff_factor = self.rolloff_factor.load();
+        let ref_distance = self.ref_distance.load(Ordering::SeqCst);
+        let rolloff_factor = self.rolloff_factor.load(Ordering::SeqCst);
         let distance = crate::spatial::distance(source_position, listener_position) as f64;
 
         let dist_gain = match distance_model {
             DistanceModelType::Linear => {
-                let max_distance = self.max_distance.load();
+                let max_distance = self.max_distance.load(Ordering::SeqCst);
                 let d2ref = ref_distance.min(max_distance);
                 let d2max = ref_distance.max(max_distance);
                 let d_clamped = distance.clamp(d2ref, d2max);


### PR DESCRIPTION
- Adhere to the _Principle Of Least Surprise_ for developers.
- Overly restrictive memory barriers could reduce performance considerably.

I expect that `SeqCst` is only needed for very few use cases. Most of the orderings could probably be downgraded to `Relaxed`. Stronger guarantees are only needed for synchronization purposes. Not for shared parameters that could change at any time in no particular order.