### PR TITLE
Async deallocations

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -66,8 +66,8 @@ pub struct AudioBufferOptions {
 ///
 #[derive(Clone, Debug)]
 pub struct AudioBuffer {
-    pub(crate) channels: Vec<ChannelData>,
-    pub(crate) sample_rate: f32,
+    channels: Vec<ChannelData>,
+    sample_rate: f32,
 }
 
 impl AudioBuffer {
@@ -88,6 +88,14 @@ impl AudioBuffer {
         Self {
             channels: vec![silence; options.number_of_channels],
             sample_rate: options.sample_rate,
+        }
+    }
+
+    /// Creates an invalid, but non-allocating AudioBuffer to be used as placeholder
+    pub(crate) fn tombstone() -> Self {
+        Self {
+            channels: Default::default(),
+            sample_rate: Default::default(),
         }
     }
 


### PR DESCRIPTION
Apologies for the messy proof of concept. Furthermore, this is untested. But I hope it gives some idea!
When I have a bit more time I will make it more performant, more readable and perhaps add testcases that actually validate no (de)allocations take place in the render thread*

* as an aside, there are some more possible (de)allocations we need to look at. Such as resizing of the main hashmap that holds the nodes, and the edge vectors, etc