### PR TITLE
Dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,10 @@ hrtf = "0.8"
 llq = "0.1.1"
 log = "0.4"
 num-complex = "0.4"
-realfft = "3.0"
+realfft = "3.3"
 rubato = "0.14"
 rustc-hash = "1.1"
-smallvec = "1.8"
+smallvec = "1.11"
 symphonia = { version = "0.5", default-features = false }
 vecmath = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ rust-version = "1.70"
 [dependencies]
 arc-swap = "1.6"
 arrayvec = "0.7"
-cpal = { version = "0.15.0", optional = true }
+cpal = { version = "0.15", optional = true }
 creek = "1.1"
 crossbeam-channel = "0.5"
-cubeb = { version = "0.10.0", optional = true }
+cubeb = { version = "0.10", optional = true }
 dasp_sample = "0.11"
 float_eq = "1.0"
 hound = "3.5"


### PR DESCRIPTION
- Specifying .0 patch versions is pointless
- Update dependencies to the latest minor version. Not essential, only to keep track.

I am actually an advocate of [PSA](https://users.rust-lang.org/t/psa-please-specify-precise-dependency-versions-in-cargo-toml/71277).