### PR TITLE
Audio nodes: don't use atomics for interior mutability

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ let file = std::fs::File::open("samples/major-scale.ogg").unwrap();
 let buffer = context.decode_audio_data_sync(file).unwrap();
 
 // setup an AudioBufferSourceNode
-let src = context.create_buffer_source();
+let mut src = context.create_buffer_source();
 src.set_buffer(buffer);
 src.set_loop(true);
 

--- a/benches/my_benchmark.rs
+++ b/benches/my_benchmark.rs
@@ -16,7 +16,7 @@ pub fn bench_ctor() {
 
 pub fn bench_sine() {
     let ctx = OfflineAudioContext::new(2, black_box(SAMPLES), SAMPLE_RATE);
-    let osc = ctx.create_oscillator();
+    let mut osc = ctx.create_oscillator();
 
     osc.connect(&ctx.destination());
     osc.start();
@@ -26,7 +26,7 @@ pub fn bench_sine() {
 
 pub fn bench_sine_gain() {
     let ctx = OfflineAudioContext::new(2, black_box(SAMPLES), SAMPLE_RATE);
-    let osc = ctx.create_oscillator();
+    let mut osc = ctx.create_oscillator();
     let gain = ctx.create_gain();
 
     osc.connect(&gain);
@@ -40,7 +40,7 @@ pub fn bench_sine_gain() {
 pub fn bench_sine_gain_delay() {
     let ctx = OfflineAudioContext::new(2, black_box(SAMPLES), SAMPLE_RATE);
 
-    let osc = ctx.create_oscillator();
+    let mut osc = ctx.create_oscillator();
     let gain = ctx.create_gain();
 
     let delay = ctx.create_delay(0.3);
@@ -61,7 +61,7 @@ pub fn bench_buffer_src() {
     let file = std::fs::File::open("samples/think-stereo-48000.wav").unwrap();
     let buffer = ctx.decode_audio_data_sync(file).unwrap();
 
-    let src = ctx.create_buffer_source();
+    let mut src = ctx.create_buffer_source();
     src.connect(&ctx.destination());
     src.set_buffer(buffer);
     src.start();
@@ -78,7 +78,7 @@ pub fn bench_buffer_src_delay() {
     let delay = ctx.create_delay(0.3);
     delay.delay_time().set_value(0.2);
 
-    let src = ctx.create_buffer_source();
+    let mut src = ctx.create_buffer_source();
     src.set_buffer(buffer);
     src.start();
 
@@ -107,7 +107,7 @@ pub fn bench_buffer_src_iir() {
     iir.connect(&ctx.destination());
 
     // Play buffer and pipe to filter
-    let src = ctx.create_buffer_source();
+    let mut src = ctx.create_buffer_source();
     src.connect(&iir);
     src.set_buffer(buffer);
     src.start();
@@ -126,7 +126,7 @@ pub fn bench_buffer_src_biquad() {
     biquad.frequency().set_value(200.);
 
     // Play buffer and pipe to filter
-    let src = ctx.create_buffer_source();
+    let mut src = ctx.create_buffer_source();
     src.connect(&biquad);
     src.set_buffer(buffer);
     src.start();
@@ -150,7 +150,7 @@ pub fn bench_stereo_positional() {
     panner.orientation_z().set_value(3.);
 
     // Play buffer and pipe to filter
-    let src = ctx.create_buffer_source();
+    let mut src = ctx.create_buffer_source();
     src.connect(&panner);
     src.set_buffer(buffer);
     src.start();
@@ -168,7 +168,7 @@ pub fn bench_stereo_panning_automation() {
     panner.pan().set_value_at_time(-1., 0.);
     panner.pan().set_value_at_time(0.2, 0.5);
 
-    let src = ctx.create_buffer_source();
+    let mut src = ctx.create_buffer_source();
     src.connect(&panner);
     src.set_buffer(buffer);
     src.set_loop(true);
@@ -188,7 +188,7 @@ pub fn bench_analyser_node() {
     let analyser = ctx.create_analyser();
     analyser.connect(&ctx.destination());
 
-    let src = ctx.create_buffer_source();
+    let mut src = ctx.create_buffer_source();
     src.connect(&analyser);
     src.set_buffer(buffer);
     src.set_loop(true);

--- a/examples/amplitude_modulation.rs
+++ b/examples/amplitude_modulation.rs
@@ -29,7 +29,7 @@ fn main() {
     modulated.gain().set_value(0.5);
     modulated.connect(&context.destination());
 
-    let carrier = context.create_oscillator();
+    let mut carrier = context.create_oscillator();
     carrier.connect(&modulated);
     carrier.frequency().set_value(300.);
 
@@ -38,7 +38,7 @@ fn main() {
     depth.gain().set_value(0.5);
     depth.connect(modulated.gain());
 
-    let modulator = context.create_oscillator();
+    let mut modulator = context.create_oscillator();
     modulator.connect(&depth);
     modulator.frequency().set_value(1.);
 

--- a/examples/analyser.rs
+++ b/examples/analyser.rs
@@ -28,7 +28,7 @@ fn main() {
     let mut analyser = context.create_analyser();
     analyser.connect(&context.destination());
 
-    let osc = context.create_oscillator();
+    let mut osc = context.create_oscillator();
     osc.frequency().set_value(200.);
     osc.connect(&analyser);
     osc.start();

--- a/examples/analyser.rs
+++ b/examples/analyser.rs
@@ -25,7 +25,7 @@ fn main() {
         ..AudioContextOptions::default()
     });
 
-    let analyser = context.create_analyser();
+    let mut analyser = context.create_analyser();
     analyser.connect(&context.destination());
 
     let osc = context.create_oscillator();

--- a/examples/audio_buffer.rs
+++ b/examples/audio_buffer.rs
@@ -43,7 +43,7 @@ fn main() {
     buffer.copy_to_channel(&sine, 0);
 
     // play the buffer in a loop
-    let src = context.create_buffer_source();
+    let mut src = context.create_buffer_source();
     src.set_buffer(buffer.clone());
     src.set_loop(true);
     src.connect(&context.destination());
@@ -55,7 +55,7 @@ fn main() {
     // play a sine at 200Hz
     println!("> Play sine at 200Hz from an OscillatorNode");
 
-    let osc = context.create_oscillator();
+    let mut osc = context.create_oscillator();
     osc.frequency().set_value(200.);
     osc.connect(&context.destination());
     osc.start_at(context.current_time());

--- a/examples/audio_buffer_source_events.rs
+++ b/examples/audio_buffer_source_events.rs
@@ -30,7 +30,7 @@ fn main() {
     let file = File::open("samples/sample.wav").unwrap();
     let buffer = context.decode_audio_data_sync(file).unwrap();
 
-    let src = context.create_buffer_source();
+    let mut src = context.create_buffer_source();
     src.connect(&context.destination());
     src.set_buffer(buffer);
 

--- a/examples/audio_buffer_source_pitching.rs
+++ b/examples/audio_buffer_source_pitching.rs
@@ -43,7 +43,7 @@ fn main() {
     buffer.copy_to_channel(&sine, 0);
 
     // play the buffer in a loop
-    let src = context.create_buffer_source();
+    let mut src = context.create_buffer_source();
     src.set_buffer(buffer.clone());
     src.connect(&context.destination());
     src.start();
@@ -52,7 +52,7 @@ fn main() {
 
     println!("> Play sine at 440Hz w/ playback rate at 0.5");
 
-    let src = context.create_buffer_source();
+    let mut src = context.create_buffer_source();
     src.set_buffer(buffer.clone());
     src.playback_rate().set_value(0.5);
     src.connect(&context.destination());
@@ -62,7 +62,7 @@ fn main() {
 
     println!("> Play sine at 440Hz w/ detune at -1200.");
 
-    let src = context.create_buffer_source();
+    let mut src = context.create_buffer_source();
     src.set_buffer(buffer.clone());
     src.detune().set_value(-1200.);
     src.connect(&context.destination());

--- a/examples/benchmarks.rs
+++ b/examples/benchmarks.rs
@@ -335,7 +335,7 @@ fn main() {
                 *b = (rng.gen_range(0.0..2.) - 1.) * (1. - i as f32 / len).powf(decay)
             });
 
-        let convolver = context.create_convolver();
+        let mut convolver = context.create_convolver();
         convolver.set_buffer(buffer);
         convolver.connect(&context.destination());
 

--- a/examples/benchmarks.rs
+++ b/examples/benchmarks.rs
@@ -400,7 +400,7 @@ fn main() {
             let env = context.create_gain();
             env.connect(&context.destination());
 
-            let osc = context.create_oscillator();
+            let mut osc = context.create_oscillator();
             osc.connect(&env);
             osc.set_type(OscillatorType::Sawtooth);
             osc.frequency().set_value(110.);
@@ -430,7 +430,7 @@ fn main() {
             let env = context.create_gain();
             env.connect(&context.destination());
 
-            let osc = context.create_oscillator();
+            let mut osc = context.create_oscillator();
             osc.connect(&env);
             osc.set_type(OscillatorType::Sawtooth);
             osc.frequency().set_value(110.);
@@ -453,7 +453,7 @@ fn main() {
         let duration = DURATION as f64;
 
         while offset < duration {
-            let osc = context.create_oscillator();
+            let mut osc = context.create_oscillator();
             osc.connect(&context.destination());
             osc.set_type(OscillatorType::Sawtooth);
             osc.frequency().set_value(110.);
@@ -482,7 +482,7 @@ fn main() {
         env.connect(&filter);
         env.gain().set_value_at_time(0., 0.);
 
-        let osc = context.create_oscillator();
+        let mut osc = context.create_oscillator();
         osc.connect(&env);
         osc.set_type(OscillatorType::Sawtooth);
         osc.frequency().set_value(110.);
@@ -547,7 +547,7 @@ fn main() {
 
         let context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
 
-        let osc = context.create_oscillator();
+        let mut osc = context.create_oscillator();
         osc.connect(&context.destination());
         osc.set_type(OscillatorType::Sawtooth);
         osc.frequency().set_value(2000.);

--- a/examples/benchmarks.rs
+++ b/examples/benchmarks.rs
@@ -95,7 +95,7 @@ fn main() {
         let name = "Simple source test without resampling (Mono)";
 
         let context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
-        let source = context.create_buffer_source();
+        let mut source = context.create_buffer_source();
         let buf = get_buffer(&sources, sample_rate, 1);
         source.set_buffer(buf);
         source.set_loop(true);
@@ -109,7 +109,7 @@ fn main() {
         let name = "Simple source test without resampling (Stereo)";
 
         let context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
-        let source = context.create_buffer_source();
+        let mut source = context.create_buffer_source();
         let buf = get_buffer(&sources, sample_rate, 2);
         source.set_buffer(buf);
         source.set_loop(true);
@@ -133,7 +133,7 @@ fn main() {
         panner.orientation_y().set_value(2.);
         panner.orientation_z().set_value(3.);
 
-        let source = context.create_buffer_source();
+        let mut source = context.create_buffer_source();
         source.connect(&panner);
 
         let buf = get_buffer(&sources, sample_rate, 2);
@@ -148,7 +148,7 @@ fn main() {
         let name = "Simple source test with resampling (Mono)";
 
         let context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
-        let source = context.create_buffer_source();
+        let mut source = context.create_buffer_source();
         let buf = get_buffer(&sources, 38000., 1);
         source.set_buffer(buf);
         source.set_loop(true);
@@ -162,7 +162,7 @@ fn main() {
         let name = "Simple source test with resampling (Stereo)";
 
         let context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
-        let source = context.create_buffer_source();
+        let mut source = context.create_buffer_source();
         let buf = get_buffer(&sources, 38000., 2);
         source.set_buffer(buf);
         source.set_loop(true);
@@ -186,7 +186,7 @@ fn main() {
         panner.orientation_y().set_value(2.);
         panner.orientation_z().set_value(3.);
 
-        let source = context.create_buffer_source();
+        let mut source = context.create_buffer_source();
         source.connect(&panner);
 
         let buf = get_buffer(&sources, 38000., 2);
@@ -201,7 +201,7 @@ fn main() {
         let name = "Upmix without resampling (Mono -> Stereo)";
 
         let context = OfflineAudioContext::new(2, DURATION * sample_rate as usize, sample_rate);
-        let source = context.create_buffer_source();
+        let mut source = context.create_buffer_source();
         let buf = get_buffer(&sources, sample_rate, 1);
         source.set_buffer(buf);
         source.set_loop(true);
@@ -215,7 +215,7 @@ fn main() {
         let name = "Downmix without resampling (Stereo -> Mono)";
 
         let context = OfflineAudioContext::new(1, DURATION * sample_rate as usize, sample_rate);
-        let source = context.create_buffer_source();
+        let mut source = context.create_buffer_source();
         let buf = get_buffer(&sources, sample_rate, 2);
         source.set_buffer(buf);
         source.set_loop(true);
@@ -233,7 +233,7 @@ fn main() {
             OfflineAudioContext::new(2, adjusted_duration * sample_rate as usize, sample_rate);
 
         for _ in 0..100 {
-            let source = context.create_buffer_source();
+            let mut source = context.create_buffer_source();
             let buf = get_buffer(&sources, 38000., 1);
             source.set_buffer(buf);
             source.set_loop(true);
@@ -257,7 +257,7 @@ fn main() {
             let mut buffer = context.create_buffer(1, reference.length(), 38000.);
             buffer.copy_to_channel(channel_data, 0);
 
-            let source = context.create_buffer_source();
+            let mut source = context.create_buffer_source();
             source.set_buffer(buffer);
             source.set_loop(true);
             source.connect(&context.destination());
@@ -288,7 +288,7 @@ fn main() {
         for _ in 0..2 {
             let buf = get_buffer(&sources, 38000., 1);
 
-            let source = context.create_buffer_source();
+            let mut source = context.create_buffer_source();
             source.set_buffer(buf);
             source.set_loop(true);
             source.start();
@@ -339,7 +339,7 @@ fn main() {
         convolver.set_buffer(buffer);
         convolver.connect(&context.destination());
 
-        let source = context.create_buffer_source();
+        let mut source = context.create_buffer_source();
         source.set_buffer(buf);
         source.set_loop(true);
         source.start();
@@ -363,7 +363,7 @@ fn main() {
             let env = context.create_gain();
             env.connect(&context.destination());
 
-            let src = context.create_buffer_source();
+            let mut src = context.create_buffer_source();
             src.connect(&env);
             src.set_buffer(buffer.clone());
 
@@ -512,7 +512,7 @@ fn main() {
         panner.connect(&context.destination());
         panner.pan().set_value(0.1);
 
-        let src = context.create_buffer_source();
+        let mut src = context.create_buffer_source();
         let buffer = get_buffer(&sources, sample_rate, 2);
         src.connect(&panner);
         src.set_buffer(buffer);
@@ -532,7 +532,7 @@ fn main() {
         panner.pan().set_value_at_time(-1., 0.);
         panner.pan().set_value_at_time(0.2, 0.5);
 
-        let src = context.create_buffer_source();
+        let mut src = context.create_buffer_source();
         let buffer = get_buffer(&sources, sample_rate, 2);
         src.connect(&panner);
         src.set_buffer(buffer);
@@ -567,7 +567,7 @@ fn main() {
         delay.delay_time().set_value(1.);
         delay.connect(&context.destination());
 
-        let source = context.create_buffer_source();
+        let mut source = context.create_buffer_source();
         let buf = get_buffer(&sources, sample_rate, 2);
         source.set_buffer(buf);
         source.set_loop(true);
@@ -595,7 +595,7 @@ fn main() {
         let iir = context.create_iir_filter(feedforward, feedback);
         iir.connect(&context.destination());
 
-        let src = context.create_buffer_source();
+        let mut src = context.create_buffer_source();
         let buffer = get_buffer(&sources, sample_rate, 2);
         src.connect(&iir);
         src.set_buffer(buffer);
@@ -615,7 +615,7 @@ fn main() {
         biquad.connect(&context.destination());
         biquad.frequency().set_value(200.);
 
-        let src = context.create_buffer_source();
+        let mut src = context.create_buffer_source();
         let buffer = get_buffer(&sources, sample_rate, 2);
         src.connect(&biquad);
         src.set_buffer(buffer);
@@ -677,12 +677,12 @@ fn main() {
         let result = &results[id];
         let name = result.name;
 
-        if let Some(cur) = current_source.take() {
+        if let Some(mut cur) = current_source.take() {
             cur.stop();
         }
 
         let buffer = result.buffer.clone();
-        let source = context.create_buffer_source();
+        let mut source = context.create_buffer_source();
         source.set_buffer(buffer);
         source.connect(&context.destination());
         source.start();

--- a/examples/biquad.rs
+++ b/examples/biquad.rs
@@ -42,7 +42,7 @@ fn main() {
         .exponential_ramp_to_value_at_time(10000., now + 10.);
 
     // pipe the audio buffer source into the lowpass filter
-    let src = context.create_buffer_source();
+    let mut src = context.create_buffer_source();
     src.connect(&biquad);
     src.set_buffer(buffer);
     src.set_loop(true);

--- a/examples/compressor.rs
+++ b/examples/compressor.rs
@@ -30,7 +30,7 @@ fn main() {
     let buffer = context.decode_audio_data_sync(file).unwrap();
 
     println!("> no compression");
-    let src = context.create_buffer_source();
+    let mut src = context.create_buffer_source();
     src.connect(&context.destination());
     src.set_buffer(buffer.clone());
     src.start();
@@ -53,7 +53,7 @@ fn main() {
         compressor.attack().set_value(0.03);
         compressor.release().set_value(0.1);
 
-        let src = context.create_buffer_source();
+        let mut src = context.create_buffer_source();
         src.connect(&compressor);
         src.set_buffer(buffer.clone());
         src.start();

--- a/examples/constant_source.rs
+++ b/examples/constant_source.rs
@@ -35,7 +35,7 @@ fn main() {
     gain_left.gain().set_value(0.);
     gain_left.connect_at(&merger, 0, 0);
 
-    let src_left = context.create_oscillator();
+    let mut src_left = context.create_oscillator();
     src_left.frequency().set_value(200.);
     src_left.connect(&gain_left);
     src_left.start();
@@ -45,13 +45,13 @@ fn main() {
     gain_right.gain().set_value(0.);
     gain_right.connect_at(&merger, 0, 1);
 
-    let src_right = context.create_oscillator();
+    let mut src_right = context.create_oscillator();
     src_right.frequency().set_value(300.);
     src_right.connect(&gain_right);
     src_right.start();
 
     // control both left and right gains with constant source
-    let constant_source = context.create_constant_source();
+    let mut constant_source = context.create_constant_source();
     constant_source.offset().set_value(0.);
     constant_source.connect(gain_left.gain());
     constant_source.connect(gain_right.gain());

--- a/examples/convolution.rs
+++ b/examples/convolution.rs
@@ -47,7 +47,7 @@ fn main() {
     let mut src = context.create_buffer_source();
     src.set_buffer(audio_buffer);
 
-    let convolver = ConvolverNode::new(&context, ConvolverOptions::default());
+    let mut convolver = ConvolverNode::new(&context, ConvolverOptions::default());
 
     src.connect(&convolver);
     convolver.connect(&context.destination());

--- a/examples/convolution.rs
+++ b/examples/convolution.rs
@@ -44,7 +44,7 @@ fn main() {
     let impulse_file2 = File::open("samples/parking-garage-response.wav").unwrap();
     let impulse_buffer2 = context.decode_audio_data_sync(impulse_file2).unwrap();
 
-    let src = context.create_buffer_source();
+    let mut src = context.create_buffer_source();
     src.set_buffer(audio_buffer);
 
     let convolver = ConvolverNode::new(&context, ConvolverOptions::default());

--- a/examples/decoding.rs
+++ b/examples/decoding.rs
@@ -63,7 +63,7 @@ fn main() {
                 println!("> sample rate: {:?}", buffer.sample_rate());
                 println!("> --------------------------------");
 
-                let src = context.create_buffer_source();
+                let mut src = context.create_buffer_source();
                 src.connect(&context.destination());
                 src.set_buffer(buffer);
                 src.start();

--- a/examples/doppler.rs
+++ b/examples/doppler.rs
@@ -41,7 +41,7 @@ fn main() {
     let file = File::open("samples/siren.mp3").unwrap();
     let buffer = context.decode_audio_data_sync(file).unwrap();
 
-    let src = context.create_buffer_source();
+    let mut src = context.create_buffer_source();
     src.set_buffer(buffer);
     src.set_loop(true);
 

--- a/examples/feedback_delay.rs
+++ b/examples/feedback_delay.rs
@@ -28,7 +28,7 @@ fn trigger_sine(context: &AudioContext, delay_input: &dyn AudioNode, rng: &mut T
     env.gain()
         .exponential_ramp_to_value_at_time(0.0001, now + 1.);
 
-    let osc = context.create_oscillator();
+    let mut osc = context.create_oscillator();
     osc.connect(&env);
     osc.frequency().set_value(base_freq * num_partial);
     osc.start_at(now);

--- a/examples/granular.rs
+++ b/examples/granular.rs
@@ -113,7 +113,7 @@ impl ScrubEngine {
         env.gain().set_value(0.);
         env.connect(&audio_context.destination());
 
-        let src = audio_context.create_buffer_source();
+        let mut src = audio_context.create_buffer_source();
         src.set_buffer(self.audio_buffer.clone());
         src.connect(&env);
 

--- a/examples/iir.rs
+++ b/examples/iir.rs
@@ -43,7 +43,7 @@ fn main() {
     iir.connect(&context.destination());
 
     // Play buffer and pipe to filter
-    let src = context.create_buffer_source();
+    let mut src = context.create_buffer_source();
     src.connect(&iir);
     src.set_buffer(buffer);
     src.set_loop(true);

--- a/examples/latency_attributes.rs
+++ b/examples/latency_attributes.rs
@@ -25,7 +25,7 @@ fn main() {
         ..AudioContextOptions::default()
     });
 
-    let sine = context.create_oscillator();
+    let mut sine = context.create_oscillator();
     sine.frequency().set_value(200.);
     sine.connect(&context.destination());
 

--- a/examples/many_oscillators.rs
+++ b/examples/many_oscillators.rs
@@ -14,7 +14,7 @@ use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 //
 // `WEB_AUDIO_LATENCY=playback cargo run --release --example many_oscillators`
 fn trigger_sine(context: &AudioContext) {
-    let osc = context.create_oscillator();
+    let mut osc = context.create_oscillator();
     osc.connect(&context.destination());
 
     let now = context.current_time();

--- a/examples/many_oscillators_with_env.rs
+++ b/examples/many_oscillators_with_env.rs
@@ -19,7 +19,7 @@ fn trigger_sine(audio_context: &AudioContext, rng: &mut ThreadRng) {
     env.gain().set_value(0.);
     env.connect(&audio_context.destination());
 
-    let osc = audio_context.create_oscillator();
+    let mut osc = audio_context.create_oscillator();
     osc.connect(&env);
 
     let now = audio_context.current_time();

--- a/examples/merger.rs
+++ b/examples/merger.rs
@@ -35,10 +35,10 @@ fn main() {
     context.destination().set_channel_count(2);
 
     // Create an oscillator
-    let left = context.create_oscillator();
+    let mut left = context.create_oscillator();
 
     //Create an oscillator
-    let right = context.create_oscillator();
+    let mut right = context.create_oscillator();
     // set a different frequency to distinguish left from right osc
     right.frequency().set_value(1000.);
 

--- a/examples/mono.rs
+++ b/examples/mono.rs
@@ -27,7 +27,7 @@ fn main() {
     });
 
     // Create an oscillator node with sine (default) type
-    let osc = context.create_oscillator();
+    let mut osc = context.create_oscillator();
 
     // Connect osc to the destination node which is the default output device
     osc.connect(&context.destination());

--- a/examples/multichannel.rs
+++ b/examples/multichannel.rs
@@ -56,7 +56,7 @@ fn main() {
 
         let now = context.current_time();
 
-        let osc = context.create_oscillator();
+        let mut osc = context.create_oscillator();
         osc.connect_at(&merger, 0, output_channel);
         osc.frequency().set_value(200.);
         osc.start_at(now);

--- a/examples/oscillators.rs
+++ b/examples/oscillators.rs
@@ -28,7 +28,7 @@ fn main() {
     });
 
     // Create an oscillator node with sine (default) type
-    let osc = context.create_oscillator();
+    let mut osc = context.create_oscillator();
 
     // Connect osc to the destination node which is the default output device
     osc.connect(&context.destination());

--- a/examples/panner_cone.rs
+++ b/examples/panner_cone.rs
@@ -32,7 +32,7 @@ fn main() {
     tone.start();
 
     // Connect tone > panner node > destination node
-    let panner = context.create_panner();
+    let mut panner = context.create_panner();
     tone.connect(&panner);
     panner.connect(&context.destination());
 

--- a/examples/panner_cone.rs
+++ b/examples/panner_cone.rs
@@ -27,7 +27,7 @@ fn main() {
     });
 
     // Create a friendly tone
-    let tone = context.create_oscillator();
+    let mut tone = context.create_oscillator();
     tone.frequency().set_value_at_time(300.0f32, 0.);
     tone.start();
 
@@ -42,7 +42,7 @@ fn main() {
     panner.orientation_x().set_value(0.);
 
     // Panner rotates around their axis, every second
-    let moving = context.create_oscillator();
+    let mut moving = context.create_oscillator();
     moving.start();
     moving.frequency().set_value_at_time(1., 0.);
     // Connect to x-orientation

--- a/examples/recorder.rs
+++ b/examples/recorder.rs
@@ -30,7 +30,7 @@ fn main() {
     });
 
     // Create an oscillator node with sine (default) type
-    let osc = context.create_oscillator();
+    let mut osc = context.create_oscillator();
 
     // Connect oscillator to speakers
     osc.connect(&context.destination());

--- a/examples/resampling.rs
+++ b/examples/resampling.rs
@@ -50,7 +50,7 @@ fn main() {
         "+ playing sample-38000.wav - decoded sample rate: {:?}",
         buffer_38000.sample_rate()
     );
-    let src = audio_context.create_buffer_source();
+    let mut src = audio_context.create_buffer_source();
     src.connect(&audio_context.destination());
     src.set_buffer(buffer_38000);
     src.start();
@@ -61,7 +61,7 @@ fn main() {
         "+ playing sample-44100.wav - decoded sample rate: {:?}",
         buffer_44100.sample_rate()
     );
-    let src = audio_context.create_buffer_source();
+    let mut src = audio_context.create_buffer_source();
     src.connect(&audio_context.destination());
     src.set_buffer(buffer_44100);
     src.start();
@@ -72,7 +72,7 @@ fn main() {
         "+ playing sample-48000.wav - decoded sample rate: {:?}",
         buffer_48000.sample_rate()
     );
-    let src = audio_context.create_buffer_source();
+    let mut src = audio_context.create_buffer_source();
     src.connect(&audio_context.destination());
     src.set_buffer(buffer_48000);
     src.start();
@@ -116,7 +116,7 @@ fn main() {
         "+ playing sample-38000.wav - decoded sample rate: {:?}",
         buffer_38000.sample_rate()
     );
-    let src = audio_context.create_buffer_source();
+    let mut src = audio_context.create_buffer_source();
     src.connect(&audio_context.destination());
     src.set_buffer(buffer_38000);
     src.start();
@@ -127,7 +127,7 @@ fn main() {
         "+ playing sample-44100.wav - decoded sample rate: {:?}",
         buffer_44100.sample_rate()
     );
-    let src = audio_context.create_buffer_source();
+    let mut src = audio_context.create_buffer_source();
     src.connect(&audio_context.destination());
     src.set_buffer(buffer_44100);
     src.start();
@@ -138,7 +138,7 @@ fn main() {
         "+ playing sample-48000.wav - decoded sample rate: {:?}",
         buffer_48000.sample_rate()
     );
-    let src = audio_context.create_buffer_source();
+    let mut src = audio_context.create_buffer_source();
     src.connect(&audio_context.destination());
     src.set_buffer(buffer_48000);
     src.start();

--- a/examples/simple_delay.rs
+++ b/examples/simple_delay.rs
@@ -34,7 +34,7 @@ fn main() {
     delay.delay_time().set_value(0.5);
     delay.connect(&context.destination());
 
-    let src = context.create_buffer_source();
+    let mut src = context.create_buffer_source();
     src.set_buffer(audio_buffer);
     // connect to both delay and destination
     src.connect(&delay);

--- a/examples/sink_id.rs
+++ b/examples/sink_id.rs
@@ -56,7 +56,7 @@ fn main() {
     context.set_onsinkchange(|_| println!("sink change event"));
 
     // Create an oscillator node with sine (default) type
-    let osc = context.create_oscillator();
+    let mut osc = context.create_oscillator();
     osc.connect(&context.destination());
     osc.start();
 

--- a/examples/spatial.rs
+++ b/examples/spatial.rs
@@ -47,7 +47,7 @@ fn main() {
         ..PannerOptions::default()
     };
 
-    let panner = PannerNode::new(&context, opts);
+    let mut panner = PannerNode::new(&context, opts);
     tone.connect(&panner);
     panner.connect(&context.destination());
 

--- a/examples/spatial.rs
+++ b/examples/spatial.rs
@@ -36,7 +36,7 @@ fn main() {
     // Create looping 'siren' sound
     let file = std::fs::File::open("samples/siren.mp3").unwrap();
     let buffer = context.decode_audio_data_sync(file).unwrap();
-    let tone = context.create_buffer_source();
+    let mut tone = context.create_buffer_source();
     tone.set_buffer(buffer);
     tone.set_loop(true);
     tone.start();
@@ -57,7 +57,7 @@ fn main() {
     // will be audible (ref distance = 1.)
     //
     // Make x-value a periodic wave
-    let moving = context.create_oscillator();
+    let mut moving = context.create_oscillator();
     moving.frequency().set_value_at_time(0.25, 0.);
     let gain = context.create_gain();
     gain.gain().set_value_at_time(10., 0.);
@@ -66,7 +66,7 @@ fn main() {
     moving.start();
 
     // Make y-value a periodic wave, delayed so it forms a circle with the x-value
-    let moving = context.create_oscillator();
+    let mut moving = context.create_oscillator();
     moving.frequency().set_value_at_time(0.25, 0.);
     let delay = context.create_delay(1.);
     delay

--- a/examples/stereo_panner.rs
+++ b/examples/stereo_panner.rs
@@ -35,7 +35,7 @@ fn main() {
     panner_1.connect(&context.destination());
     panner_1.pan().set_value(pan_1);
     // create an oscillator
-    let osc_1 = context.create_oscillator();
+    let mut osc_1 = context.create_oscillator();
     osc_1.connect(&panner_1);
     osc_1.frequency().set_value(200.);
     osc_1.start();
@@ -47,7 +47,7 @@ fn main() {
     panner_2.connect(&context.destination());
     panner_2.pan().set_value(pan_2);
     // create an oscillator
-    let osc_2 = context.create_oscillator();
+    let mut osc_2 = context.create_oscillator();
     osc_2.connect(&panner_2);
     osc_2.frequency().set_value(300.);
     osc_2.start();

--- a/examples/trigger_soundfile.rs
+++ b/examples/trigger_soundfile.rs
@@ -33,13 +33,13 @@ fn main() {
     // @fixme - if only one node in the graph it is never removed even when returning
     // false, se we put this dummy node in the graph so that other ones are properly
     // removed
-    let src = context.create_buffer_source();
+    let mut src = context.create_buffer_source();
     src.set_buffer(audio_buffer.clone());
     src.connect(&context.destination());
 
     {
         println!("++ play until end");
-        let src = context.create_buffer_source();
+        let mut src = context.create_buffer_source();
         src.set_buffer(audio_buffer.clone());
         src.connect(&context.destination());
         src.start_at(context.current_time());
@@ -49,7 +49,7 @@ fn main() {
 
     {
         println!("++ play / stop 1sec");
-        let src = context.create_buffer_source();
+        let mut src = context.create_buffer_source();
         src.set_buffer(audio_buffer.clone());
         src.connect(&context.destination());
         src.start_at(context.current_time());
@@ -60,7 +60,7 @@ fn main() {
 
     {
         println!("++ play / stop 1sec with offset");
-        let src = context.create_buffer_source();
+        let mut src = context.create_buffer_source();
         src.set_buffer(audio_buffer.clone());
         src.connect(&context.destination());
         src.start_at_with_offset(context.current_time(), 1.);
@@ -71,7 +71,7 @@ fn main() {
 
     {
         println!("++ play 1sec with offset and duration");
-        let src = context.create_buffer_source();
+        let mut src = context.create_buffer_source();
         src.set_buffer(audio_buffer.clone());
         src.connect(&context.destination());
         src.start_at_with_offset_and_duration(context.current_time(), 1., 1.);
@@ -81,7 +81,7 @@ fn main() {
 
     {
         println!("++ play backward from offset 1.");
-        let src = context.create_buffer_source();
+        let mut src = context.create_buffer_source();
         src.set_buffer(audio_buffer.clone());
         src.connect(&context.destination());
         src.playback_rate().set_value(-1.);
@@ -92,7 +92,7 @@ fn main() {
 
     {
         println!("++ play backward full buffer");
-        let src = context.create_buffer_source();
+        let mut src = context.create_buffer_source();
         src.set_buffer(audio_buffer.clone());
         src.connect(&context.destination());
         src.playback_rate().set_value(-1.);
@@ -103,7 +103,7 @@ fn main() {
 
     {
         println!("++ simple loop (x2)");
-        let src = context.create_buffer_source();
+        let mut src = context.create_buffer_source();
         src.set_buffer(audio_buffer.clone());
         src.connect(&context.destination());
         src.set_loop(true);
@@ -115,7 +115,7 @@ fn main() {
 
     {
         println!("++ loop between 1 and 2 starting from 0");
-        let src = context.create_buffer_source();
+        let mut src = context.create_buffer_source();
         src.set_buffer(audio_buffer.clone());
         src.connect(&context.destination());
         src.set_loop(true);
@@ -131,7 +131,7 @@ fn main() {
 
     {
         println!("++ loop backward between 1 and 2 starting from end");
-        let src = context.create_buffer_source();
+        let mut src = context.create_buffer_source();
         src.set_buffer(audio_buffer.clone());
         src.connect(&context.destination());
         src.playback_rate().set_value(-1.);
@@ -156,7 +156,7 @@ fn main() {
         env.gain().set_value(gain);
         env.connect(&context.destination());
 
-        let src = context.create_buffer_source();
+        let mut src = context.create_buffer_source();
         src.set_buffer(audio_buffer.clone());
         src.connect(&env);
         src.start_at(context.current_time() + offset);

--- a/examples/waveshaper.rs
+++ b/examples/waveshaper.rs
@@ -70,7 +70,7 @@ fn main() {
         pre_gain.gain().set_value(gain);
         post_gain.gain().set_value(1. / gain);
 
-        let src = context.create_buffer_source();
+        let mut src = context.create_buffer_source();
         src.connect(&pre_gain);
         src.set_buffer(buffer.clone());
         src.start();

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -53,7 +53,7 @@ pub struct AudioBufferOptions {
 /// buffer.copy_to_channel(&sine, 0);
 ///
 /// // play the buffer in a loop
-/// let src = context.create_buffer_source();
+/// let mut src = context.create_buffer_source();
 /// src.set_buffer(buffer.clone());
 /// src.set_loop(true);
 /// src.connect(&context.destination());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,12 +18,12 @@
 //! volume.connect(&context.destination());
 //! volume.gain().set_value(0.5);
 //!
-//! let buffer_source = context.create_buffer_source();
+//! let mut buffer_source = context.create_buffer_source();
 //! buffer_source.connect(&volume);
 //! buffer_source.set_buffer(buffer);
 //!
 //! // create oscillator branch
-//! let osc = context.create_oscillator();
+//! let mut osc = context.create_oscillator();
 //! osc.connect(&context.destination());
 //!
 //! // start the sources

--- a/src/node/analyser.rs
+++ b/src/node/analyser.rs
@@ -57,7 +57,7 @@ impl Default for AnalyserOptions {
 /// let mut analyser = context.create_analyser();
 /// analyser.connect(&context.destination());
 ///
-/// let osc = context.create_oscillator();
+/// let mut osc = context.create_oscillator();
 /// osc.frequency().set_value(200.);
 /// osc.connect(&analyser);
 /// osc.start();

--- a/src/node/analyser.rs
+++ b/src/node/analyser.rs
@@ -1,5 +1,3 @@
-use std::sync::RwLock;
-
 use crate::analysis::{
     Analyser, AnalyserRingBuffer, DEFAULT_FFT_SIZE, DEFAULT_MAX_DECIBELS, DEFAULT_MIN_DECIBELS,
     DEFAULT_SMOOTHING_TIME_CONSTANT,
@@ -56,7 +54,7 @@ impl Default for AnalyserOptions {
 ///
 /// let context = AudioContext::default();
 ///
-/// let analyser = context.create_analyser();
+/// let mut analyser = context.create_analyser();
 /// analyser.connect(&context.destination());
 ///
 /// let osc = context.create_oscillator();
@@ -82,8 +80,7 @@ impl Default for AnalyserOptions {
 pub struct AnalyserNode {
     registration: AudioContextRegistration,
     channel_config: ChannelConfig,
-    // RwLock is needed to make the AnalyserNode API immutable
-    analyser: RwLock<Analyser>,
+    analyser: Analyser,
 }
 
 impl AudioNode for AnalyserNode {
@@ -125,7 +122,7 @@ impl AnalyserNode {
             let node = AnalyserNode {
                 registration,
                 channel_config: options.channel_config.into(),
-                analyser: RwLock::new(analyser),
+                analyser,
             };
 
             (node, Box::new(render))
@@ -138,7 +135,7 @@ impl AnalyserNode {
     ///
     /// This method may panic if the lock to the inner analyser is poisoned
     pub fn fft_size(&self) -> usize {
-        self.analyser.read().unwrap().fft_size()
+        self.analyser.fft_size()
     }
 
     /// Set FFT size
@@ -146,8 +143,8 @@ impl AnalyserNode {
     /// # Panics
     ///
     /// This function panics if fft_size is not a power of two or not in the range [32, 32768]
-    pub fn set_fft_size(&self, fft_size: usize) {
-        self.analyser.write().unwrap().set_fft_size(fft_size);
+    pub fn set_fft_size(&mut self, fft_size: usize) {
+        self.analyser.set_fft_size(fft_size);
     }
 
     /// Time averaging parameter with the last analysis frame.
@@ -158,7 +155,7 @@ impl AnalyserNode {
     ///
     /// This method may panic if the lock to the inner analyser is poisoned
     pub fn smoothing_time_constant(&self) -> f64 {
-        self.analyser.read().unwrap().smoothing_time_constant()
+        self.analyser.smoothing_time_constant()
     }
 
     /// Set smoothing time constant
@@ -166,11 +163,8 @@ impl AnalyserNode {
     /// # Panics
     ///
     /// This function panics if the value is set to a value less than 0 or more than 1.
-    pub fn set_smoothing_time_constant(&self, value: f64) {
-        self.analyser
-            .write()
-            .unwrap()
-            .set_smoothing_time_constant(value);
+    pub fn set_smoothing_time_constant(&mut self, value: f64) {
+        self.analyser.set_smoothing_time_constant(value);
     }
 
     /// Minimum power value in the scaling range for the FFT analysis data for
@@ -180,7 +174,7 @@ impl AnalyserNode {
     ///
     /// This method may panic if the lock to the inner analyser is poisoned
     pub fn min_decibels(&self) -> f64 {
-        self.analyser.read().unwrap().min_decibels()
+        self.analyser.min_decibels()
     }
 
     /// Set min decibels
@@ -189,8 +183,8 @@ impl AnalyserNode {
     ///
     /// This function panics if the value is set to a value more than or equal
     /// to max decibels.
-    pub fn set_min_decibels(&self, value: f64) {
-        self.analyser.write().unwrap().set_min_decibels(value);
+    pub fn set_min_decibels(&mut self, value: f64) {
+        self.analyser.set_min_decibels(value);
     }
 
     /// Maximum power value in the scaling range for the FFT analysis data for
@@ -200,7 +194,7 @@ impl AnalyserNode {
     ///
     /// This method may panic if the lock to the inner analyser is poisoned
     pub fn max_decibels(&self) -> f64 {
-        self.analyser.read().unwrap().max_decibels()
+        self.analyser.max_decibels()
     }
 
     /// Set max decibels
@@ -209,8 +203,8 @@ impl AnalyserNode {
     ///
     /// This function panics if the value is set to a value less than or equal
     /// to min decibels.
-    pub fn set_max_decibels(&self, value: f64) {
-        self.analyser.write().unwrap().set_max_decibels(value);
+    pub fn set_max_decibels(&mut self, value: f64) {
+        self.analyser.set_max_decibels(value);
     }
 
     /// Number of bins in the FFT results, is half the FFT size
@@ -219,7 +213,7 @@ impl AnalyserNode {
     ///
     /// This method may panic if the lock to the inner analyser is poisoned
     pub fn frequency_bin_count(&self) -> usize {
-        self.analyser.read().unwrap().frequency_bin_count()
+        self.analyser.frequency_bin_count()
     }
 
     /// Copy the current time domain data as f32 values into the provided buffer
@@ -227,11 +221,8 @@ impl AnalyserNode {
     /// # Panics
     ///
     /// This method may panic if the lock to the inner analyser is poisoned
-    pub fn get_float_time_domain_data(&self, buffer: &mut [f32]) {
-        self.analyser
-            .write()
-            .unwrap()
-            .get_float_time_domain_data(buffer);
+    pub fn get_float_time_domain_data(&mut self, buffer: &mut [f32]) {
+        self.analyser.get_float_time_domain_data(buffer);
     }
 
     /// Copy the current time domain data as u8 values into the provided buffer
@@ -239,11 +230,8 @@ impl AnalyserNode {
     /// # Panics
     ///
     /// This method may panic if the lock to the inner analyser is poisoned
-    pub fn get_byte_time_domain_data(&self, buffer: &mut [u8]) {
-        self.analyser
-            .write()
-            .unwrap()
-            .get_byte_time_domain_data(buffer);
+    pub fn get_byte_time_domain_data(&mut self, buffer: &mut [u8]) {
+        self.analyser.get_byte_time_domain_data(buffer);
     }
 
     /// Copy the current frequency data into the provided buffer
@@ -251,12 +239,9 @@ impl AnalyserNode {
     /// # Panics
     ///
     /// This method may panic if the lock to the inner analyser is poisoned
-    pub fn get_float_frequency_data(&self, buffer: &mut [f32]) {
+    pub fn get_float_frequency_data(&mut self, buffer: &mut [f32]) {
         let current_time = self.registration.context().current_time();
-        self.analyser
-            .write()
-            .unwrap()
-            .get_float_frequency_data(buffer, current_time);
+        self.analyser.get_float_frequency_data(buffer, current_time);
     }
 
     /// Copy the current frequency data scaled between min_decibels and
@@ -265,12 +250,9 @@ impl AnalyserNode {
     /// # Panics
     ///
     /// This method may panic if the lock to the inner analyser is poisoned
-    pub fn get_byte_frequency_data(&self, buffer: &mut [u8]) {
+    pub fn get_byte_frequency_data(&mut self, buffer: &mut [u8]) {
         let current_time = self.registration.context().current_time();
-        self.analyser
-            .write()
-            .unwrap()
-            .get_byte_frequency_data(buffer, current_time);
+        self.analyser.get_byte_frequency_data(buffer, current_time);
     }
 }
 

--- a/src/node/biquad_filter.rs
+++ b/src/node/biquad_filter.rs
@@ -281,7 +281,7 @@ impl Default for BiquadFilterOptions {
 ///     .exponential_ramp_to_value_at_time(10000., context.current_time() + 10.);
 ///
 /// // pipe the audio buffer source into the lowpass filter
-/// let src = context.create_buffer_source();
+/// let mut src = context.create_buffer_source();
 /// src.connect(&biquad);
 /// src.set_buffer(buffer);
 /// src.set_loop(true);

--- a/src/node/biquad_filter.rs
+++ b/src/node/biquad_filter.rs
@@ -1,7 +1,6 @@
 //! The biquad filter control and renderer parts
 use std::any::Any;
 use std::f64::consts::{PI, SQRT_2};
-use std::sync::atomic::{AtomicU32, Ordering};
 
 use num_complex::Complex;
 
@@ -309,8 +308,8 @@ pub struct BiquadFilterNode {
     /// boost/attenuation (dB) - its impact on the frequency response of the
     /// filter, depends on the `BiquadFilterType`
     gain: AudioParam,
-    /// `BiquadFilterType` represented as u32
-    type_: AtomicU32,
+    /// Current biquad filter type
+    type_: BiquadFilterType,
 }
 
 impl AudioNode for BiquadFilterNode {
@@ -402,7 +401,7 @@ impl BiquadFilterNode {
             let node = Self {
                 registration,
                 channel_config: channel_config.into(),
-                type_: AtomicU32::new(type_ as u32),
+                type_,
                 q: q_param,
                 detune: d_param,
                 frequency: f_param,
@@ -440,7 +439,7 @@ impl BiquadFilterNode {
     /// Returns the biquad filter type
     #[must_use]
     pub fn type_(&self) -> BiquadFilterType {
-        self.type_.load(Ordering::Acquire).into()
+        self.type_
     }
 
     /// biquad filter type setter
@@ -448,8 +447,8 @@ impl BiquadFilterNode {
     /// # Arguments
     ///
     /// * `type_` - the biquad filter type (lowpass, highpass,...)
-    pub fn set_type(&self, type_: BiquadFilterType) {
-        self.type_.store(type_ as u32, Ordering::Release);
+    pub fn set_type(&mut self, type_: BiquadFilterType) {
+        self.type_ = type_;
         self.registration.post_message(type_);
     }
 
@@ -820,7 +819,7 @@ mod tests {
                 -2.6204006671905518,
             ];
 
-            let filter = context.create_biquad_filter();
+            let mut filter = context.create_biquad_filter();
             filter.set_type(type_);
             filter.frequency().set_value(frequency);
             filter.q().set_value(q);
@@ -862,7 +861,7 @@ mod tests {
                 0.5211920142173767,
             ];
 
-            let filter = context.create_biquad_filter();
+            let mut filter = context.create_biquad_filter();
             filter.set_type(type_);
             filter.frequency().set_value(frequency);
             filter.q().set_value(q);
@@ -904,7 +903,7 @@ mod tests {
                 -0.9985077977180481,
             ];
 
-            let filter = context.create_biquad_filter();
+            let mut filter = context.create_biquad_filter();
             filter.set_type(type_);
             filter.frequency().set_value(frequency);
             filter.q().set_value(q);
@@ -946,7 +945,7 @@ mod tests {
                 0.5722885727882385,
             ];
 
-            let filter = context.create_biquad_filter();
+            let mut filter = context.create_biquad_filter();
             filter.set_type(type_);
             filter.frequency().set_value(frequency);
             filter.q().set_value(q);
@@ -977,7 +976,7 @@ mod tests {
                 1.144577145576477,
             ];
 
-            let filter = context.create_biquad_filter();
+            let mut filter = context.create_biquad_filter();
             filter.set_type(type_);
             filter.frequency().set_value(frequency);
             filter.q().set_value(q);
@@ -1019,7 +1018,7 @@ mod tests {
                 -0.1567305326461792,
             ];
 
-            let filter = context.create_biquad_filter();
+            let mut filter = context.create_biquad_filter();
             filter.set_type(type_);
             filter.frequency().set_value(frequency);
             filter.q().set_value(q);
@@ -1061,7 +1060,7 @@ mod tests {
                 -0.1404205560684204,
             ];
 
-            let filter = context.create_biquad_filter();
+            let mut filter = context.create_biquad_filter();
             filter.set_type(type_);
             filter.frequency().set_value(frequency);
             filter.q().set_value(q);
@@ -1103,7 +1102,7 @@ mod tests {
                 0.1404205560684204,
             ];
 
-            let filter = context.create_biquad_filter();
+            let mut filter = context.create_biquad_filter();
             filter.set_type(type_);
             filter.frequency().set_value(frequency);
             filter.q().set_value(q);

--- a/src/node/constant_source.rs
+++ b/src/node/constant_source.rs
@@ -94,21 +94,21 @@ impl AudioNode for ConstantSourceNode {
 }
 
 impl AudioScheduledSourceNode for ConstantSourceNode {
-    fn start(&self) {
+    fn start(&mut self) {
         let when = self.registration.context().current_time();
         self.start_at(when);
     }
 
-    fn start_at(&self, when: f64) {
+    fn start_at(&mut self, when: f64) {
         self.registration.post_message(Schedule::Start(when));
     }
 
-    fn stop(&self) {
+    fn stop(&mut self) {
         let when = self.registration.context().current_time();
         self.stop_at(when);
     }
 
-    fn stop_at(&self, when: f64) {
+    fn stop_at(&mut self, when: f64) {
         self.registration.post_message(Schedule::Stop(when));
     }
 }
@@ -239,7 +239,7 @@ mod tests {
         let stop_in_samples = (256 + 1) as f64; // stop rendering of 3rd block
         let context = OfflineAudioContext::new(1, 128 * 4, sample_rate);
 
-        let src = context.create_constant_source();
+        let mut src = context.create_constant_source();
         src.connect(&context.destination());
 
         src.start_at(start_in_samples / sample_rate as f64);
@@ -269,7 +269,7 @@ mod tests {
     fn test_start_in_the_past() {
         let context = OfflineAudioContext::new(1, 128, 48000.);
 
-        let src = context.create_constant_source();
+        let mut src = context.create_constant_source();
         src.connect(&context.destination());
         src.start_at(-1.);
 

--- a/src/node/convolver.rs
+++ b/src/node/convolver.rs
@@ -92,7 +92,7 @@ pub struct ConvolverOptions {
 /// let impulse_file = File::open("samples/small-room-response.wav").unwrap();
 /// let impulse_buffer = context.decode_audio_data_sync(impulse_file).unwrap();
 ///
-/// let src = context.create_buffer_source();
+/// let mut src = context.create_buffer_source();
 /// src.set_buffer(audio_buffer);
 ///
 /// let convolve = ConvolverNode::new(&context, ConvolverOptions::default());
@@ -485,7 +485,7 @@ mod tests {
         conv.connect(&context.destination());
 
         let buffer = AudioBuffer::from(vec![channel_data; 1], sample_rate);
-        let src = context.create_buffer_source();
+        let mut src = context.create_buffer_source();
         src.connect(&conv);
         src.set_buffer(buffer);
         src.start();
@@ -500,7 +500,7 @@ mod tests {
         let context = OfflineAudioContext::new(1, length, sample_rate);
 
         let input = AudioBuffer::from(vec![signal.to_vec()], sample_rate);
-        let src = AudioBufferSourceNode::new(&context, AudioBufferSourceOptions::default());
+        let mut src = AudioBufferSourceNode::new(&context, AudioBufferSourceOptions::default());
         src.set_buffer(input);
         src.start();
 

--- a/src/node/delay.rs
+++ b/src/node/delay.rs
@@ -63,7 +63,7 @@ struct PlaybackInfo {
 /// delay.delay_time().set_value(0.5);
 /// delay.connect(&context.destination());
 ///
-/// let src = context.create_buffer_source();
+/// let mut src = context.create_buffer_source();
 /// src.set_buffer(audio_buffer);
 /// // connect to both delay and destination
 /// src.connect(&delay);
@@ -663,7 +663,7 @@ mod tests {
             let mut dirac = context.create_buffer(1, 1, sample_rate);
             dirac.copy_to_channel(&[1.], 0);
 
-            let src = context.create_buffer_source();
+            let mut src = context.create_buffer_source();
             src.connect(&delay);
             src.set_buffer(dirac);
             src.start_at(0.);
@@ -692,7 +692,7 @@ mod tests {
             let mut dirac = context.create_buffer(1, 1, sample_rate);
             dirac.copy_to_channel(&[1.], 0);
 
-            let src = context.create_buffer_source();
+            let mut src = context.create_buffer_source();
             src.connect(&delay);
             src.set_buffer(dirac);
             src.start_at(0.);
@@ -719,7 +719,7 @@ mod tests {
             let mut dirac = context.create_buffer(1, 1, sample_rate);
             dirac.copy_to_channel(&[1.], 0);
 
-            let src = context.create_buffer_source();
+            let mut src = context.create_buffer_source();
             src.connect(&delay);
             src.set_buffer(dirac);
             src.start_at(0.);
@@ -750,7 +750,7 @@ mod tests {
         two_chan_dirac.copy_to_channel(&[1.], 0);
         two_chan_dirac.copy_to_channel(&[0., 1.], 1);
 
-        let src = context.create_buffer_source();
+        let mut src = context.create_buffer_source();
         src.connect(&delay);
         src.set_buffer(two_chan_dirac);
         src.start_at(0.);
@@ -781,7 +781,7 @@ mod tests {
         let mut one_chan_dirac = context.create_buffer(1, 128, sample_rate);
         one_chan_dirac.copy_to_channel(&[1.], 0);
 
-        let src1 = context.create_buffer_source();
+        let mut src1 = context.create_buffer_source();
         src1.connect(&delay);
         src1.set_buffer(one_chan_dirac);
         src1.start_at(0.);
@@ -791,7 +791,7 @@ mod tests {
         two_chan_dirac.copy_to_channel(&[1.], 0);
         two_chan_dirac.copy_to_channel(&[0., 1.], 1);
         // start second buffer at next block
-        let src2 = context.create_buffer_source();
+        let mut src2 = context.create_buffer_source();
         src2.connect(&delay);
         src2.set_buffer(two_chan_dirac);
         src2.start_at(delay_in_samples as f64 / sample_rate as f64);
@@ -830,7 +830,7 @@ mod tests {
                 let mut dirac = context.create_buffer(1, 1, sample_rate);
                 dirac.copy_to_channel(&[1.], 0);
 
-                let src = context.create_buffer_source();
+                let mut src = context.create_buffer_source();
                 src.connect(&delay);
                 src.set_buffer(dirac);
                 // 3rd block - play buffer
@@ -860,7 +860,7 @@ mod tests {
             let mut dirac = context.create_buffer(1, 1, sample_rate);
             dirac.copy_to_channel(&[1.], 0);
 
-            let src = context.create_buffer_source();
+            let mut src = context.create_buffer_source();
             src.connect(&delay);
             src.set_buffer(dirac);
             src.start_at(0.);
@@ -893,7 +893,7 @@ mod tests {
         let mut dirac = context.create_buffer(1, 1, sample_rate);
         dirac.copy_to_channel(&[1.], 0);
 
-        let src = context.create_buffer_source();
+        let mut src = context.create_buffer_source();
         src.connect(&delay);
         src.set_buffer(dirac);
         src.start_at(0.);
@@ -932,7 +932,7 @@ mod tests {
             let mut dirac = context.create_buffer(1, 1, sample_rate);
             dirac.copy_to_channel(&[1.], 0);
 
-            let src = context.create_buffer_source();
+            let mut src = context.create_buffer_source();
             src.connect(&delay);
             src.set_buffer(dirac);
             src.start_at(0.);
@@ -966,7 +966,7 @@ mod tests {
             let mut dirac = context.create_buffer(1, 1, sample_rate);
             dirac.copy_to_channel(&[1.], 0);
 
-            let src = context.create_buffer_source();
+            let mut src = context.create_buffer_source();
             src.connect(&delay);
             src.set_buffer(dirac);
             src.start_at(0.);
@@ -992,7 +992,7 @@ mod tests {
             let mut dirac = context.create_buffer(1, 1, sample_rate);
             dirac.copy_to_channel(&[1.], 0);
 
-            let src = context.create_buffer_source();
+            let mut src = context.create_buffer_source();
             src.connect(&delay);
             src.set_buffer(dirac);
             src.start_at(0.);
@@ -1022,7 +1022,7 @@ mod tests {
             delay.connect(&context.destination());
 
             // emit 120 samples
-            let src = context.create_constant_source();
+            let mut src = context.create_constant_source();
             src.connect(&delay);
             src.start_at(0.);
             src.stop_at(120. / sample_rate as f64);

--- a/src/node/destination.rs
+++ b/src/node/destination.rs
@@ -25,7 +25,7 @@ use super::{
 ///
 /// let context = AudioContext::default();
 ///
-/// let osc = context.create_oscillator();
+/// let mut osc = context.create_oscillator();
 /// osc.connect(&context.destination());
 /// osc.start();
 /// ```

--- a/src/node/dynamics_compressor.rs
+++ b/src/node/dynamics_compressor.rs
@@ -86,7 +86,7 @@ impl Default for DynamicsCompressorOptions {
 /// compressor.connect(&context.destination());
 ///
 /// // pipe the audio source in the compressor
-/// let src = context.create_buffer_source();
+/// let mut src = context.create_buffer_source();
 /// src.connect(&compressor);
 /// src.set_buffer(buffer.clone());
 /// src.start();
@@ -480,7 +480,7 @@ mod tests {
         let signal = [1.; 128 * 5];
         buffer.copy_to_channel(&signal, 0);
 
-        let src = context.create_buffer_source();
+        let mut src = context.create_buffer_source();
         src.set_buffer(buffer);
         src.connect(&compressor);
         src.start();
@@ -545,7 +545,7 @@ mod tests {
     //     // println!("{:?}", signal);
     //     buffer.copy_to_channel(&signal, 0);
 
-    //     let src = context.create_buffer_source();
+    //     let mut src = context.create_buffer_source();
     //     src.set_buffer(buffer);
     //     src.connect(&compressor);
     //     src.start();

--- a/src/node/iir_filter.rs
+++ b/src/node/iir_filter.rs
@@ -115,7 +115,7 @@ pub struct IIRFilterOptions {
 /// iir.connect(&context.destination());
 ///
 /// // play the buffer and pipe it into the filter
-/// let src = context.create_buffer_source();
+/// let mut src = context.create_buffer_source();
 /// src.connect(&iir);
 /// src.set_buffer(buffer);
 /// src.set_loop(true);
@@ -517,7 +517,7 @@ mod tests {
                 biquad.q().set_value(q);
                 biquad.gain().set_value(gain);
 
-                let src = context.create_buffer_source();
+                let mut src = context.create_buffer_source();
                 src.connect(&biquad);
                 src.set_buffer(noise.clone());
                 src.start();
@@ -531,7 +531,7 @@ mod tests {
                 let iir = context.create_iir_filter(feedforward, feedback);
                 iir.connect(&context.destination());
 
-                let src = context.create_buffer_source();
+                let mut src = context.create_buffer_source();
                 src.connect(&iir);
                 src.set_buffer(noise.clone());
                 src.start();

--- a/src/node/iir_filter.rs
+++ b/src/node/iir_filter.rs
@@ -510,7 +510,7 @@ mod tests {
             let biquad_res = {
                 let context = OfflineAudioContext::new(1, 1000, 44_100.);
 
-                let biquad = context.create_biquad_filter();
+                let mut biquad = context.create_biquad_filter();
                 biquad.connect(&context.destination());
                 biquad.set_type(filter_type);
                 biquad.frequency().set_value(frequency);
@@ -753,7 +753,7 @@ mod tests {
                 let mut mags = [0.; 10];
                 let mut phases = [0.; 10];
 
-                let biquad = context.create_biquad_filter();
+                let mut biquad = context.create_biquad_filter();
                 biquad.set_type(filter_type);
                 biquad.frequency().set_value(frequency);
                 biquad.q().set_value(q);

--- a/src/node/media_element_source.rs
+++ b/src/node/media_element_source.rs
@@ -35,7 +35,7 @@ pub struct MediaElementAudioSourceOptions<'a> {
 /// let context = AudioContext::default();
 /// let mut media = MediaElement::new("samples/major-scale.ogg").unwrap();
 ///
-/// let src = context.create_media_element_source(&mut media);
+/// let mut src = context.create_media_element_source(&mut media);
 /// src.connect(&context.destination());
 ///
 /// media.set_loop(true); // continuously loop

--- a/src/node/media_stream_destination.rs
+++ b/src/node/media_stream_destination.rs
@@ -31,7 +31,7 @@ use crossbeam_channel::{self, Receiver, Sender};
 /// let context = AudioContext::default();
 ///
 /// // Create an oscillator node with sine (default) type
-/// let osc = context.create_oscillator();
+/// let mut osc = context.create_oscillator();
 ///
 /// // Create a media destination node
 /// let dest = context.create_media_stream_destination();

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -371,28 +371,28 @@ pub trait AudioScheduledSourceNode: AudioNode {
     /// # Panics
     ///
     /// Panics if the source was already started
-    fn start(&self);
+    fn start(&mut self);
 
     /// Schedule playback start at given timestamp
     ///
     /// # Panics
     ///
     /// Panics if the source was already started
-    fn start_at(&self, when: f64);
+    fn start_at(&mut self, when: f64);
 
     /// Stop immediately
     ///
     /// # Panics
     ///
     /// Panics if the source was already stopped
-    fn stop(&self);
+    fn stop(&mut self);
 
     /// Schedule playback stop at given timestamp
     ///
     /// # Panics
     ///
     /// Panics if the source was already stopped
-    fn stop_at(&self, when: f64);
+    fn stop_at(&mut self, when: f64);
 
     /// Register callback to run when the source node has stopped playing
     ///

--- a/src/node/oscillator.rs
+++ b/src/node/oscillator.rs
@@ -154,21 +154,21 @@ impl AudioNode for OscillatorNode {
 }
 
 impl AudioScheduledSourceNode for OscillatorNode {
-    fn start(&self) {
+    fn start(&mut self) {
         let when = self.registration.context().current_time();
         self.start_at(when);
     }
 
-    fn start_at(&self, when: f64) {
+    fn start_at(&mut self, when: f64) {
         self.registration.post_message(Schedule::Start(when));
     }
 
-    fn stop(&self) {
+    fn stop(&mut self) {
         let when = self.registration.context().current_time();
         self.stop_at(when);
     }
 
-    fn stop_at(&self, when: f64) {
+    fn stop_at(&mut self, when: f64) {
         self.registration.post_message(Schedule::Stop(when));
     }
 }
@@ -674,7 +674,7 @@ mod tests {
 
             let context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
 
-            let osc = context.create_oscillator();
+            let mut osc = context.create_oscillator();
             osc.connect(&context.destination());
             osc.frequency().set_value(freq);
             osc.start_at(0.);
@@ -710,7 +710,7 @@ mod tests {
 
             let context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
 
-            let osc = context.create_oscillator();
+            let mut osc = context.create_oscillator();
             osc.connect(&context.destination());
             osc.frequency().set_value(freq);
             osc.start_at(0.);
@@ -1000,7 +1000,7 @@ mod tests {
         let sample_rate = 44_100;
 
         let context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
-        let osc = context.create_oscillator();
+        let mut osc = context.create_oscillator();
         osc.connect(&context.destination());
         osc.frequency().set_value(freq);
         osc.start_at(2. / sample_rate as f64);
@@ -1032,7 +1032,7 @@ mod tests {
         let sample_rate = 96000;
 
         let context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
-        let osc = context.create_oscillator();
+        let mut osc = context.create_oscillator();
         osc.connect(&context.destination());
         osc.frequency().set_value(freq);
         // start between second and third sample
@@ -1064,7 +1064,7 @@ mod tests {
         let sample_rate = 44_100;
 
         let context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
-        let osc = context.create_oscillator();
+        let mut osc = context.create_oscillator();
         osc.connect(&context.destination());
         osc.frequency().set_value(freq);
         osc.start_at(0.);
@@ -1096,7 +1096,7 @@ mod tests {
         let sample_rate = 44_100;
 
         let context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
-        let osc = context.create_oscillator();
+        let mut osc = context.create_oscillator();
         osc.connect(&context.destination());
         osc.frequency().set_value(freq);
         osc.start_at(0.);
@@ -1128,7 +1128,7 @@ mod tests {
         let sample_rate = 44_100;
 
         let context = OfflineAudioContext::new(1, sample_rate, sample_rate as f32);
-        let osc = context.create_oscillator();
+        let mut osc = context.create_oscillator();
         osc.connect(&context.destination());
         osc.frequency().set_value(freq);
         osc.start_at(-1.);

--- a/src/node/panner.rs
+++ b/src/node/panner.rs
@@ -892,7 +892,7 @@ mod tests {
 
         // 128 input samples of value 1.
         let input = AudioBuffer::from(vec![vec![1.; RENDER_QUANTUM_SIZE]], sample_rate);
-        let src = AudioBufferSourceNode::new(&context, AudioBufferSourceOptions::default());
+        let mut src = AudioBufferSourceNode::new(&context, AudioBufferSourceOptions::default());
         src.set_buffer(input);
         src.start();
 
@@ -944,7 +944,7 @@ mod tests {
 
         // 128 input samples of value 1.
         let input = AudioBuffer::from(vec![vec![1.; RENDER_QUANTUM_SIZE]], sample_rate);
-        let src = AudioBufferSourceNode::new(&context, AudioBufferSourceOptions::default());
+        let mut src = AudioBufferSourceNode::new(&context, AudioBufferSourceOptions::default());
         src.set_buffer(input);
         src.start();
 

--- a/src/node/panner.rs
+++ b/src/node/panner.rs
@@ -244,7 +244,7 @@ impl HrtfState {
 /// let context = AudioContext::default();
 ///
 /// // Create a friendly tone
-/// let tone = context.create_oscillator();
+/// let mut tone = context.create_oscillator();
 /// tone.frequency().set_value_at_time(300.0f32, 0.);
 /// tone.start();
 ///
@@ -257,7 +257,7 @@ impl HrtfState {
 /// panner.position_z().set_value_at_time(1., 0.);
 ///
 /// // And sweeps 10 units left to right, every second
-/// let moving = context.create_oscillator();
+/// let mut moving = context.create_oscillator();
 /// moving.start();
 /// moving.frequency().set_value_at_time(1., 0.);
 /// let gain = context.create_gain();

--- a/src/node/panner.rs
+++ b/src/node/panner.rs
@@ -1,6 +1,5 @@
 use std::any::Any;
 use std::f32::consts::PI;
-use std::sync::atomic::{AtomicU8, Ordering};
 
 use float_eq::float_eq;
 use hrtf::{HrirSphere, HrtfContext, HrtfProcessor, Vec3};
@@ -8,7 +7,7 @@ use hrtf::{HrirSphere, HrtfContext, HrtfProcessor, Vec3};
 use crate::context::{AudioContextRegistration, AudioParamId, BaseAudioContext};
 use crate::param::{AudioParam, AudioParamDescriptor};
 use crate::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum, RenderScope};
-use crate::{AtomicF64, RENDER_QUANTUM_SIZE};
+use crate::RENDER_QUANTUM_SIZE;
 
 use super::{
     AudioNode, ChannelConfig, ChannelConfigOptions, ChannelCountMode, ChannelInterpretation,
@@ -115,7 +114,7 @@ impl Default for PannerOptions {
 }
 
 enum ControlMessage {
-    DistanceModel(u8),
+    DistanceModel(DistanceModelType),
     // Box this payload - one large variant can penalize the memory layout of this enum
     PanningModel(Box<Option<HrtfState>>),
     RefDistance(f64),
@@ -282,14 +281,14 @@ pub struct PannerNode {
     orientation_x: AudioParam,
     orientation_y: AudioParam,
     orientation_z: AudioParam,
-    cone_inner_angle: AtomicF64,
-    cone_outer_angle: AtomicF64,
-    cone_outer_gain: AtomicF64,
-    distance_model: AtomicU8,
-    ref_distance: AtomicF64,
-    max_distance: AtomicF64,
-    rolloff_factor: AtomicF64,
-    panning_model: AtomicU8,
+    cone_inner_angle: f64,
+    cone_outer_angle: f64,
+    cone_outer_gain: f64,
+    distance_model: DistanceModelType,
+    ref_distance: f64,
+    max_distance: f64,
+    rolloff_factor: f64,
+    panning_model: PanningModelType,
 }
 
 impl AudioNode for PannerNode {
@@ -340,7 +339,7 @@ impl PannerNode {
     /// Can panic when loading HRIR-sphere
     #[allow(clippy::missing_panics_doc)]
     pub fn new<C: BaseAudioContext>(context: &C, options: PannerOptions) -> Self {
-        let node = context.register(|registration| {
+        let mut node = context.register(|registration| {
             use crate::spatial::PARAM_OPTS;
 
             let PannerOptions {
@@ -409,14 +408,14 @@ impl PannerNode {
                 orientation_x: param_ox,
                 orientation_y: param_oy,
                 orientation_z: param_oz,
-                distance_model: AtomicU8::new(distance_model as u8),
-                ref_distance: AtomicF64::new(ref_distance),
-                max_distance: AtomicF64::new(max_distance),
-                rolloff_factor: AtomicF64::new(rolloff_factor),
-                cone_inner_angle: AtomicF64::new(cone_inner_angle),
-                cone_outer_angle: AtomicF64::new(cone_outer_angle),
-                cone_outer_gain: AtomicF64::new(cone_outer_gain),
-                panning_model: AtomicU8::new(panning_model as u8),
+                distance_model,
+                ref_distance,
+                max_distance,
+                rolloff_factor,
+                cone_inner_angle,
+                cone_outer_angle,
+                cone_outer_gain,
+                panning_model,
             };
 
             // instruct to BaseContext to add the AudioListener if it has not already
@@ -473,82 +472,81 @@ impl PannerNode {
     }
 
     pub fn distance_model(&self) -> DistanceModelType {
-        self.distance_model.load(Ordering::Acquire).into()
+        self.distance_model
     }
 
-    pub fn set_distance_model(&self, value: DistanceModelType) {
-        let value = value as u8;
-        self.distance_model.store(value, Ordering::Release);
+    pub fn set_distance_model(&mut self, value: DistanceModelType) {
+        self.distance_model = value;
         self.registration
             .post_message(ControlMessage::DistanceModel(value));
     }
 
     pub fn ref_distance(&self) -> f64 {
-        self.ref_distance.load(Ordering::Acquire)
+        self.ref_distance
     }
 
-    pub fn set_ref_distance(&self, value: f64) {
-        self.ref_distance.store(value, Ordering::Release);
+    pub fn set_ref_distance(&mut self, value: f64) {
+        self.ref_distance = value;
         self.registration
             .post_message(ControlMessage::RefDistance(value));
     }
 
     pub fn max_distance(&self) -> f64 {
-        self.max_distance.load(Ordering::Acquire)
+        self.max_distance
     }
 
-    pub fn set_max_distance(&self, value: f64) {
-        self.max_distance.store(value, Ordering::Release);
+    pub fn set_max_distance(&mut self, value: f64) {
+        self.max_distance = value;
         self.registration
             .post_message(ControlMessage::MaxDistance(value));
     }
 
     pub fn rolloff_factor(&self) -> f64 {
-        self.rolloff_factor.load(Ordering::Acquire)
+        self.rolloff_factor
     }
 
-    pub fn set_rolloff_factor(&self, value: f64) {
-        self.rolloff_factor.store(value, Ordering::Release);
+    pub fn set_rolloff_factor(&mut self, value: f64) {
+        self.rolloff_factor = value;
         self.registration
             .post_message(ControlMessage::RollOffFactor(value));
     }
 
     pub fn cone_inner_angle(&self) -> f64 {
-        self.cone_inner_angle.load(Ordering::Acquire)
+        self.cone_inner_angle
     }
 
-    pub fn set_cone_inner_angle(&self, value: f64) {
-        self.cone_inner_angle.store(value, Ordering::Release);
+    pub fn set_cone_inner_angle(&mut self, value: f64) {
+        self.cone_inner_angle = value;
         self.registration
             .post_message(ControlMessage::ConeInnerAngle(value));
     }
 
     pub fn cone_outer_angle(&self) -> f64 {
-        self.cone_outer_angle.load(Ordering::Acquire)
+        self.cone_outer_angle
     }
 
-    pub fn set_cone_outer_angle(&self, value: f64) {
-        self.cone_outer_angle.store(value, Ordering::Release);
+    pub fn set_cone_outer_angle(&mut self, value: f64) {
+        self.cone_outer_angle = value;
         self.registration
             .post_message(ControlMessage::ConeOuterAngle(value));
     }
 
     pub fn cone_outer_gain(&self) -> f64 {
-        self.cone_outer_gain.load(Ordering::Acquire)
+        self.cone_outer_gain
     }
 
-    pub fn set_cone_outer_gain(&self, value: f64) {
-        self.cone_outer_gain.store(value, Ordering::Release);
+    pub fn set_cone_outer_gain(&mut self, value: f64) {
+        self.cone_outer_gain = value;
         self.registration
             .post_message(ControlMessage::ConeOuterGain(value));
     }
 
     pub fn panning_model(&self) -> PanningModelType {
-        self.panning_model.load(Ordering::Acquire).into()
+        self.panning_model
     }
 
     #[allow(clippy::missing_panics_doc)] // loading the provided HRTF will not panic
-    pub fn set_panning_model(&self, value: PanningModelType) {
+    pub fn set_panning_model(&mut self, value: PanningModelType) {
         let hrtf_option = match value {
             PanningModelType::EqualPower => None,
             PanningModelType::HRTF => {
@@ -559,7 +557,7 @@ impl PannerNode {
             }
         };
 
-        self.panning_model.store(value as u8, Ordering::Release);
+        self.panning_model = value;
         self.registration
             .post_message(ControlMessage::PanningModel(Box::new(hrtf_option)));
     }
@@ -797,7 +795,7 @@ impl AudioProcessor for PannerRenderer {
     fn onmessage(&mut self, msg: &mut dyn Any) {
         if let Some(control) = msg.downcast_mut::<ControlMessage>() {
             match control {
-                ControlMessage::DistanceModel(value) => self.distance_model = (*value).into(),
+                ControlMessage::DistanceModel(value) => self.distance_model = *value,
                 ControlMessage::RefDistance(value) => self.ref_distance = *value,
                 ControlMessage::MaxDistance(value) => self.max_distance = *value,
                 ControlMessage::RollOffFactor(value) => self.rolloff_factor = *value,

--- a/src/node/stereo_panner.rs
+++ b/src/node/stereo_panner.rs
@@ -405,7 +405,7 @@ mod tests {
             );
             panner.connect(&context.destination());
 
-            let src = context.create_buffer_source();
+            let mut src = context.create_buffer_source();
             src.connect(&panner);
             src.set_buffer(buffer.clone());
             src.start();
@@ -433,7 +433,7 @@ mod tests {
             );
             panner.connect(&context.destination());
 
-            let src = context.create_buffer_source();
+            let mut src = context.create_buffer_source();
             src.connect(&panner);
             src.set_buffer(buffer.clone());
             src.start();
@@ -461,7 +461,7 @@ mod tests {
             );
             panner.connect(&context.destination());
 
-            let src = context.create_buffer_source();
+            let mut src = context.create_buffer_source();
             src.connect(&panner);
             src.set_buffer(buffer.clone());
             src.start();
@@ -504,7 +504,7 @@ mod tests {
             );
             panner.connect(&context.destination());
 
-            let src = context.create_buffer_source();
+            let mut src = context.create_buffer_source();
             src.connect(&panner);
             src.set_buffer(buffer.clone());
             src.start();
@@ -528,7 +528,7 @@ mod tests {
             );
             panner.connect(&context.destination());
 
-            let src = context.create_buffer_source();
+            let mut src = context.create_buffer_source();
             src.connect(&panner);
             src.set_buffer(buffer.clone());
             src.start();
@@ -552,7 +552,7 @@ mod tests {
             );
             panner.connect(&context.destination());
 
-            let src = context.create_buffer_source();
+            let mut src = context.create_buffer_source();
             src.connect(&panner);
             src.set_buffer(buffer.clone());
             src.start();

--- a/src/node/stereo_panner.rs
+++ b/src/node/stereo_panner.rs
@@ -102,7 +102,7 @@ fn get_stereo_gains(sine_table: &[f32], x: f32) -> [f32; 2] {
 /// panner.pan().set_value(-1.);
 ///
 /// // pipe an oscillator into the stereo panner
-/// let osc = context.create_oscillator();
+/// let mut osc = context.create_oscillator();
 /// osc.frequency().set_value(200.);
 /// osc.connect(&panner);
 /// osc.start();

--- a/src/node/waveshaper.rs
+++ b/src/node/waveshaper.rs
@@ -110,7 +110,7 @@ impl Default for WaveShaperOptions {
 /// pre_gain.connect(&shaper);
 /// pre_gain.gain().set_value(drive);
 ///
-/// let src = context.create_buffer_source();
+/// let mut src = context.create_buffer_source();
 /// src.connect(&pre_gain);
 /// src.set_buffer(buffer);
 ///
@@ -681,7 +681,7 @@ mod tests {
         let mut buffer = context.create_buffer(1, 3 * RENDER_QUANTUM_SIZE, sample_rate);
         buffer.copy_to_channel(&data, 0);
 
-        let src = context.create_buffer_source();
+        let mut src = context.create_buffer_source();
         src.connect(&shaper);
         src.set_buffer(buffer);
         src.start_at(0.);
@@ -714,7 +714,7 @@ mod tests {
         let mut buffer = context.create_buffer(1, 3 * RENDER_QUANTUM_SIZE, sample_rate);
         buffer.copy_to_channel(&data, 0);
 
-        let src = context.create_buffer_source();
+        let mut src = context.create_buffer_source();
         src.connect(&shaper);
         src.set_buffer(buffer);
         src.start_at(0.);

--- a/src/periodic_wave.rs
+++ b/src/periodic_wave.rs
@@ -59,7 +59,7 @@ pub struct PeriodicWaveOptions {
 ///
 /// let periodic_wave = PeriodicWave::new(&context, options);
 ///
-/// let osc = context.create_oscillator();
+/// let mut osc = context.create_oscillator();
 /// osc.set_periodic_wave(periodic_wave);
 /// osc.connect(&context.destination());
 /// osc.start();

--- a/tests/mixing.rs
+++ b/tests/mixing.rs
@@ -26,7 +26,7 @@ fn run_with_intermediate_channel_config(
 ) -> AudioBuffer {
     {
         // input signal
-        let constant = context.create_constant_source();
+        let mut constant = context.create_constant_source();
         constant.start();
 
         // gain node is only added for mixing

--- a/tests/offline.rs
+++ b/tests/offline.rs
@@ -17,11 +17,11 @@ fn test_offline_render() {
     assert_eq!(context.length(), LENGTH);
 
     {
-        let constant1 = context.create_constant_source();
+        let mut constant1 = context.create_constant_source();
         constant1.offset().set_value(2.);
         constant1.connect(&context.destination());
 
-        let constant2 = context.create_constant_source();
+        let mut constant2 = context.create_constant_source();
         constant2.offset().set_value(-4.);
         constant2.connect(&context.destination());
 
@@ -59,7 +59,7 @@ fn test_start_stop() {
             frequency: 0., // constant signal
             ..Default::default()
         };
-        let osc = OscillatorNode::new(&context, opts);
+        let mut osc = OscillatorNode::new(&context, opts);
         osc.connect(&context.destination());
 
         osc.start_at(128. / sample_rate as f64);
@@ -93,7 +93,7 @@ fn test_delayed_constant_source() {
         delay.delay_time().set_value(128. * 2. / sample_rate);
         delay.connect(&context.destination());
 
-        let source = context.create_constant_source();
+        let mut source = context.create_constant_source();
         source.connect(&delay);
         source.start();
     }
@@ -120,15 +120,15 @@ fn test_audio_param_graph() {
         gain.gain().set_value(0.5); // intrinsic value
         gain.connect(&context.destination());
 
-        let source = context.create_constant_source();
+        let mut source = context.create_constant_source();
         source.offset().set_value(0.8);
         source.connect(&gain);
 
-        let param_input1 = context.create_constant_source();
+        let mut param_input1 = context.create_constant_source();
         param_input1.offset().set_value(0.1);
         param_input1.connect(gain.gain());
 
-        let param_input2 = context.create_constant_source();
+        let mut param_input2 = context.create_constant_source();
         param_input2.offset().set_value(0.3);
         param_input2.connect(gain.gain());
 
@@ -181,11 +181,11 @@ fn test_cycle() {
         // here we go
         cycle1.connect(&cycle2);
 
-        let source_cycle = context.create_constant_source();
+        let mut source_cycle = context.create_constant_source();
         source_cycle.offset().set_value(1.);
         source_cycle.connect(&cycle1);
 
-        let other = context.create_constant_source();
+        let mut other = context.create_constant_source();
         other.offset().set_value(2.);
         other.connect(&context.destination());
 
@@ -215,7 +215,7 @@ fn test_cycle_breaker() {
         // here we go
         delay.connect(&delay);
 
-        let source = context.create_constant_source();
+        let mut source = context.create_constant_source();
         source.offset().set_value(1.);
         source.connect(&delay);
         source.connect(&context.destination());
@@ -261,7 +261,7 @@ fn test_spatial() {
     listener.up_z().set_value(1.);
 
     // add constant tone
-    let constant = context.create_constant_source();
+    let mut constant = context.create_constant_source();
 
     // add panner at (10, 10, 0) - no cone/direction
     let panner = context.create_panner();

--- a/tests/processor_error.rs
+++ b/tests/processor_error.rs
@@ -62,13 +62,13 @@ fn test_processor_error() {
 
     {
         // create constant source with value 1, connect to destination
-        let source1 = context.create_constant_source();
+        let mut source1 = context.create_constant_source();
         source1.offset().set_value(1.);
         source1.connect(&context.destination());
         source1.start();
 
         // create constant source with value 2, connect to error processor
-        let source2 = context.create_constant_source();
+        let mut source2 = context.create_constant_source();
         source2.offset().set_value(2.);
         let panic = PanicNode::new(&context);
         source2.connect(&panic);

--- a/tests/stall_render.rs
+++ b/tests/stall_render.rs
@@ -43,7 +43,7 @@ fn test_event_handler() {
     let context = AudioContext::new(options);
 
     for _ in 0..512 {
-        let constant_source = context.create_constant_source();
+        let mut constant_source = context.create_constant_source();
         constant_source.connect(&context.destination());
         constant_source.start();
         constant_source.stop_at(0.001);


### PR DESCRIPTION
- [x] AnalyserNode
- [x] AudioBufferSourceNode
- [x] AudioDestinationNode
- [x] BiquadFilterNode
- [ ] ChannelConfig
- [x] ChannelMergerNode
- [x] ChannelSplitterNode
- [x] ConstantSourceNode
- [x] ConvolverNode
- [x] DelayNode
- [x] DynamicsCompressorNode
- [x] GainNode
- [x] IIRFilterNode
- [x] MediaElementAudioSourceNode
- [x] MediaStreamAudioDestinationNode
- [x] MediaStreamAudioSourceNode
- [x] MediaStreamTrackAudioSourceNode
- [x] OscillatorNode
- [x] PannerNode
- [x] StereoPannerNode
- [x] WaveShaperNode