### PR TITLE
Fix: use cpal feature only for clippy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,7 +64,7 @@ repos:
             --locked,
             --workspace,
             --features,
-            cpal,
+            cubeb,
             --all-targets,
             --,
             -D,
@@ -82,7 +82,8 @@ repos:
             doc,
             --locked,
             --workspace,
-            --all-features,
+            --features,
+            cubeb,
             --no-deps,
             --document-private-items,
           ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,8 @@ repos:
           [
             --locked,
             --workspace,
-            --all-features,
+            --features,
+            cpal,
             --all-targets,
             --,
             -D,


### PR DESCRIPTION
Just a small fix in the pre-commit file that was crashing on Mac because of the clippy `--all-features` flag, I guess because the JACK backend is not implemented by cpal for Mac or Windows:

```
error[E0599]: no variant or associated item named `Jack` found for enum `cpal::HostId` in the current scope
  --> src/io/cpal.rs:77:45
   |
77 |             .find(|id| *id == cpal::HostId::Jack)
   |                                             ^^^^ variant or associated item not found in `HostId`
```


