### PR TITLE
Deallocate processors outside render thread

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -1,4 +1,5 @@
 use crate::context::AudioNodeId;
+use crate::render::AudioProcessor;
 use crate::AudioRenderCapacityEvent;
 
 use std::any::Any;
@@ -21,6 +22,7 @@ pub(crate) enum EventType {
     SinkChange,
     RenderCapacity,
     ProcessorError(AudioNodeId),
+    DropProcessor,
 }
 
 /// The Error Event interface
@@ -39,6 +41,7 @@ pub(crate) enum EventPayload {
     None,
     RenderCapacity(AudioRenderCapacityEvent),
     ProcessorError(ErrorEvent),
+    DropProcessor(Box<dyn AudioProcessor>),
 }
 
 pub(crate) struct EventDispatch {
@@ -72,6 +75,13 @@ impl EventDispatch {
         EventDispatch {
             type_: EventType::ProcessorError(id),
             payload: EventPayload::ProcessorError(value),
+        }
+    }
+
+    pub fn drop_processor(processor: Box<dyn AudioProcessor>) -> Self {
+        EventDispatch {
+            type_: EventType::DropProcessor,
+            payload: EventPayload::DropProcessor(processor),
         }
     }
 }

--- a/src/node/delay.rs
+++ b/src/node/delay.rs
@@ -583,7 +583,7 @@ impl AudioProcessor for DelayReader {
     // Clear the ring buffer so that the processor can be safely sent back
     // to the control thread.
     //
-    // Note this is only implemented on the reader side
+    // @note - only implement on the reader side as it may outlive the writer
     fn release_resources(&mut self) {
         let mut ring_buffer = self.ring_buffer_mut();
         ring_buffer.clear();

--- a/src/node/delay.rs
+++ b/src/node/delay.rs
@@ -579,6 +579,15 @@ impl AudioProcessor for DelayReader {
 
         true
     }
+
+    // Clear the ring buffer so that the processor can be safely sent back
+    // to the control thread.
+    //
+    // Note this is only implemented on the reader side
+    fn release_resources(&mut self) {
+        let mut ring_buffer = self.ring_buffer_mut();
+        ring_buffer.clear();
+    }
 }
 
 impl DelayReader {

--- a/src/node/dynamics_compressor.rs
+++ b/src/node/dynamics_compressor.rs
@@ -415,6 +415,12 @@ impl AudioProcessor for DynamicsCompressorRenderer {
 
         true
     }
+
+    // Clear the ring buffer so that the processor can be safely sent back
+    // to the control thread.
+    fn release_resources(&mut self) {
+        self.ring_buffer.clear();
+    }
 }
 
 #[cfg(test)]

--- a/src/render/processor.rs
+++ b/src/render/processor.rs
@@ -117,6 +117,12 @@ pub trait AudioProcessor: Send {
     fn onmessage(&mut self, msg: &mut dyn Any) {
         log::warn!("Ignoring incoming message");
     }
+
+    /// Method called before the AudioProcessor is recycled, i.e. when sent back
+    /// to the control thread when its rendering has finished.
+    fn release_resources(&mut self) {
+        // nothing to do
+    }
 }
 
 struct DerefAudioRenderQuantumChannel<'a>(std::cell::Ref<'a, Node>);


### PR DESCRIPTION
Hey, 

Just to share a (rather dirty) test I've made to drop processors outside the render thread. Very probably not something to merge as is but can be a basis for discussion

Several notes:
  - it implies adding a method on the `AudioProcessor` trait
  - I chose to send back the processors to the control thread rather than in the garbage collector thread, because it opens the room for some node pooling system I guess
  - I just abused the event system to make it work without much modifications, but probably a dedicated channel would be better.
