### PR TITLE
Don't merge: experimenting towards allocator-free rendering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,9 @@ rustc-hash = "1.1"
 smallvec = "1.11"
 symphonia = { version = "0.5", default-features = false }
 vecmath = "1.0"
+assert_no_alloc = { git = "https://github.com/Windfisch/rust-assert-no-alloc/", default-features = false, features = ["backtrace"] }
 
 [dev-dependencies]
-alloc_counter = "0.0.4"
 env_logger = "0.10"
 iai = "0.1.1"
 rand = "0.8"

--- a/examples/audio_buffer_source_events.rs
+++ b/examples/audio_buffer_source_events.rs
@@ -41,6 +41,7 @@ fn main() {
     let now = context.current_time();
     src.start_at(now);
     src.stop_at(now + 1.);
+    drop(src);
 
     std::thread::sleep(std::time::Duration::from_secs(4));
 }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -66,8 +66,8 @@ pub struct AudioBufferOptions {
 ///
 #[derive(Clone, Debug)]
 pub struct AudioBuffer {
-    pub(crate) channels: Vec<ChannelData>,
-    pub(crate) sample_rate: f32,
+    channels: Vec<ChannelData>,
+    sample_rate: f32,
 }
 
 impl AudioBuffer {
@@ -88,6 +88,14 @@ impl AudioBuffer {
         Self {
             channels: vec![silence; options.number_of_channels],
             sample_rate: options.sample_rate,
+        }
+    }
+
+    /// Creates an invalid, but non-allocating AudioBuffer to be used as placeholder
+    pub(crate) fn tombstone() -> Self {
+        Self {
+            channels: Default::default(),
+            sample_rate: Default::default(),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,9 @@
 #![warn(clippy::clone_on_ref_ptr)]
 #![deny(trivial_numeric_casts)]
 
+#[global_allocator]
+static A: assert_no_alloc::AllocDisabler = assert_no_alloc::AllocDisabler;
+
 use std::error::Error;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 

--- a/src/param.rs
+++ b/src/param.rs
@@ -128,7 +128,7 @@ struct AudioParamEventTimeline {
 impl AudioParamEventTimeline {
     fn new() -> Self {
         Self {
-            inner: Vec::new(),
+            inner: Vec::with_capacity(5),
             dirty: false,
         }
     }

--- a/src/render/quantum.rs
+++ b/src/render/quantum.rs
@@ -681,7 +681,7 @@ mod tests {
         let alloc = Alloc::with_capacity(2);
         assert_eq!(alloc.pool_size(), 2);
 
-        alloc_counter::deny_alloc(|| {
+        assert_no_alloc::assert_no_alloc(|| {
             {
                 // take a buffer out of the pool
                 let a = alloc.allocate();
@@ -712,7 +712,7 @@ mod tests {
                 let a = alloc.allocate();
                 let b = alloc.allocate();
 
-                let c = alloc_counter::allow_alloc(|| {
+                let c = assert_no_alloc::permit_alloc(|| {
                     // we can allocate beyond the pool size
                     let c = alloc.allocate();
                     assert_eq!(alloc.pool_size(), 0);
@@ -728,7 +728,7 @@ mod tests {
             };
 
             // dropping c will cause a re-allocation: the pool capacity is extended
-            alloc_counter::allow_alloc(move || {
+            assert_no_alloc::permit_alloc(move || {
                 std::mem::drop(c);
             });
 


### PR DESCRIPTION
The goal is to run `cargo run --example audio_buffer_source_events` without failing for now.
It shows that the #366 works like intended, there is no deallocation of the audio buffer taking place.
But this PR made me realize we also need to look into all `Arc<..>` items of renderers, because it now fails with
```
  13: <alloc::sync::Arc<T> as core::ops::drop::Drop>::drop
             at /rustc/d5c2e9c342b358556da91d61ed4133f6f50fc0c3/library/alloc/src/sync.rs:1897:13
  14: core::ptr::drop_in_place<alloc::sync::Arc<web_audio_api::AtomicF64>>
             at /rustc/d5c2e9c342b358556da91d61ed4133f6f50fc0c3/library/core/src/ptr/mod.rs:497:1
```

And then there's still more issues to look at (`Box<dyn AudioProcessor>` for example)