### PR TITLE
Fix bench workflow

### DIFF
--- a/.github/workflows/benchmark-post-result.yaml
+++ b/.github/workflows/benchmark-post-result.yaml
@@ -16,6 +16,8 @@ on:
 jobs:
   upload:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
     steps:
       - name: "Download artifact"
         uses: actions/github-script@v6

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -17,7 +17,7 @@ env:
 jobs:
   benchmark:
     runs-on: ubuntu-latest
-    if: ${{ github.event.issue.pull_request }} && contains(github.event.comment.body, '/bench')
+    if: contains(github.event.comment.body, '/bench')
 
     steps:
       # the workflow is triggered from main branch


### PR DESCRIPTION
ok that was not working properly... benches were triggered on every comment (so basically worse than the previous situation...)

So now
- benchmark workflow should only run if comment is "/bench"
- "post benchmark" is skipped if "benchmark" is not a success

Hopefully should be good now (these things are a real pain to test...)