### PR TITLE
Prevent render thread panic when the graph is not fully initialized yet

### DIFF
--- a/src/render/graph.rs
+++ b/src/render/graph.rs
@@ -104,6 +104,12 @@ impl Graph {
         }
     }
 
+    /// Check if the graph is fully initialized and can start rendering
+    pub fn is_active(&self) -> bool {
+        // currently we only require the destination node to be present
+        !self.nodes.is_empty()
+    }
+
     pub fn add_node(
         &mut self,
         index: AudioNodeId,

--- a/src/render/thread.rs
+++ b/src/render/thread.rs
@@ -235,7 +235,7 @@ impl RenderThread {
         self.handle_control_messages();
 
         // if the thread is still booting, or shutting down, fill with silence
-        if self.graph.is_none() {
+        if !self.graph.as_ref().is_some_and(Graph::is_active) {
             output_buffer.fill(S::from_sample_(0.));
             return;
         }


### PR DESCRIPTION
When the rendering has already commenced but the control thread has not set up the destination node, a panic occurs:

```
thread '<unnamed>' panicked at 'called `Option::unwrap()` on a `None` value', src/render/graph.rs:479:14
```

We now wait with rendering before the node count is at least 1


I managed to reproduce the panic by inserting a `sleep` in the AudioContext constructor. These changes mitigate the panic. I'm afraid I can't really build a regression test for this.