### PR TITLE
Remove redundant 'static lifetime bounds

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -30,7 +30,7 @@ pub struct ErrorEvent {
     /// The error message
     pub message: String,
     /// The object with which panic was originally invoked.
-    pub error: Box<dyn Any + Send + 'static>,
+    pub error: Box<dyn Any + Send>,
     /// Inherits from this base Event
     pub event: Event,
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -49,6 +49,6 @@ pub(crate) enum ControlMessage {
     /// Generic message to be handled by AudioProcessor
     NodeMessage {
         id: AudioNodeId,
-        msg: llq::Node<Box<dyn Any + Send + 'static>>,
+        msg: llq::Node<Box<dyn Any + Send>>,
     },
 }

--- a/src/render/processor.rs
+++ b/src/render/processor.rs
@@ -35,7 +35,7 @@ impl RenderScope {
         }
     }
 
-    pub(crate) fn report_error(&self, error: Box<dyn Any + Send + 'static>) {
+    pub(crate) fn report_error(&self, error: Box<dyn Any + Send>) {
         pub fn type_name_of_val<T: ?Sized>(_val: &T) -> &'static str {
             std::any::type_name::<T>()
         }

--- a/src/render/thread.rs
+++ b/src/render/thread.rs
@@ -32,7 +32,7 @@ pub(crate) struct RenderThread {
     buffer_offset: Option<(usize, AudioRenderQuantum)>,
     load_value_sender: Option<Sender<AudioRenderCapacityLoad>>,
     event_sender: Option<Sender<EventDispatch>>,
-    garbage_collector: llq::Producer<Box<dyn Any + Send + 'static>>,
+    garbage_collector: llq::Producer<Box<dyn Any + Send>>,
 }
 
 // SAFETY:
@@ -315,11 +315,11 @@ const GARBAGE_COLLECTOR_THREAD_TIMEOUT: Duration = Duration::from_millis(100);
 struct TerminateGarbageCollectorThread;
 
 // Spawns a sidecar thread of the `RenderThread` for dropping resources.
-fn spawn_garbage_collector_thread(consumer: llq::Consumer<Box<dyn Any + Send + 'static>>) {
+fn spawn_garbage_collector_thread(consumer: llq::Consumer<Box<dyn Any + Send>>) {
     let _join_handle = std::thread::spawn(move || run_garbage_collector_thread(consumer));
 }
 
-fn run_garbage_collector_thread(mut consumer: llq::Consumer<Box<dyn Any + Send + 'static>>) {
+fn run_garbage_collector_thread(mut consumer: llq::Consumer<Box<dyn Any + Send>>) {
     log::info!("Entering garbage collector thread");
     loop {
         if let Some(node) = consumer.pop() {


### PR DESCRIPTION
`Any` already implies `'static'`.