### PR TITLE
Improve HRTF panner initialization time by caching the HRIR sphere

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ cubeb = { version = "0.10", optional = true }
 dasp_sample = "0.11"
 float_eq = "1.0"
 hound = "3.5"
-hrtf = "0.8"
+hrtf = "0.8.1"
 llq = "0.1.1"
 log = "0.4"
 num-complex = "0.4"

--- a/benches/my_benchmark.rs
+++ b/benches/my_benchmark.rs
@@ -2,8 +2,7 @@ use iai::black_box;
 
 use web_audio_api::context::BaseAudioContext;
 use web_audio_api::context::OfflineAudioContext;
-use web_audio_api::node::AudioNode;
-use web_audio_api::node::AudioScheduledSourceNode;
+use web_audio_api::node::{AudioNode, AudioScheduledSourceNode, PanningModelType};
 
 const SAMPLE_RATE: f32 = 48000.;
 const DURATION: usize = 10;
@@ -197,6 +196,27 @@ pub fn bench_analyser_node() {
     assert_eq!(ctx.start_rendering_sync().length(), SAMPLES);
 }
 
+pub fn bench_hrtf_panners() {
+    let ctx = OfflineAudioContext::new(2, black_box(SAMPLES), SAMPLE_RATE);
+
+    let mut panner1 = ctx.create_panner();
+    panner1.set_panning_model(PanningModelType::HRTF);
+    panner1.position_x().set_value(10.0);
+    panner1.connect(&ctx.destination());
+
+    let mut panner2 = ctx.create_panner();
+    panner2.set_panning_model(PanningModelType::HRTF);
+    panner2.position_x().set_value(-10.0);
+    panner2.connect(&ctx.destination());
+
+    let mut osc = ctx.create_oscillator();
+    osc.connect(&panner1);
+    osc.connect(&panner2);
+    osc.start();
+
+    assert_eq!(ctx.start_rendering_sync().length(), SAMPLES);
+}
+
 iai::main!(
     bench_ctor,
     bench_sine,
@@ -209,4 +229,5 @@ iai::main!(
     bench_stereo_positional,
     bench_stereo_panning_automation,
     bench_analyser_node,
+    bench_hrtf_panners,
 );

--- a/src/node/panner.rs
+++ b/src/node/panner.rs
@@ -1,5 +1,7 @@
 use std::any::Any;
+use std::collections::HashMap;
 use std::f32::consts::PI;
+use std::sync::{Mutex, OnceLock};
 
 use float_eq::float_eq;
 use hrtf::{HrirSphere, HrtfContext, HrtfProcessor, Vec3};
@@ -12,6 +14,24 @@ use crate::RENDER_QUANTUM_SIZE;
 use super::{
     AudioNode, ChannelConfig, ChannelConfigOptions, ChannelCountMode, ChannelInterpretation,
 };
+
+/// Load the HRIR sphere for the given sample_rate
+///
+/// The included data contains the impulse responses at 44100 Hertz, so it needs to be resampled
+/// for other values (which can easily take 100s of milliseconds). Therefore cache the result (per
+/// sample rate) in a global variable and clone it every time a new panner is created.
+fn load_hrir_sphere(sample_rate: u32) -> HrirSphere {
+    static INSTANCE: OnceLock<Mutex<HashMap<u32, HrirSphere>>> = OnceLock::new();
+    let cache = INSTANCE.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut guard = cache.lock().unwrap();
+    guard
+        .entry(sample_rate)
+        .or_insert_with(|| {
+            let resource = include_bytes!("../../resources/IRC_1003_C.bin");
+            HrirSphere::new(&resource[..], sample_rate).unwrap()
+        })
+        .clone()
+}
 
 /// Spatialization algorithm used to position the audio in 3D space
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
@@ -549,9 +569,8 @@ impl PannerNode {
         let hrtf_option = match value {
             PanningModelType::EqualPower => None,
             PanningModelType::HRTF => {
-                let resource = include_bytes!("../../resources/IRC_1003_C.bin");
                 let sample_rate = self.context().sample_rate() as u32;
-                let hrir_sphere = HrirSphere::new(&resource[..], sample_rate).unwrap();
+                let hrir_sphere = load_hrir_sphere(sample_rate);
                 Some(HrtfState::new(hrir_sphere))
             }
         };

--- a/src/node/panner.rs
+++ b/src/node/panner.rs
@@ -20,7 +20,7 @@ use super::{
 /// The included data contains the impulse responses at 44100 Hertz, so it needs to be resampled
 /// for other values (which can easily take 100s of milliseconds). Therefore cache the result (per
 /// sample rate) in a global variable and clone it every time a new panner is created.
-fn load_hrtf_processor(sample_rate: u32) -> (HrtfProcessor, usize) {
+pub(crate) fn load_hrtf_processor(sample_rate: u32) -> (HrtfProcessor, usize) {
     static INSTANCE: OnceLock<Mutex<HashMap<u32, (HrtfProcessor, usize)>>> = OnceLock::new();
     let cache = INSTANCE.get_or_init(|| Mutex::new(HashMap::new()));
     let mut guard = cache.lock().unwrap();


### PR DESCRIPTION
relates to #371