### PR TITLE
Fix and unify source/sink device_id selection in examples

### DIFF
--- a/examples/microphone.rs
+++ b/examples/microphone.rs
@@ -18,24 +18,21 @@ use web_audio_api::node::AudioNode;
 
 fn ask_source_id() -> Option<String> {
     println!("Enter the input 'device_id' and press <Enter>");
-    println!("- Use 0 for the default audio input device");
+    println!("- Leave empty ('') for the default audio input device");
 
     let input = std::io::stdin().lines().next().unwrap().unwrap();
     match input.trim() {
-        "0" => None,
+        "" => None,
         i => Some(i.to_string()),
     }
 }
 
 fn ask_sink_id() -> String {
-    println!("Enter the output 'sink' and press <Enter>");
-    println!("- Use 0 for the default audio output device");
+    println!("Enter the output 'device_id' and press <Enter>");
+    println!("- type 'none' to disable the output");
+    println!("- Leave empty ('') for the default audio output device");
 
-    let input = std::io::stdin().lines().next().unwrap().unwrap();
-    match input.trim() {
-        "0" => "".to_string(),
-        i => i.to_string(),
-    }
+    std::io::stdin().lines().next().unwrap().unwrap()
 }
 
 fn main() {

--- a/examples/roundtrip_latency_test.rs
+++ b/examples/roundtrip_latency_test.rs
@@ -32,24 +32,21 @@ use std::sync::Arc;
 
 fn ask_source_id() -> Option<String> {
     println!("Enter the input 'device_id' and press <Enter>");
-    println!("- Use 0 for the default audio input device");
+    println!("- Leave empty ('') for the default audio input device");
 
     let input = std::io::stdin().lines().next().unwrap().unwrap();
     match input.trim() {
-        "0" => None,
+        "" => None,
         i => Some(i.to_string()),
     }
 }
 
 fn ask_sink_id() -> String {
-    println!("Enter the output 'sink' and press <Enter>");
-    println!("- Use 0 for the default audio output device");
+    println!("Enter the output 'device_id' and press <Enter>");
+    println!("- type 'none' to disable the output");
+    println!("- Leave empty ('') for the default audio output device");
 
-    let input = std::io::stdin().lines().next().unwrap().unwrap();
-    match input.trim() {
-        "0" => "none".to_string(),
-        i => i.to_string(),
-    }
+    std::io::stdin().lines().next().unwrap().unwrap()
 }
 
 struct AtomicF64 {

--- a/examples/sink_id.rs
+++ b/examples/sink_id.rs
@@ -16,14 +16,10 @@ use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
 
 fn ask_sink_id() -> String {
     println!("Enter the output 'device_id' and press <Enter>");
-    println!("- Leave empty for AudioSinkType 'none'");
-    println!("- Use 0 for the default audio output device");
+    println!("- type 'none' to disable the output");
+    println!("- Leave empty ('') for the default audio output device");
 
-    let input = std::io::stdin().lines().next().unwrap().unwrap();
-    match input.trim() {
-        "0" => "none".to_string(),
-        i => i.to_string(),
-    }
+    std::io::stdin().lines().next().unwrap().unwrap()
 }
 
 fn main() {


### PR DESCRIPTION
I think we had it mixed up in some cases

Use empty ('') for default device
Use 'none' to disable the output device (not for inputs)