### PR TITLE
Perf - use `ArrayVec` instead of `Vec` for internal `AudioParam` buffer

### DIFF
--- a/src/param.rs
+++ b/src/param.rs
@@ -1088,11 +1088,11 @@ impl AudioParamProcessor {
             match some_event {
                 None => {
                     if is_a_rate {
-                        let buffer = [self.intrinsic_value; RENDER_QUANTUM_SIZE];
-                        // we don't use `buffer.remaining_capacity` to correctly handle
-                        // the tests where `count` is lower than RENDER_QUANTUM_SIZE
-                        let remaining = count - self.buffer.len();
-                        let _ = self.buffer.try_extend_from_slice(&buffer[..remaining]);
+                        // @todo(perf) - consider using try_extend_from_slice
+                        // which internally uses ptr::copy_nonoverlapping
+                        for _ in self.buffer.len()..count {
+                            self.buffer.push(self.intrinsic_value);
+                        }
                     }
                     break;
                 }

--- a/src/param.rs
+++ b/src/param.rs
@@ -1088,6 +1088,9 @@ impl AudioParamProcessor {
             match some_event {
                 None => {
                     if is_a_rate {
+                        // @note - we use `count` rather then `buffer.remaining_capacity`
+                        // to correctly unit tests where `count` is lower than RENDER_QUANTUM_SIZE
+                        //
                         // @todo(perf) - consider using try_extend_from_slice
                         // which internally uses ptr::copy_nonoverlapping
                         for _ in self.buffer.len()..count {

--- a/src/param.rs
+++ b/src/param.rs
@@ -672,7 +672,7 @@ impl AudioProcessor for AudioParamProcessor {
 impl AudioParamProcessor {
     // Warning: compute_intrinsic_values in called directly in the unit tests so
     // everything important for the tests should be done here
-    // The returned value is used in tests is only used in tests
+    // The returned value is only used in tests
     fn compute_intrinsic_values(&mut self, block_time: f64, dt: f64, count: usize) -> &[f32] {
         self.compute_buffer(block_time, dt, count);
         self.buffer.as_slice()


### PR DESCRIPTION
cf. #359