### PR TITLE
Fix broken resampling in MediaElement, support more media types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.70"
 arc-swap = "1.6"
 arrayvec = "0.7"
 cpal = { version = "0.15.0", optional = true }
-creek = "1.0"
+creek = "1.1"
 crossbeam-channel = "0.5"
 cubeb = { version = "0.10.0", optional = true }
 dasp_sample = "0.11"
@@ -54,12 +54,9 @@ mp3 = ["symphonia/mp3", "creek/decode-mp3"]
 ogg = ["symphonia/ogg", "symphonia/vorbis", "creek/decode-ogg", "creek/decode-vorbis"]
 flac = ["symphonia/flac", "creek/decode-flac"]
 wav = ["symphonia/wav", "symphonia/pcm", "creek/decode-wav", "creek/decode-pcm"]
-# TODO(m4a): Add "creek/decode-aac" after <https://github.com/MeadowlarkDAW/creek/pull/22> has been merged
-aac = ["symphonia/aac"]
-# TODO(m4a): Add "creek/decode-isomp4" after <https://github.com/MeadowlarkDAW/creek/pull/22> has been merged
-m4a = ["aac", "symphonia/isomp4"]
-# TODO(alac): Add "creek/decode-alac" and "creek/decode-isomp4" after <https://github.com/MeadowlarkDAW/creek/pull/22> has been merged
-alac = ["symphonia/alac", "symphonia/isomp4"]
+aac = ["symphonia/aac", "creek/decode-aac"]
+m4a = ["aac", "symphonia/isomp4", "creek/decode-isomp4"]
+alac = ["symphonia/alac", "symphonia/isomp4", "creek/decode-alac", "creek/decode-isomp4"]
 cpal = ["dep:cpal"]
 cubeb = ["dep:cubeb"]
 cpal-jack = ["cpal", "cpal/jack"]

--- a/tests/media_element.rs
+++ b/tests/media_element.rs
@@ -17,7 +17,9 @@ fn test_media_element_source_progress() {
     src.connect(&context.destination());
     media.play();
 
-    // sleep for a bit, make sure the audio thread has started
+    // TODO improve test setup of online AudioContext
+    // <https://github.com/orottier/web-audio-api-rs/issues/323>
+    // Sleep for a bit, make sure the audio thread has started
     std::thread::sleep(std::time::Duration::from_millis(100));
 
     // assert the media has progressed

--- a/tests/media_element.rs
+++ b/tests/media_element.rs
@@ -1,0 +1,25 @@
+use web_audio_api::context::{AudioContext, AudioContextOptions, BaseAudioContext};
+use web_audio_api::node::AudioNode;
+use web_audio_api::MediaElement;
+
+#[test]
+fn test_media_element_source_progress() {
+    let options = AudioContextOptions {
+        sink_id: "none".into(),
+        ..AudioContextOptions::default()
+    };
+    let context = AudioContext::new(options);
+
+    let mut media = MediaElement::new("samples/major-scale.ogg").unwrap();
+    media.set_loop(true);
+
+    let src = context.create_media_element_source(&mut media);
+    src.connect(&context.destination());
+    media.play();
+
+    // sleep for a bit, make sure the audio thread has started
+    std::thread::sleep(std::time::Duration::from_millis(100));
+
+    // assert the media has progressed
+    assert!(media.current_time() > 0.05);
+}


### PR DESCRIPTION
For your info @b-ma, @uklotzde and I have taken over maintenance of the `creek` dependency.

Some features of the media element that we don't have implemented right now (reverse playback, and perhaps pitch preserving playback settings) could be implemented there.