### PR TITLE
cpal-jack: Fix panic caused by unwrap()

### DIFF
--- a/src/io/cpal.rs
+++ b/src/io/cpal.rs
@@ -425,11 +425,11 @@ impl AudioBackendManager for CpalBackend {
 
 fn latency_in_seconds(infos: &OutputCallbackInfo) -> f64 {
     let timestamp = infos.timestamp();
-    let delta = timestamp
+    timestamp
         .playback
         .duration_since(&timestamp.callback)
-        .unwrap();
-    delta.as_secs() as f64 + delta.subsec_nanos() as f64 * 1e-9
+        .map(|delta| delta.as_secs() as f64 + delta.subsec_nanos() as f64 * 1e-9)
+        .unwrap_or(0.0)
 }
 
 /// Creates an output stream


### PR DESCRIPTION
Using a latency of 0.0 as a fallback seems to work. I have no clue how this undocumented latency calculation is supposed to work.

```
[2023-06-18T23:44:55Z INFO  web_audio_api::io::cpal] Audio Output Host: cpal Jack
[2023-06-18T23:44:55Z INFO  web_audio_api::io::cpal] Output device: Ok("cpal_client_out")
[2023-06-18T23:44:55Z DEBUG web_audio_api::io::cpal] Attempt output stream with preferred config: StreamConfig { channels: 2, sample_rate: SampleRate(48000), buffer_size: Fixed(1024) }
[2023-06-18T23:44:56Z DEBUG web_audio_api::io::cpal] Output stream set up successfully
```

Also fixes #288 for me. No wonder with such a generous buffer size.