### PR TITLE
Propagate changes to node's ChannelConfig via the main message bus

### DIFF
--- a/src/context/concrete_base.rs
+++ b/src/context/concrete_base.rs
@@ -128,7 +128,7 @@ impl BaseAudioContext for ConcreteBaseAudioContext {
             node: render,
             inputs: node.number_of_inputs(),
             outputs: node.number_of_outputs(),
-            channel_config: node.channel_config().clone(),
+            channel_config: node.channel_config().inner(),
         };
 
         // if this is the AudioListener or its params, do not add it to the graph just yet

--- a/src/message.rs
+++ b/src/message.rs
@@ -3,7 +3,7 @@
 use std::any::Any;
 
 use crate::context::AudioNodeId;
-use crate::node::ChannelConfig;
+use crate::node::{ChannelConfigInner, ChannelCountMode, ChannelInterpretation};
 use crate::render::graph::Graph;
 use crate::render::AudioProcessor;
 
@@ -16,7 +16,7 @@ pub(crate) enum ControlMessage {
         node: Box<dyn AudioProcessor>,
         inputs: usize,
         outputs: usize,
-        channel_config: ChannelConfig,
+        channel_config: ChannelConfigInner,
     },
 
     /// Connect a node to another in the audio graph
@@ -64,6 +64,21 @@ pub(crate) enum ControlMessage {
 
     /// Request a diagnostic report of the audio graph
     RunDiagnostics { buffer: Vec<u8> },
+
+    /// Update the channel count of a node
+    SetChannelCount { id: AudioNodeId, count: usize },
+
+    /// Update the channel count mode of a node
+    SetChannelCountMode {
+        id: AudioNodeId,
+        mode: ChannelCountMode,
+    },
+
+    /// Update the channel interpretation of a node
+    SetChannelInterpretation {
+        id: AudioNodeId,
+        interpretation: ChannelInterpretation,
+    },
 }
 
 /// Helper object to emit single notification

--- a/src/node/channel_merger.rs
+++ b/src/node/channel_merger.rs
@@ -80,12 +80,13 @@ impl AudioNode for ChannelMergerNode {
 
     fn set_channel_count(&self, count: usize) {
         assert_valid_channel_count(count);
-        self.channel_config.set_count(count);
+        self.channel_config.set_count(count, self.registration());
     }
 
     fn set_channel_count_mode(&self, mode: ChannelCountMode) {
         assert_valid_channel_count_mode(mode);
-        self.channel_config.set_count_mode(mode);
+        self.channel_config
+            .set_count_mode(mode, self.registration());
     }
 
     fn number_of_inputs(&self) -> usize {

--- a/src/node/channel_splitter.rs
+++ b/src/node/channel_splitter.rs
@@ -87,12 +87,14 @@ impl AudioNode for ChannelSplitterNode {
 
     fn set_channel_count_mode(&self, mode: ChannelCountMode) {
         assert_valid_channel_count_mode(mode);
-        self.channel_config.set_count_mode(mode);
+        self.channel_config
+            .set_count_mode(mode, self.registration());
     }
 
     fn set_channel_interpretation(&self, interpretation: ChannelInterpretation) {
         assert_valid_channel_interpretation(interpretation);
-        self.channel_config.set_interpretation(interpretation);
+        self.channel_config
+            .set_interpretation(interpretation, self.registration());
     }
 
     fn number_of_inputs(&self) -> usize {

--- a/src/node/destination.rs
+++ b/src/node/destination.rs
@@ -75,7 +75,7 @@ impl AudioNode for AudioDestinationNode {
             "InvalidStateError - AudioDestinationNode has channel count mode constraints",
         );
 
-        self.channel_config.set_count_mode(v);
+        self.channel_config.set_count_mode(v, self.registration());
     }
 }
 

--- a/src/node/destination.rs
+++ b/src/node/destination.rs
@@ -61,7 +61,7 @@ impl AudioNode for AudioDestinationNode {
                 self.max_channel_count()
             );
         }
-        self.channel_config.set_count(v);
+        self.channel_config.set_count(v, self.registration());
     }
     fn set_channel_count_mode(&self, _v: ChannelCountMode) {
         // [spec] If the AudioDestinationNode is the destination node of an

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1,10 +1,10 @@
 //! The AudioNode interface and concrete types
 use std::f32::consts::PI;
-use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::context::{AudioContextRegistration, ConcreteBaseAudioContext};
 use crate::events::{ErrorEvent, EventHandler, EventPayload, EventType};
+use crate::message::ControlMessage;
 use crate::render::{AudioParamValues, AudioProcessor, AudioRenderQuantum, RenderScope};
 use crate::AudioBufferIter;
 use crate::Event;
@@ -153,14 +153,14 @@ impl Default for ChannelConfigOptions {
 /// let _: ChannelConfig = opts.into();
 #[derive(Clone, Debug)]
 pub struct ChannelConfig {
-    inner: Arc<ChannelConfigInner>,
+    inner: Arc<Mutex<ChannelConfigInner>>,
 }
 
-#[derive(Debug)]
-struct ChannelConfigInner {
-    count: AtomicUsize,
-    count_mode: AtomicU32,
-    interpretation: AtomicU32,
+#[derive(Debug, Clone)]
+pub(crate) struct ChannelConfigInner {
+    pub(crate) count: usize,
+    pub(crate) count_mode: ChannelCountMode,
+    pub(crate) interpretation: ChannelInterpretation,
 }
 
 impl Default for ChannelConfig {
@@ -180,32 +180,58 @@ impl ChannelConfig {
     /// Represents an enumerated value describing the way channels must be matched between the
     /// node's inputs and outputs.
     pub(crate) fn count_mode(&self) -> ChannelCountMode {
-        self.inner.count_mode.load(Ordering::Acquire).into()
+        self.inner.lock().unwrap().count_mode
     }
 
-    fn set_count_mode(&self, v: ChannelCountMode) {
-        self.inner.count_mode.store(v as u32, Ordering::Release)
+    fn set_count_mode(&self, v: ChannelCountMode, registration: &AudioContextRegistration) {
+        self.inner.lock().unwrap().count_mode = v;
+
+        let message = ControlMessage::SetChannelCountMode {
+            id: registration.id(),
+            mode: v,
+        };
+        registration.context().send_control_msg(message);
     }
 
     /// Represents an enumerated value describing the meaning of the channels. This interpretation
     /// will define how audio up-mixing and down-mixing will happen.
     pub(crate) fn interpretation(&self) -> ChannelInterpretation {
-        self.inner.interpretation.load(Ordering::Acquire).into()
+        self.inner.lock().unwrap().interpretation
     }
 
-    fn set_interpretation(&self, v: ChannelInterpretation) {
-        self.inner.interpretation.store(v as u32, Ordering::Release)
+    fn set_interpretation(
+        &self,
+        v: ChannelInterpretation,
+        registration: &AudioContextRegistration,
+    ) {
+        self.inner.lock().unwrap().interpretation = v;
+
+        let message = ControlMessage::SetChannelInterpretation {
+            id: registration.id(),
+            interpretation: v,
+        };
+        registration.context().send_control_msg(message);
     }
 
     /// Represents an integer used to determine how many channels are used when up-mixing and
     /// down-mixing connections to any inputs to the node.
     pub(crate) fn count(&self) -> usize {
-        self.inner.count.load(Ordering::Acquire)
+        self.inner.lock().unwrap().count
     }
 
-    fn set_count(&self, v: usize) {
+    fn set_count(&self, v: usize, registration: &AudioContextRegistration) {
         crate::assert_valid_number_of_channels(v);
-        self.inner.count.store(v, Ordering::Release)
+        self.inner.lock().unwrap().count = v;
+
+        let message = ControlMessage::SetChannelCount {
+            id: registration.id(),
+            count: v,
+        };
+        registration.context().send_control_msg(message);
+    }
+
+    pub(crate) fn inner(&self) -> ChannelConfigInner {
+        self.inner.lock().unwrap().clone()
     }
 }
 
@@ -214,12 +240,12 @@ impl From<ChannelConfigOptions> for ChannelConfig {
         crate::assert_valid_number_of_channels(opts.count);
 
         let inner = ChannelConfigInner {
-            count: AtomicUsize::from(opts.count),
-            count_mode: AtomicU32::from(opts.count_mode as u32),
-            interpretation: AtomicU32::from(opts.interpretation as u32),
+            count: opts.count,
+            count_mode: opts.count_mode,
+            interpretation: opts.interpretation,
         };
         Self {
-            inner: Arc::new(inner),
+            inner: Arc::new(Mutex::new(inner)),
         }
     }
 }
@@ -317,7 +343,7 @@ pub trait AudioNode {
 
     /// Update the `channel_count_mode` attribute
     fn set_channel_count_mode(&self, v: ChannelCountMode) {
-        self.channel_config().set_count_mode(v)
+        self.channel_config().set_count_mode(v, self.registration())
     }
 
     /// Represents an enumerated value describing the meaning of the channels. This interpretation
@@ -328,7 +354,8 @@ pub trait AudioNode {
 
     /// Update the `channel_interpretation` attribute
     fn set_channel_interpretation(&self, v: ChannelInterpretation) {
-        self.channel_config().set_interpretation(v)
+        self.channel_config()
+            .set_interpretation(v, self.registration())
     }
     /// Represents an integer used to determine how many channels are used when up-mixing and
     /// down-mixing connections to any inputs to the node.
@@ -338,7 +365,7 @@ pub trait AudioNode {
 
     /// Update the `channel_count` attribute
     fn set_channel_count(&self, v: usize) {
-        self.channel_config().set_count(v)
+        self.channel_config().set_count(v, self.registration())
     }
 
     /// Register callback to run when an unhandled exception occurs in the audio processor.

--- a/src/node/panner.rs
+++ b/src/node/panner.rs
@@ -342,12 +342,13 @@ impl AudioNode for PannerNode {
     // see: https://webaudio.github.io/web-audio-api/#panner-channel-limitations
     fn set_channel_count(&self, count: usize) {
         assert_valid_channel_count(count);
-        self.channel_config.set_count(count);
+        self.channel_config.set_count(count, self.registration());
     }
 
     fn set_channel_count_mode(&self, mode: ChannelCountMode) {
         assert_valid_channel_count_mode(mode);
-        self.channel_config.set_count_mode(mode);
+        self.channel_config
+            .set_count_mode(mode, self.registration());
     }
 }
 

--- a/src/node/stereo_panner.rs
+++ b/src/node/stereo_panner.rs
@@ -145,12 +145,13 @@ impl AudioNode for StereoPannerNode {
 
     fn set_channel_count_mode(&self, mode: ChannelCountMode) {
         assert_valid_channel_count_mode(mode);
-        self.channel_config.set_count_mode(mode);
+        self.channel_config
+            .set_count_mode(mode, self.registration());
     }
 
     fn set_channel_count(&self, count: usize) {
         assert_valid_channel_count(count);
-        self.channel_config.set_count(count);
+        self.channel_config.set_count(count, self.registration());
     }
 }
 

--- a/src/render/graph.rs
+++ b/src/render/graph.rs
@@ -7,7 +7,7 @@ use crate::context::AudioNodeId;
 use smallvec::{smallvec, SmallVec};
 
 use super::{Alloc, AudioParamValues, AudioProcessor, AudioRenderQuantum, NodeCollection};
-use crate::node::ChannelConfig;
+use crate::node::{ChannelConfigInner, ChannelCountMode, ChannelInterpretation};
 use crate::render::RenderScope;
 
 /// Connection between two audio nodes
@@ -46,7 +46,7 @@ pub struct Node {
     /// Reusable output buffers, consumed by subsequent Nodes in this graph
     outputs: Vec<AudioRenderQuantum>,
     /// Channel configuration: determines up/down-mixing of inputs
-    channel_config: ChannelConfig,
+    channel_config: ChannelConfigInner,
     /// Outgoing edges: tuple of outcoming node reference, our output index and their input index
     outgoing_edges: SmallVec<[OutgoingEdge; 2]>,
     /// Indicates if the control thread has dropped this Node
@@ -163,7 +163,7 @@ impl Graph {
         processor: Box<dyn AudioProcessor>,
         number_of_inputs: usize,
         number_of_outputs: usize,
-        channel_config: ChannelConfig,
+        channel_config: ChannelConfigInner,
     ) {
         // todo: pre-allocate the buffers on the control thread
 
@@ -238,6 +238,16 @@ impl Graph {
 
     pub fn mark_cycle_breaker(&mut self, index: AudioNodeId) {
         self.nodes[index].get_mut().cycle_breaker = true;
+    }
+
+    pub fn set_channel_count(&mut self, index: AudioNodeId, v: usize) {
+        self.nodes[index].get_mut().channel_config.count = v;
+    }
+    pub fn set_channel_count_mode(&mut self, index: AudioNodeId, v: ChannelCountMode) {
+        self.nodes[index].get_mut().channel_config.count_mode = v;
+    }
+    pub fn set_channel_interpretation(&mut self, index: AudioNodeId, v: ChannelInterpretation) {
+        self.nodes[index].get_mut().channel_config.interpretation = v;
     }
 
     pub fn route_message(&mut self, index: AudioNodeId, msg: &mut dyn Any) {
@@ -419,8 +429,8 @@ impl Graph {
 
             // make sure all input buffers have the correct number of channels, this might not be
             // the case if the node has no inputs connected or the channel count has just changed
-            let interpretation = node.channel_config.interpretation();
-            let count = node.channel_config.count();
+            let interpretation = node.channel_config.interpretation;
+            let count = node.channel_config.count;
             node.inputs
                 .iter_mut()
                 .for_each(|i| i.mix(count, interpretation));
@@ -553,13 +563,12 @@ mod tests {
         }
     }
 
-    fn config() -> ChannelConfig {
-        crate::node::ChannelConfigOptions {
+    fn config() -> ChannelConfigInner {
+        ChannelConfigInner {
             count: 2,
             count_mode: crate::node::ChannelCountMode::Explicit,
             interpretation: crate::node::ChannelInterpretation::Speakers,
         }
-        .into()
     }
 
     fn add_node(graph: &mut Graph, id: u64, node: Box<dyn AudioProcessor>) {

--- a/src/render/quantum.rs
+++ b/src/render/quantum.rs
@@ -3,7 +3,7 @@ use arrayvec::ArrayVec;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use crate::node::{ChannelConfig, ChannelCountMode, ChannelInterpretation};
+use crate::node::{ChannelConfigInner, ChannelCountMode, ChannelInterpretation};
 
 use crate::assert_valid_number_of_channels;
 use crate::{MAX_CHANNELS, RENDER_QUANTUM_SIZE};
@@ -620,16 +620,16 @@ impl AudioRenderQuantum {
     /// Sum two `AudioRenderQuantum`s
     ///
     /// Both buffers will be mixed up front according to the supplied `channel_config`
-    pub(crate) fn add(&mut self, other: &Self, channel_config: &ChannelConfig) {
+    pub(crate) fn add(&mut self, other: &Self, channel_config: &ChannelConfigInner) {
         // gather initial channel counts
         let channels_self = self.number_of_channels();
         let channels_other = other.number_of_channels();
         let max_channels = channels_self.max(channels_other);
 
         // up/down-mix the to the desired channel count for the receiving node
-        let interpretation = channel_config.interpretation();
-        let mode = channel_config.count_mode();
-        let count = channel_config.count();
+        let interpretation = channel_config.interpretation;
+        let mode = channel_config.count_mode;
+        let count = channel_config.count;
 
         let new_channels = match mode {
             ChannelCountMode::Max => max_channels,
@@ -1542,12 +1542,11 @@ mod tests {
         signal2.copy_from_slice(&[2.; RENDER_QUANTUM_SIZE]);
         let buffer2 = AudioRenderQuantum::from(signal2);
 
-        let channel_config = crate::node::ChannelConfigOptions {
+        let channel_config = ChannelConfigInner {
             count: 2,
             count_mode: ChannelCountMode::Explicit,
             interpretation: ChannelInterpretation::Discrete,
-        }
-        .into();
+        };
 
         buffer.add(&buffer2, &channel_config);
 

--- a/src/render/thread.rs
+++ b/src/render/thread.rs
@@ -198,6 +198,24 @@ impl RenderThread {
                     self.set_state(AudioContextState::Closed);
                     notify.send();
                 }
+
+                SetChannelCount { id, count } => {
+                    self.graph.as_mut().unwrap().set_channel_count(id, count);
+                }
+
+                SetChannelCountMode { id, mode } => {
+                    self.graph
+                        .as_mut()
+                        .unwrap()
+                        .set_channel_count_mode(id, mode);
+                }
+
+                SetChannelInterpretation { id, interpretation } => {
+                    self.graph
+                        .as_mut()
+                        .unwrap()
+                        .set_channel_interpretation(id, interpretation);
+                }
             }
         }
     }


### PR DESCRIPTION
To prevent out of order arrival with other node settings.

For simplicity, I left the interior mutability pattern of the channel config but instead of using atomics, a mutex is used now. This should be fixed later to take &mut references to the node's channel config.