### PR TITLE
RenderThread: Rename method according to code comments

### DIFF
--- a/src/context/offline.rs
+++ b/src/context/offline.rs
@@ -31,7 +31,7 @@ mod private {
         }
 
         pub fn render_audiobuffer(self, buffer_size: usize) -> AudioBuffer {
-            self.0.render_audiobuffer(buffer_size)
+            self.0.render_audiobuffer_sync(buffer_size)
         }
     }
 

--- a/src/render/thread.rs
+++ b/src/render/thread.rs
@@ -126,12 +126,12 @@ impl RenderThread {
         }
     }
 
-    // Render method of the `OfflineAudioContext::start_redering_sync`
+    // Render method of the `OfflineAudioContext::start_rendering_sync`
     // This method is not spec compliant and obviously marked as synchronous, so we
     // don't launch a thread.
     //
     // cf. https://webaudio.github.io/web-audio-api/#dom-offlineaudiocontext-startrendering
-    pub fn render_audiobuffer(mut self, length: usize) -> AudioBuffer {
+    pub fn render_audiobuffer_sync(mut self, length: usize) -> AudioBuffer {
         let options = AudioBufferOptions {
             number_of_channels: self.number_of_channels,
             length,


### PR DESCRIPTION
The code comments seem to be inconsistent with the code. This is what I would expect according to the comments.