### PR TITLE
Fix output stream number of channels

### DIFF
--- a/examples/multichannel.maxpat
+++ b/examples/multichannel.maxpat
@@ -1,0 +1,222 @@
+{
+	"patcher" : 	{
+		"fileversion" : 1,
+		"appversion" : 		{
+			"major" : 8,
+			"minor" : 5,
+			"revision" : 3,
+			"architecture" : "x64",
+			"modernui" : 1
+		}
+,
+		"classnamespace" : "box",
+		"rect" : [ 309.0, 671.0, 1188.0, 539.0 ],
+		"bglocked" : 0,
+		"openinpresentation" : 0,
+		"default_fontsize" : 12.0,
+		"default_fontface" : 0,
+		"default_fontname" : "Arial",
+		"gridonopen" : 1,
+		"gridsize" : [ 15.0, 15.0 ],
+		"gridsnaponopen" : 1,
+		"objectsnaponopen" : 1,
+		"statusbarvisible" : 2,
+		"toolbarvisible" : 1,
+		"lefttoolbarpinned" : 0,
+		"toptoolbarpinned" : 0,
+		"righttoolbarpinned" : 0,
+		"bottomtoolbarpinned" : 0,
+		"toolbars_unpinned_last_save" : 0,
+		"tallnewobj" : 0,
+		"boxanimatetime" : 200,
+		"enablehscroll" : 1,
+		"enablevscroll" : 1,
+		"devicewidth" : 0.0,
+		"description" : "",
+		"digest" : "",
+		"tags" : "",
+		"style" : "",
+		"subpatcher_template" : "",
+		"assistshowspatchername" : 0,
+		"boxes" : [ 			{
+				"box" : 				{
+					"id" : "obj-5",
+					"maxclass" : "meter~",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "float" ],
+					"patching_rect" : [ 606.428571428571445, 189.0, 19.0, 65.0 ]
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-6",
+					"maxclass" : "meter~",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "float" ],
+					"patching_rect" : [ 575.428571428571445, 189.0, 19.0, 65.0 ]
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-7",
+					"maxclass" : "meter~",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "float" ],
+					"patching_rect" : [ 548.0, 189.0, 19.0, 65.0 ]
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-8",
+					"maxclass" : "meter~",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "float" ],
+					"patching_rect" : [ 519.0, 189.0, 19.0, 65.0 ]
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-4",
+					"maxclass" : "meter~",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "float" ],
+					"patching_rect" : [ 488.428571428571445, 189.0, 19.0, 65.0 ]
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-27",
+					"maxclass" : "meter~",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "float" ],
+					"patching_rect" : [ 457.428571428571445, 189.0, 19.0, 65.0 ]
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-26",
+					"maxclass" : "meter~",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "float" ],
+					"patching_rect" : [ 430.0, 189.0, 19.0, 65.0 ]
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-25",
+					"maxclass" : "meter~",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "float" ],
+					"patching_rect" : [ 401.0, 189.0, 19.0, 65.0 ]
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-3",
+					"maxclass" : "toggle",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "int" ],
+					"parameter_enable" : 0,
+					"patching_rect" : [ 430.0, 75.0, 24.0, 24.0 ]
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-1",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 8,
+					"outlettype" : [ "signal", "signal", "signal", "signal", "signal", "signal", "signal", "signal" ],
+					"patching_rect" : [ 430.0, 124.0, 115.0, 22.0 ],
+					"text" : "adc~ 1 2 3 4 5 6 7 8"
+				}
+
+			}
+ ],
+		"lines" : [ 			{
+				"patchline" : 				{
+					"destination" : [ "obj-25", 0 ],
+					"source" : [ "obj-1", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-26", 0 ],
+					"source" : [ "obj-1", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-27", 0 ],
+					"source" : [ "obj-1", 2 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-4", 0 ],
+					"source" : [ "obj-1", 3 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-5", 0 ],
+					"source" : [ "obj-1", 7 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-6", 0 ],
+					"source" : [ "obj-1", 6 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-7", 0 ],
+					"source" : [ "obj-1", 5 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-8", 0 ],
+					"source" : [ "obj-1", 4 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-1", 0 ],
+					"source" : [ "obj-3", 0 ]
+				}
+
+			}
+ ],
+		"dependency_cache" : [  ],
+		"autosave" : 0
+	}
+
+}

--- a/examples/multichannel.rs
+++ b/examples/multichannel.rs
@@ -1,0 +1,69 @@
+use web_audio_api::context::{
+    AudioContext, AudioContextLatencyCategory, AudioContextOptions, BaseAudioContext,
+};
+use web_audio_api::node::{AudioNode, AudioScheduledSourceNode, ChannelInterpretation};
+
+// Example of multichannel routing, for now the library can only handle up to
+// 32 channels.
+//
+// The example can be tested with a virtual soundcard such as Blackhole
+// https://github.com/ExistentialAudio/BlackHole
+// - select backhole as the default system output
+// - then use blackhole as input in another program to check the example output
+// (see `multichannel.maxpat` if you have Max installed, @todo make a Pd version)
+//
+// `cargo run --release --example multichannel`
+//
+// If you are on Linux and use ALSA as audio backend backend, you might want to run
+// the example with the `WEB_AUDIO_LATENCY=playback ` env variable which will
+// increase the buffer size to 1024
+//
+// `WEB_AUDIO_LATENCY=playback cargo run --release --example multichannel`
+fn main() {
+    env_logger::init();
+
+    let latency_hint = match std::env::var("WEB_AUDIO_LATENCY").as_deref() {
+        Ok("playback") => AudioContextLatencyCategory::Playback,
+        _ => AudioContextLatencyCategory::default(),
+    };
+
+    let context = AudioContext::new(AudioContextOptions {
+        latency_hint,
+        ..AudioContextOptions::default()
+    });
+
+    // this should be clamped to MAX_CHANNELS (32), even if the soundcard can provide more channels
+    println!(
+        "> Max channel count: {:?}",
+        context.destination().max_channels_count()
+    );
+
+    let num_channels = 8;
+
+    context.destination().set_channel_count(num_channels);
+    context
+        .destination()
+        .set_channel_interpretation(ChannelInterpretation::Discrete);
+
+    let merger = context.create_channel_merger(num_channels);
+    merger.set_channel_interpretation(ChannelInterpretation::Discrete);
+    merger.connect(&context.destination());
+
+    let mut output_channel = 0;
+
+    loop {
+        println!("- output sine in channel {:?}", output_channel);
+
+        let now = context.current_time();
+
+        let osc = context.create_oscillator();
+        osc.connect_at(&merger, 0, output_channel);
+        osc.frequency().set_value(200.);
+        osc.start_at(now);
+        osc.stop_at(now + 1.);
+
+        output_channel = (output_channel + 1) % num_channels;
+
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+}

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -9,6 +9,7 @@ use crate::media_devices::{enumerate_devices_sync, MediaDeviceInfoKind};
 use crate::media_streams::{MediaStream, MediaStreamTrack};
 use crate::message::ControlMessage;
 use crate::node::{self, ChannelConfigOptions};
+use crate::render::graph::Graph;
 use crate::MediaElement;
 use crate::{AudioRenderCapacity, Event};
 
@@ -172,8 +173,8 @@ impl AudioContext {
             event_recv,
         } = control_thread_init;
 
-        let graph = crate::render::graph::Graph::new();
-        let message = crate::message::ControlMessage::Startup { graph };
+        let graph = Graph::new();
+        let message = ControlMessage::Startup { graph };
         ctrl_msg_send.send(message).unwrap();
 
         let base = ConcreteBaseAudioContext::new(

--- a/src/io/cpal.rs
+++ b/src/io/cpal.rs
@@ -382,7 +382,7 @@ impl AudioBackendManager for CpalBackend {
     }
 
     fn output_latency(&self) -> f64 {
-        self.output_latency.load(Ordering::SeqCst)
+        self.output_latency.load(Ordering::Relaxed)
     }
 
     fn sink_id(&self) -> &str {
@@ -471,7 +471,7 @@ fn spawn_output_stream(
             config,
             move |d: &mut [f32], i: &OutputCallbackInfo| {
                 render.render(d);
-                output_latency.store(latency_in_seconds(i), Ordering::SeqCst);
+                output_latency.store(latency_in_seconds(i), Ordering::Relaxed);
             },
             err_fn,
             None,
@@ -480,7 +480,7 @@ fn spawn_output_stream(
             config,
             move |d: &mut [f64], i: &OutputCallbackInfo| {
                 render.render(d);
-                output_latency.store(latency_in_seconds(i), Ordering::SeqCst);
+                output_latency.store(latency_in_seconds(i), Ordering::Relaxed);
             },
             err_fn,
             None,
@@ -489,7 +489,7 @@ fn spawn_output_stream(
             config,
             move |d: &mut [u8], i: &OutputCallbackInfo| {
                 render.render(d);
-                output_latency.store(latency_in_seconds(i), Ordering::SeqCst);
+                output_latency.store(latency_in_seconds(i), Ordering::Relaxed);
             },
             err_fn,
             None,
@@ -498,7 +498,7 @@ fn spawn_output_stream(
             config,
             move |d: &mut [u16], i: &OutputCallbackInfo| {
                 render.render(d);
-                output_latency.store(latency_in_seconds(i), Ordering::SeqCst);
+                output_latency.store(latency_in_seconds(i), Ordering::Relaxed);
             },
             err_fn,
             None,
@@ -507,7 +507,7 @@ fn spawn_output_stream(
             config,
             move |d: &mut [u32], i: &OutputCallbackInfo| {
                 render.render(d);
-                output_latency.store(latency_in_seconds(i), Ordering::SeqCst);
+                output_latency.store(latency_in_seconds(i), Ordering::Relaxed);
             },
             err_fn,
             None,
@@ -516,7 +516,7 @@ fn spawn_output_stream(
             config,
             move |d: &mut [u64], i: &OutputCallbackInfo| {
                 render.render(d);
-                output_latency.store(latency_in_seconds(i), Ordering::SeqCst);
+                output_latency.store(latency_in_seconds(i), Ordering::Relaxed);
             },
             err_fn,
             None,
@@ -525,7 +525,7 @@ fn spawn_output_stream(
             config,
             move |d: &mut [i8], i: &OutputCallbackInfo| {
                 render.render(d);
-                output_latency.store(latency_in_seconds(i), Ordering::SeqCst);
+                output_latency.store(latency_in_seconds(i), Ordering::Relaxed);
             },
             err_fn,
             None,
@@ -534,7 +534,7 @@ fn spawn_output_stream(
             config,
             move |d: &mut [i16], i: &OutputCallbackInfo| {
                 render.render(d);
-                output_latency.store(latency_in_seconds(i), Ordering::SeqCst);
+                output_latency.store(latency_in_seconds(i), Ordering::Relaxed);
             },
             err_fn,
             None,
@@ -543,7 +543,7 @@ fn spawn_output_stream(
             config,
             move |d: &mut [i32], i: &OutputCallbackInfo| {
                 render.render(d);
-                output_latency.store(latency_in_seconds(i), Ordering::SeqCst);
+                output_latency.store(latency_in_seconds(i), Ordering::Relaxed);
             },
             err_fn,
             None,
@@ -552,7 +552,7 @@ fn spawn_output_stream(
             config,
             move |d: &mut [i64], i: &OutputCallbackInfo| {
                 render.render(d);
-                output_latency.store(latency_in_seconds(i), Ordering::SeqCst);
+                output_latency.store(latency_in_seconds(i), Ordering::Relaxed);
             },
             err_fn,
             None,

--- a/src/io/cubeb.rs
+++ b/src/io/cubeb.rs
@@ -7,7 +7,7 @@ use crate::context::AudioContextOptions;
 use crate::io::microphone::MicrophoneRender;
 use crate::media_devices::{MediaDeviceInfo, MediaDeviceInfoKind};
 use crate::render::RenderThread;
-use crate::RENDER_QUANTUM_SIZE;
+use crate::{MAX_CHANNELS, RENDER_QUANTUM_SIZE};
 
 use cubeb::{Context, DeviceId, DeviceType, StereoFrame, Stream, StreamParams};
 
@@ -166,7 +166,10 @@ impl AudioBackendManager for CubebBackend {
             .map(|v| v as usize)
             .ok()
             .unwrap_or(2);
-        crate::assert_valid_number_of_channels(number_of_channels);
+
+        // clamp the requested stream number of channels to MAX_CHANNELS even if
+        // the soundcard can provide more channels
+        let number_of_channels = number_of_channels.min(MAX_CHANNELS);
 
         let layout = match number_of_channels {
             1 => cubeb::ChannelLayout::MONO,

--- a/src/render/thread.rs
+++ b/src/render/thread.rs
@@ -23,6 +23,8 @@ use super::graph::Graph;
 pub(crate) struct RenderThread {
     graph: Option<Graph>,
     sample_rate: f32,
+    /// number of channels of the backend stream, i.e. sound card number of
+    /// channels clamped to MAX_CHANNELS
     number_of_channels: usize,
     frames_played: Arc<AtomicU64>,
     receiver: Option<Receiver<ControlMessage>>,
@@ -176,12 +178,12 @@ impl RenderThread {
         buffer
     }
 
-    pub fn render<S: FromSample<f32> + Clone>(&mut self, buffer: &mut [S]) {
+    pub fn render<S: FromSample<f32> + Clone>(&mut self, output_buffer: &mut [S]) {
         // collect timing information
         let render_start = Instant::now();
 
         // perform actual rendering
-        self.render_inner(buffer);
+        self.render_inner(output_buffer);
 
         // calculate load value and ship to control thread
         if let Some(load_value_sender) = &self.load_value_sender {
@@ -198,13 +200,13 @@ impl RenderThread {
         }
     }
 
-    fn render_inner<S: FromSample<f32> + Clone>(&mut self, mut buffer: &mut [S]) {
+    fn render_inner<S: FromSample<f32> + Clone>(&mut self, mut output_buffer: &mut [S]) {
         // There may be audio frames left over from the previous render call,
         // if the cpal buffer size did not align with our internal RENDER_QUANTUM_SIZE
         if let Some((offset, prev_rendered)) = self.buffer_offset.take() {
             let leftover_len = (RENDER_QUANTUM_SIZE - offset) * self.number_of_channels;
             // split the leftover frames slice, to fit in `buffer`
-            let (first, next) = buffer.split_at_mut(leftover_len.min(buffer.len()));
+            let (first, next) = output_buffer.split_at_mut(leftover_len.min(output_buffer.len()));
 
             // copy rendered audio into output slice
             for i in 0..self.number_of_channels {
@@ -226,7 +228,7 @@ impl RenderThread {
             }
 
             // if there's still space left in the buffer, continue rendering
-            buffer = next;
+            output_buffer = next;
         }
 
         // handle addition/removal of nodes/edges
@@ -234,7 +236,7 @@ impl RenderThread {
 
         // if the thread is still booting, or shutting down, fill with silence
         if self.graph.is_none() {
-            buffer.fill(S::from_sample_(0.));
+            output_buffer.fill(S::from_sample_(0.));
             return;
         }
 
@@ -242,7 +244,7 @@ impl RenderThread {
         // may not be able to emit chunks of this size.
         let chunk_size = RENDER_QUANTUM_SIZE * self.number_of_channels;
 
-        for data in buffer.chunks_mut(chunk_size) {
+        for data in output_buffer.chunks_mut(chunk_size) {
             // update time
             let current_frame = self
                 .frames_played
@@ -258,17 +260,19 @@ impl RenderThread {
             };
 
             // render audio graph, clone it in case we need to mutate/store the value later
-            let mut rendered = self.graph.as_mut().unwrap().render(&scope).clone();
+            let mut destination_buffer = self.graph.as_mut().unwrap().render(&scope).clone();
 
-            // online AudioContext allows channel count to be less than no of hardware channels
-            if rendered.number_of_channels() != self.number_of_channels {
-                rendered.mix(self.number_of_channels, ChannelInterpretation::Discrete);
+            // online AudioContext allows channel count to be less than the number
+            // of channels of the backend stream, i.e. number of channels of the
+            // soundcard clamped to MAX_CHANNELS.
+            if destination_buffer.number_of_channels() < self.number_of_channels {
+                destination_buffer.mix(self.number_of_channels, ChannelInterpretation::Discrete);
             }
 
             // copy rendered audio into output slice
             for i in 0..self.number_of_channels {
                 let output = data.iter_mut().skip(i).step_by(self.number_of_channels);
-                let channel = rendered.channel_data(i).iter();
+                let channel = destination_buffer.channel_data(i).iter();
                 for (sample, input) in output.zip(channel) {
                     let value = S::from_sample_(*input);
                     *sample = value;
@@ -279,7 +283,7 @@ impl RenderThread {
                 // this is the last chunk, and it contained less than RENDER_QUANTUM_SIZE samples
                 let channel_offset = data.len() / self.number_of_channels;
                 debug_assert!(channel_offset < RENDER_QUANTUM_SIZE);
-                self.buffer_offset = Some((channel_offset, rendered));
+                self.buffer_offset = Some((channel_offset, destination_buffer));
             }
 
             // handle addition/removal of nodes/edges


### PR DESCRIPTION
Fixes #320 and https://github.com/ircam-ismm/node-web-audio-api/issues/23

Actually the issue was that the buffer returned by the destination node is filled with silence up to the backend number of channel by the render thread using `AudioRenderQuantum::mix`, cf. https://github.com/orottier/web-audio-api-rs/blob/ec5f9efecf696683f69c4c05fcd4e6737ac75126/src/render/thread.rs#L264-L266

But the backend streams were actually not clamped to `MAX_CHANNELS` therefore the `assert_valid_number_of_channels` in `AudioRenderQuantum::mix` was failing.

Also `destination.maxNumberOfChannels` now returns 32 even if the soundcard has actually more output channels (behaviour checked on Chrome and Firefox)

Note that I've added a Max patch in the examples folder to help checking the multichannel output with a virtual soundcard. Even if we agree to keep this kind of stuff, I'm not sure this is nice as Max is a paid software, would be better with a free solution (e.g. PureData)