### PR TITLE
Update bench bot behavior

### DIFF
--- a/.github/workflows/benchmark-post-result.yaml
+++ b/.github/workflows/benchmark-post-result.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow
 
-name: Post benchmark results
+name: benchmark post results
 
 # read-write repo token
 # access to secrets
@@ -9,42 +9,37 @@ name: Post benchmark results
 # see https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
 on:
   workflow_run:
-    branches-ignore:
-      - "main"
-    workflows: ["Build"]
+    workflows: ["benchmark"]
     types:
       - completed
 
 jobs:
   upload:
     runs-on: ubuntu-latest
-    if: >
-      ${{ github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: "Download artifact"
-        uses: actions/github-script@v3.1.0
+        uses: actions/github-script@v6
         with:
           script: |
-            const artifacts = await github.actions.listWorkflowRunArtifacts({
+            const fs = require('fs');
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
                run_id: ${{github.event.workflow_run.id }},
             });
-            const matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+            const matchArtifact = artifacts.data.artifacts.find((artifact) => {
               return artifact.name == "pr"
-            })[0];
-            const download = await github.actions.downloadArtifact({
+            });
+            const download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
                artifact_id: matchArtifact.id,
                archive_format: 'zip',
             });
-            const fs = require('fs');
             fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
       - run: unzip pr.zip
       - name: "Write result in PR"
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -54,7 +49,7 @@ jobs:
 
             const message = '```\nBenchmark result:\n\n' + iai_feature + '\n```\n';
 
-            await github.issues.createComment({
+            await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issue_number,

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -20,11 +20,18 @@ jobs:
     if: ${{ github.event.issue.pull_request }} && contains(github.event.comment.body, '/bench')
 
     steps:
-      # checkout repo, install dependencies
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      # the workflow is triggered from main branch
+      # cf. https://github.com/actions/checkout/issues/331
+      # need this first step to init the git repo
+      - name: Checkout
+        uses: actions/checkout@v3
 
+      - name: Checkout Pull Request
+        run: hub pr checkout ${{ github.event.issue.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # install dependencies
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow
 
-name: Build
+name: benchmark
 
 # read-only repo token, no access to secrets
 permissions:
@@ -8,51 +8,16 @@ permissions:
 
 # no access to secrets
 on:
-  push:
-    branches: [main]
-  pull_request:
+  issue_comment:
+    types: [created, edited]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  verify-build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Install ALSA and Jack dependencies
-        run: |
-          sudo apt-get update && sudo apt-get install -y libasound2-dev libjack-jackd2-dev cmake
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt
-
-      - name: Check out repository
-        uses: actions/checkout@v3
-
-      - name: Generate Cargo.lock
-        run: cargo generate-lockfile
-
-      # restore cargo cache from previous runs
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          # Distinguished by the action name to avoid sharing!
-          shared-key: "rust"
-
-      # check it builds
-      - name: Build
-        run: cargo build --verbose --all-targets --all-features
-
-      # run tests
-      - name: Run tests
-        run: cargo test --verbose --all-features
-
   benchmark:
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main'
+    if: ${{ github.event.issue.pull_request }} && contains(github.event.comment.body, '/bench')
 
     steps:
       # checkout repo, install dependencies
@@ -83,12 +48,16 @@ jobs:
       - name: Run bench against baseline
         run: cargo bench --no-default-features | sed '0,/^test result:/d' | tee bench.txt
 
+      # for testing
+      # - name: create mock results
+      #   run: echo "my bench results" > bench.txt
+
       ## Save results
       ## see https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
       - name: Save PR number and bench results
         run: |
           mkdir -p ./pr
-          echo ${{ github.event.number }} > ./pr/pr_number.txt
+          echo ${{ github.event.issue.number }} > ./pr/pr_number.txt
           mv bench.txt ./pr/bench.txt
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,51 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow
+
+name: build
+
+# read-only repo token, no access to secrets
+permissions:
+  contents: read
+
+# no access to secrets
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  verify-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install ALSA and Jack dependencies
+        run: |
+          sudo apt-get update && sudo apt-get install -y libasound2-dev libjack-jackd2-dev cmake
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
+
+      # restore cargo cache from previous runs
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          # Distinguished by the action name to avoid sharing!
+          shared-key: "rust"
+
+      # check it builds
+      - name: Build
+        run: cargo build --verbose --all-targets --all-features
+
+      # run tests
+      - name: Run tests
+        run: cargo test --verbose --all-features


### PR DESCRIPTION
Fix #335

- split `rust` workflow into `build` and `benchmark`
- `benchmark` workflow now runs only if "/bench" is put into a comment

Hope this works... not sure in which branch the workflow actually runs...