### PR TITLE
onmessage: Either consume and handle or drop incoming messages

### DIFF
--- a/examples/worklet.rs
+++ b/examples/worklet.rs
@@ -143,13 +143,17 @@ impl AudioProcessor for WhiteNoiseProcessor {
 
     fn onmessage(&mut self, msg: Box<dyn std::any::Any + Send + 'static>) {
         // handle incoming signals requesting for change of color
-        if let Some(&color) = msg.downcast_ref::<NoiseColor>() {
-            self.color = color;
-            return;
-        }
+        let msg = match msg.downcast::<NoiseColor>() {
+            Ok(color) => {
+                self.color = *color;
+                return;
+            }
+            Err(msg) => msg,
+        };
 
-        // ignore other incoming messages
-        log::warn!("WhiteNoiseProcessor: Ignoring incoming message");
+        // ...add more message handlers here...
+
+        log::warn!("WhiteNoiseProcessor: Dropping incoming message {msg:?}");
     }
 }
 

--- a/src/node/constant_source.rs
+++ b/src/node/constant_source.rs
@@ -203,15 +203,18 @@ impl AudioProcessor for ConstantSourceRenderer {
     }
 
     fn onmessage(&mut self, msg: Box<dyn std::any::Any + Send + 'static>) {
-        if let Ok(schedule) = msg.downcast::<Schedule>() {
-            match *schedule {
-                Schedule::Start(v) => self.start_time = v,
-                Schedule::Stop(v) => self.stop_time = v,
+        let msg = match msg.downcast::<Schedule>() {
+            Ok(schedule) => {
+                match *schedule {
+                    Schedule::Start(v) => self.start_time = v,
+                    Schedule::Stop(v) => self.stop_time = v,
+                }
+                return;
             }
-            return;
-        }
+            Err(msg) => msg,
+        };
 
-        log::warn!("ConstantSourceRenderer: Ignoring incoming message");
+        log::warn!("ConstantSourceRenderer: Dropping incoming message {msg:?}");
     }
 }
 

--- a/src/node/constant_source.rs
+++ b/src/node/constant_source.rs
@@ -208,6 +208,7 @@ impl AudioProcessor for ConstantSourceRenderer {
                 Schedule::Start(v) => self.start_time = v,
                 Schedule::Stop(v) => self.stop_time = v,
             }
+            return;
         }
 
         log::warn!("ConstantSourceRenderer: Ignoring incoming message");


### PR DESCRIPTION
Use a common pattern for consuming/handling/dropping messages that prevents handling the same message twice in AudioProcessor::onmessage() by chaining multiple invocations of `downcast` instead of using `downcast_ref`.

Such a common pattern might allow us to introduce a macro for avoiding all this boilerplate that now became more obvious. It might also be a precondition to prevent deallocation in the real-time thread in a consistent and safe manner in the future.