### PR TITLE
Experiment: store nodes in contiguous Vec instead of HashMap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ no_denormals = "0.1.2"
 num-complex = "0.4"
 realfft = "3.3"
 rubato = "0.14"
-rustc-hash = "1.1"
 smallvec = "1.11"
 symphonia = { version = "0.5", default-features = false }
 vecmath = "1.0"

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -43,7 +43,7 @@ pub(crate) struct AudioNodeId(pub u64);
 ///
 /// Store these in your `AudioProcessor` to get access to `AudioParam` values.
 #[derive(Debug)]
-pub struct AudioParamId(pub(crate) u64);
+pub struct AudioParamId(u64);
 
 // bit contrived, but for type safety only the context mod can access the inner u64
 impl From<&AudioParamId> for AudioNodeId {

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -43,7 +43,7 @@ pub(crate) struct AudioNodeId(pub u64);
 ///
 /// Store these in your `AudioProcessor` to get access to `AudioParam` values.
 #[derive(Debug)]
-pub struct AudioParamId(u64);
+pub struct AudioParamId(pub(crate) u64);
 
 // bit contrived, but for type safety only the context mod can access the inner u64
 impl From<&AudioParamId> for AudioNodeId {

--- a/src/context/offline.rs
+++ b/src/context/offline.rs
@@ -43,7 +43,8 @@ impl OfflineAudioContext {
         // unbounded is fine because it does not need to be realtime safe
         let (sender, receiver) = crossbeam_channel::unbounded();
 
-        let graph = crate::render::graph::Graph::new();
+        let (node_id_producer, node_id_consumer) = llq::Queue::new().split();
+        let graph = crate::render::graph::Graph::new(node_id_producer);
         let message = crate::message::ControlMessage::Startup { graph };
         sender.send(message).unwrap();
 
@@ -67,6 +68,7 @@ impl OfflineAudioContext {
             sender,
             None,
             true,
+            node_id_consumer,
         );
 
         Self {

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -173,7 +173,8 @@ impl AudioContext {
             event_recv,
         } = control_thread_init;
 
-        let graph = Graph::new();
+        let (node_id_producer, node_id_consumer) = llq::Queue::new().split();
+        let graph = Graph::new(node_id_producer);
         let message = ControlMessage::Startup { graph };
         ctrl_msg_send.send(message).unwrap();
 
@@ -184,6 +185,7 @@ impl AudioContext {
             ctrl_msg_send,
             Some((event_send, event_recv)),
             false,
+            node_id_consumer,
         );
         base.set_state(AudioContextState::Running);
 

--- a/src/media_devices/mod.rs
+++ b/src/media_devices/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! <https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices>
 
-use rustc_hash::FxHasher;
+use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
 use crate::context::{AudioContextLatencyCategory, AudioContextOptions};
@@ -54,7 +54,7 @@ impl DeviceId {
             index,
         };
 
-        let mut hasher = FxHasher::default();
+        let mut hasher = DefaultHasher::new();
         device_info.hash(&mut hasher);
         format!("{}", hasher.finish())
     }

--- a/src/message.rs
+++ b/src/message.rs
@@ -14,6 +14,7 @@ pub(crate) enum ControlMessage {
     /// Register a new node in the audio graph
     RegisterNode {
         id: AudioNodeId,
+        reclaim_id: llq::Node<AudioNodeId>,
         node: Box<dyn AudioProcessor>,
         inputs: usize,
         outputs: usize,

--- a/src/render/graph.rs
+++ b/src/render/graph.rs
@@ -130,7 +130,6 @@ impl Graph {
         let inputs = vec![AudioRenderQuantum::from(self.alloc.silence()); number_of_inputs];
         let outputs = vec![AudioRenderQuantum::from(self.alloc.silence()); number_of_outputs];
 
-        let index = index.0 as usize;
         self.nodes.insert(
             index,
             RefCell::new(Node {
@@ -148,7 +147,7 @@ impl Graph {
     }
 
     pub fn add_edge(&mut self, source: (AudioNodeId, usize), dest: (AudioNodeId, usize)) {
-        self.nodes[source.0 .0 as usize]
+        self.nodes[source.0]
             .get_mut()
             .outgoing_edges
             .push(OutgoingEdge {
@@ -161,7 +160,7 @@ impl Graph {
     }
 
     pub fn remove_edge(&mut self, source: AudioNodeId, dest: AudioNodeId) {
-        self.nodes[source.0 as usize]
+        self.nodes[source]
             .get_mut()
             .outgoing_edges
             .retain(|edge| edge.other_id != dest);
@@ -170,10 +169,7 @@ impl Graph {
     }
 
     pub fn remove_edges_from(&mut self, source: AudioNodeId) {
-        self.nodes[source.0 as usize]
-            .get_mut()
-            .outgoing_edges
-            .clear();
+        self.nodes[source].get_mut().outgoing_edges.clear();
 
         self.nodes.values_mut().for_each(|node| {
             node.get_mut()
@@ -188,20 +184,17 @@ impl Graph {
         // Issue #92, a race condition can occur for AudioParams. They may have already been
         // removed from the audio graph if the node they feed into was dropped.
         // Therefore, do not assume this node still exists:
-        if let Some(node) = self.nodes.get_mut(index.0 as usize) {
+        if let Some(node) = self.nodes.get_mut(index) {
             node.get_mut().free_when_finished = true;
         }
     }
 
     pub fn mark_cycle_breaker(&mut self, index: AudioNodeId) {
-        self.nodes[index.0 as usize].get_mut().cycle_breaker = true;
+        self.nodes[index].get_mut().cycle_breaker = true;
     }
 
     pub fn route_message(&mut self, index: AudioNodeId, msg: &mut dyn Any) {
-        self.nodes[index.0 as usize]
-            .get_mut()
-            .processor
-            .onmessage(msg);
+        self.nodes[index].get_mut().processor.onmessage(msg);
     }
 
     /// Helper function for `order_nodes` - traverse node and outgoing edges
@@ -224,7 +217,7 @@ impl Graph {
             let cycle_breaker_node = marked_temp
                 .iter()
                 .skip(pos)
-                .find(|node_id| self.nodes[node_id.0 as usize].borrow().cycle_breaker);
+                .find(|&&node_id| self.nodes[node_id].borrow().cycle_breaker);
 
             match cycle_breaker_node {
                 Some(&node_id) => {
@@ -253,11 +246,7 @@ impl Graph {
         marked_temp.push(node_id);
 
         // Visit outgoing nodes, and call `visit` on them recursively
-        for edge in self.nodes[node_id.0 as usize]
-            .borrow()
-            .outgoing_edges
-            .iter()
-        {
+        for edge in self.nodes[node_id].borrow().outgoing_edges.iter() {
             let cycle_breaker_applied = self.visit(
                 edge.other_id,
                 marked,
@@ -319,7 +308,7 @@ impl Graph {
             // since the audio graph could contain legs detached from the destination and those should
             // still be rendered.
             let mut cycle_breaker_applied = false;
-            for node_id in self.nodes.keys().map(|i| AudioNodeId(i as u64)) {
+            for node_id in self.nodes.keys() {
                 cycle_breaker_applied = self.visit(
                     node_id,
                     &mut marked,
@@ -338,7 +327,7 @@ impl Graph {
                 // clear the outgoing edges of the nodes that have been recognized as cycle breaker
                 let nodes = &mut self.nodes;
                 cycle_breakers.iter().for_each(|node_id| {
-                    nodes[node_id.0 as usize].get_mut().outgoing_edges.clear();
+                    nodes[*node_id].get_mut().outgoing_edges.clear();
                 });
 
                 continue;
@@ -379,7 +368,7 @@ impl Graph {
         // process every node, in topological sorted order
         self.ordered.iter().for_each(|index| {
             // acquire a mutable borrow of the current processing node
-            let mut node = nodes[index.0 as usize].borrow_mut();
+            let mut node = nodes[*index].borrow_mut();
 
             // make sure all input buffers have the correct number of channels, this might not be
             // the case if the node has no inputs connected or the channel count has just changed
@@ -414,7 +403,7 @@ impl Graph {
                 // audio params are connected to the 'hidden' usize::MAX output, ignore them here
                 .filter(|edge| edge.other_index != usize::MAX)
                 .for_each(|edge| {
-                    let mut output_node = nodes[edge.other_id.0 as usize].borrow_mut();
+                    let mut output_node = nodes[edge.other_id].borrow_mut();
                     output_node.has_inputs_connected = true;
                     let signal = &node.outputs[edge.self_index];
                     let channel_config = &output_node.channel_config.clone();
@@ -440,7 +429,7 @@ impl Graph {
             // Check if we can decommission this node (end of life)
             if can_free {
                 // Node is dropped, remove it from the node list
-                let mut node = nodes.remove(index.0 as usize).into_inner();
+                let mut node = nodes.remove(*index).into_inner();
                 self.reclaim_id_channel
                     .push(node.reclaim_id.take().unwrap());
                 drop(node);
@@ -467,7 +456,7 @@ impl Graph {
                     // - special node (destination = id 0, listener = id 1), or
                     // - not connected to this dropped node, or
                     // - if the control thread still has a handle to it.
-                    let retain = id < 2 || !was_connected || !node.free_when_finished;
+                    let retain = id.0 < 2 || !was_connected || !node.free_when_finished;
 
                     if !retain {
                         self.reclaim_id_channel
@@ -482,7 +471,7 @@ impl Graph {
         if nodes_dropped {
             let mut i = 0;
             while i < self.ordered.len() {
-                if nodes.get(self.ordered[i].0 as usize).is_none() {
+                if nodes.get(self.ordered[i]).is_none() {
                     self.ordered.remove(i);
                 } else {
                     i += 1;
@@ -491,7 +480,7 @@ impl Graph {
         }
 
         // Return the output buffer of destination node
-        &self.nodes[0].get_mut().outputs[0]
+        &self.nodes[AudioNodeId(0)].get_mut().outputs[0]
     }
 }
 
@@ -681,7 +670,7 @@ mod tests {
         // dropped and the AudioNodeId(3) should be reclaimed
         add_node(&mut graph, 2, node.clone());
         // Mark the node as 'detached from the control thread', so it is allowed to drop
-        graph.nodes[2].get_mut().free_when_finished = true;
+        graph.nodes[AudioNodeId(2)].get_mut().free_when_finished = true;
 
         // Connect the regular node to the AudioDestinationNode
         add_edge(&mut graph, 2, 0);
@@ -723,7 +712,7 @@ mod tests {
         // dropped and the AudioNodeId(3) should be reclaimed
         add_node(&mut graph, 2, node.clone());
         // Mark the node as 'detached from the control thread', so it is allowed to drop
-        graph.nodes[2].get_mut().free_when_finished = true;
+        graph.nodes[AudioNodeId(2)].get_mut().free_when_finished = true;
 
         // Connect the regular node to the AudioDestinationNode
         add_edge(&mut graph, 2, 0);
@@ -732,7 +721,7 @@ mod tests {
         let param = Box::new(TestNode { tail_time: true }); // audio params have tail time true
         add_node(&mut graph, 3, param);
         // Mark the node as 'detached from the control thread', so it is allowed to drop
-        graph.nodes[3].get_mut().free_when_finished = true;
+        graph.nodes[AudioNodeId(3)].get_mut().free_when_finished = true;
 
         // Connect the audioparam to the regular node
         add_audioparam(&mut graph, 3, 2);

--- a/src/render/graph.rs
+++ b/src/render/graph.rs
@@ -6,7 +6,7 @@ use std::panic::{self, AssertUnwindSafe};
 use crate::context::AudioNodeId;
 use smallvec::{smallvec, SmallVec};
 
-use super::{Alloc, AudioParamValues, AudioProcessor, AudioRenderQuantum};
+use super::{Alloc, AudioParamValues, AudioProcessor, AudioRenderQuantum, NodeCollection};
 use crate::node::ChannelConfig;
 use crate::render::RenderScope;
 
@@ -75,7 +75,7 @@ impl Node {
 /// The audio graph
 pub(crate) struct Graph {
     /// Processing Nodes
-    nodes: Vec<Option<RefCell<Node>>>,
+    nodes: NodeCollection,
     /// Allocator for audio buffers
     alloc: Alloc,
 
@@ -94,7 +94,7 @@ pub(crate) struct Graph {
 impl Graph {
     pub fn new() -> Self {
         Graph {
-            nodes: Vec::with_capacity(64),
+            nodes: NodeCollection::new(),
             ordered: vec![],
             marked: vec![],
             marked_temp: vec![],
@@ -126,27 +126,23 @@ impl Graph {
         let outputs = vec![AudioRenderQuantum::from(self.alloc.silence()); number_of_outputs];
 
         let index = index.0 as usize;
-        if index >= self.nodes.len() {
-            self.nodes.resize_with(index + 1, || None);
-        }
-        self.nodes[index] = Some(RefCell::new(Node {
-            processor,
-            inputs,
-            outputs,
-            channel_config,
-            outgoing_edges: smallvec![],
-            free_when_finished: false,
-            has_inputs_connected: false,
-            cycle_breaker: false,
-        }));
+        self.nodes.insert(
+            index,
+            RefCell::new(Node {
+                processor,
+                inputs,
+                outputs,
+                channel_config,
+                outgoing_edges: smallvec![],
+                free_when_finished: false,
+                has_inputs_connected: false,
+                cycle_breaker: false,
+            }),
+        );
     }
 
     pub fn add_edge(&mut self, source: (AudioNodeId, usize), dest: (AudioNodeId, usize)) {
-        self.nodes
-            .get_mut(source.0 .0 as usize)
-            .unwrap_or_else(|| panic!("cannot connect {:?} to {:?}", source, dest))
-            .as_mut()
-            .unwrap()
+        self.nodes[source.0 .0 as usize]
             .get_mut()
             .outgoing_edges
             .push(OutgoingEdge {
@@ -159,11 +155,7 @@ impl Graph {
     }
 
     pub fn remove_edge(&mut self, source: AudioNodeId, dest: AudioNodeId) {
-        self.nodes
-            .get_mut(source.0 as usize)
-            .unwrap_or_else(|| panic!("cannot remove the edge from {:?} to {:?}", source, dest))
-            .as_mut()
-            .unwrap()
+        self.nodes[source.0 as usize]
             .get_mut()
             .outgoing_edges
             .retain(|edge| edge.other_id != dest);
@@ -172,16 +164,12 @@ impl Graph {
     }
 
     pub fn remove_edges_from(&mut self, source: AudioNodeId) {
-        self.nodes
-            .get_mut(source.0 as usize)
-            .unwrap_or_else(|| panic!("cannot remove edges from {:?}", source))
-            .as_mut()
-            .unwrap()
+        self.nodes[source.0 as usize]
             .get_mut()
             .outgoing_edges
             .clear();
 
-        self.nodes.iter_mut().flatten().for_each(|node| {
+        self.nodes.values_mut().for_each(|node| {
             node.get_mut()
                 .outgoing_edges
                 .retain(|edge| edge.other_id != source);
@@ -194,27 +182,17 @@ impl Graph {
         // Issue #92, a race condition can occur for AudioParams. They may have already been
         // removed from the audio graph if the node they feed into was dropped.
         // Therefore, do not assume this node still exists:
-        if let Some(node) = self.nodes.get_mut(index.0 as usize).unwrap().as_mut() {
+        if let Some(node) = self.nodes.get_mut(index.0 as usize) {
             node.get_mut().free_when_finished = true;
         }
     }
 
     pub fn mark_cycle_breaker(&mut self, index: AudioNodeId) {
-        self.nodes
-            .get_mut(index.0 as usize)
-            .unwrap()
-            .as_mut()
-            .unwrap()
-            .get_mut()
-            .cycle_breaker = true;
+        self.nodes[index.0 as usize].get_mut().cycle_breaker = true;
     }
 
     pub fn route_message(&mut self, index: AudioNodeId, msg: &mut dyn Any) {
-        self.nodes
-            .get_mut(index.0 as usize)
-            .unwrap()
-            .as_mut()
-            .unwrap()
+        self.nodes[index.0 as usize]
             .get_mut()
             .processor
             .onmessage(msg);
@@ -237,15 +215,10 @@ impl Graph {
         // If this node is in the cycle detection list, it is part of a cycle!
         if let Some(pos) = marked_temp.iter().position(|&m| m == node_id) {
             // check if we can find some node that can break the cycle
-            let cycle_breaker_node = marked_temp.iter().skip(pos).find(|node_id| {
-                self.nodes
-                    .get(node_id.0 as usize)
-                    .unwrap()
-                    .as_ref()
-                    .unwrap()
-                    .borrow()
-                    .cycle_breaker
-            });
+            let cycle_breaker_node = marked_temp
+                .iter()
+                .skip(pos)
+                .find(|node_id| self.nodes[node_id.0 as usize].borrow().cycle_breaker);
 
             match cycle_breaker_node {
                 Some(&node_id) => {
@@ -274,12 +247,7 @@ impl Graph {
         marked_temp.push(node_id);
 
         // Visit outgoing nodes, and call `visit` on them recursively
-        for edge in self
-            .nodes
-            .get(node_id.0 as usize)
-            .unwrap()
-            .as_ref()
-            .unwrap()
+        for edge in self.nodes[node_id.0 as usize]
             .borrow()
             .outgoing_edges
             .iter()
@@ -345,13 +313,7 @@ impl Graph {
             // since the audio graph could contain legs detached from the destination and those should
             // still be rendered.
             let mut cycle_breaker_applied = false;
-            for node_id in self
-                .nodes
-                .iter()
-                .enumerate()
-                .filter(|(_, v)| v.is_some())
-                .map(|(i, _)| AudioNodeId(i as u64))
-            {
+            for node_id in self.nodes.keys().map(|i| AudioNodeId(i as u64)) {
                 cycle_breaker_applied = self.visit(
                     node_id,
                     &mut marked,
@@ -370,8 +332,7 @@ impl Graph {
                 // clear the outgoing edges of the nodes that have been recognized as cycle breaker
                 let nodes = &mut self.nodes;
                 cycle_breakers.iter().for_each(|node_id| {
-                    let node = nodes.get_mut(node_id.0 as usize).unwrap().as_mut().unwrap();
-                    node.get_mut().outgoing_edges.clear();
+                    nodes[node_id.0 as usize].get_mut().outgoing_edges.clear();
                 });
 
                 continue;
@@ -412,12 +373,7 @@ impl Graph {
         // process every node, in topological sorted order
         self.ordered.iter().for_each(|index| {
             // acquire a mutable borrow of the current processing node
-            let mut node = nodes
-                .get(index.0 as usize)
-                .unwrap()
-                .as_ref()
-                .unwrap()
-                .borrow_mut();
+            let mut node = nodes[index.0 as usize].borrow_mut();
 
             // make sure all input buffers have the correct number of channels, this might not be
             // the case if the node has no inputs connected or the channel count has just changed
@@ -428,7 +384,7 @@ impl Graph {
                 .for_each(|i| i.mix(count, interpretation));
 
             // let the current node process (catch any panics that may occur)
-            let params = AudioParamValues::from(nodes.as_slice());
+            let params = AudioParamValues::from(nodes);
             scope.node_id.set(*index);
             let (success, tail_time) = {
                 // We are abusing AssertUnwindSafe here, we cannot guarantee it upholds.
@@ -452,12 +408,7 @@ impl Graph {
                 // audio params are connected to the 'hidden' usize::MAX output, ignore them here
                 .filter(|edge| edge.other_index != usize::MAX)
                 .for_each(|edge| {
-                    let mut output_node = nodes
-                        .get(edge.other_id.0 as usize)
-                        .unwrap()
-                        .as_ref()
-                        .unwrap()
-                        .borrow_mut();
+                    let mut output_node = nodes[edge.other_id.0 as usize].borrow_mut();
                     output_node.has_inputs_connected = true;
                     let signal = &node.outputs[edge.self_index];
                     let channel_config = &output_node.channel_config.clone();
@@ -483,36 +434,28 @@ impl Graph {
             // Check if we can decommission this node (end of life)
             if can_free {
                 // Node is dropped, remove it from the node list
-                nodes[index.0 as usize] = None;
+                nodes.remove(index.0 as usize);
 
                 // And remove it from the ordering after we have processed all nodes
                 nodes_dropped = true;
 
                 // Nodes are only dropped when they do not have incoming connections.
                 // But they may have AudioParams feeding into them, these can de dropped too.
-                for (id, node) in nodes.iter_mut().enumerate() {
-                    if node.is_none() {
-                        continue;
-                    }
+                nodes.retain(|id, node| {
                     // Check if this node was connected to the dropped node. In that case, it is
                     // either an AudioParam (which can be dropped), or the AudioListener that feeds
                     // into a PannerNode (which can be disconnected).
                     let was_connected = {
-                        let outgoing_edges =
-                            &mut node.as_mut().unwrap().borrow_mut().outgoing_edges;
+                        let outgoing_edges = &mut node.borrow_mut().outgoing_edges;
                         let prev_len = outgoing_edges.len();
                         outgoing_edges.retain(|e| e.other_id != *index);
                         outgoing_edges.len() != prev_len
                     };
 
+                    // retain when special or not connected to this dropped node
                     let special = id < 2; // never drop Listener and Destination node
-
-                    if special || !was_connected {
-                        // retain
-                    } else {
-                        *node = None;
-                    }
-                }
+                    special || !was_connected
+                })
             }
         });
 
@@ -520,7 +463,7 @@ impl Graph {
         if nodes_dropped {
             let mut i = 0;
             while i < self.ordered.len() {
-                if nodes[self.ordered[i].0 as usize].is_none() {
+                if nodes.get(self.ordered[i].0 as usize).is_none() {
                     self.ordered.remove(i);
                 } else {
                     i += 1;
@@ -529,14 +472,7 @@ impl Graph {
         }
 
         // Return the output buffer of destination node
-        &self
-            .nodes
-            .get_mut(0)
-            .unwrap()
-            .as_mut()
-            .unwrap()
-            .get_mut()
-            .outputs[0]
+        &self.nodes[0].get_mut().outputs[0]
     }
 }
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -11,4 +11,8 @@ pub(crate) use thread::*;
 mod processor;
 pub use processor::*;
 mod quantum;
+
+mod node_collection;
+pub(crate) use node_collection::NodeCollection;
+
 pub use quantum::*;

--- a/src/render/node_collection.rs
+++ b/src/render/node_collection.rs
@@ -1,8 +1,10 @@
+use crate::context::AudioNodeId;
 use crate::render::graph::Node;
+
 use std::cell::RefCell;
 use std::ops::{Index, IndexMut};
 
-pub struct NodeCollection {
+pub(crate) struct NodeCollection {
     nodes: Vec<Option<RefCell<Node>>>,
 }
 
@@ -26,26 +28,25 @@ impl NodeCollection {
     }
 
     #[inline(always)]
-    pub fn insert(&mut self, index: usize, value: RefCell<Node>) {
+    pub fn insert(&mut self, index: AudioNodeId, value: RefCell<Node>) {
+        let index = index.0 as usize;
         self.ensure_capacity(index + 1);
         self.nodes[index] = Some(value);
     }
 
     #[inline(always)]
-    pub fn remove(&mut self, index: usize) -> RefCell<Node> {
-        self.nodes
-            .get_mut(index)
-            .expect("Unexpected remove index for NodeCollection")
+    pub fn remove(&mut self, index: AudioNodeId) -> RefCell<Node> {
+        self.nodes[index.0 as usize]
             .take()
             .expect("Unable to remove non-existing Node in NodeCollection")
     }
 
     #[inline(always)]
-    pub fn keys(&self) -> impl Iterator<Item = usize> + '_ {
+    pub fn keys(&self) -> impl Iterator<Item = AudioNodeId> + '_ {
         self.nodes
             .iter()
             .enumerate()
-            .filter_map(|(i, v)| v.as_ref().and(Some(i)))
+            .filter_map(|(i, v)| v.as_ref().and(Some(AudioNodeId(i as u64))))
     }
 
     #[inline(always)]
@@ -54,23 +55,23 @@ impl NodeCollection {
     }
 
     #[inline(always)]
-    pub fn get(&self, index: usize) -> Option<&RefCell<Node>> {
-        self.nodes[index].as_ref()
+    pub fn get(&self, index: AudioNodeId) -> Option<&RefCell<Node>> {
+        self.nodes[index.0 as usize].as_ref()
     }
 
     #[inline(always)]
-    pub fn get_mut(&mut self, index: usize) -> Option<&mut RefCell<Node>> {
-        self.nodes[index].as_mut()
+    pub fn get_mut(&mut self, index: AudioNodeId) -> Option<&mut RefCell<Node>> {
+        self.nodes[index.0 as usize].as_mut()
     }
 
     #[inline(always)]
     pub fn retain<F>(&mut self, mut f: F)
     where
-        F: FnMut(usize, &mut RefCell<Node>) -> bool,
+        F: FnMut(AudioNodeId, &mut RefCell<Node>) -> bool,
     {
         self.nodes.iter_mut().enumerate().for_each(|(i, opt)| {
             if let Some(v) = opt.as_mut() {
-                if !f(i, v) {
+                if !f(AudioNodeId(i as u64), v) {
                     *opt = None;
                 }
             }
@@ -78,28 +79,28 @@ impl NodeCollection {
     }
 }
 
-impl Index<usize> for NodeCollection {
+impl Index<AudioNodeId> for NodeCollection {
     type Output = RefCell<Node>;
 
     #[track_caller]
     #[inline(always)]
-    fn index(&self, index: usize) -> &Self::Output {
+    fn index(&self, index: AudioNodeId) -> &Self::Output {
         self.nodes
-            .get(index)
-            .unwrap_or_else(|| panic!("Unexpected index {} for NodeCollection", index))
+            .get(index.0 as usize)
+            .unwrap_or_else(|| panic!("Unexpected index {} for NodeCollection", index.0))
             .as_ref()
-            .unwrap_or_else(|| panic!("Index {} for dropped Node in NodeCollection", index))
+            .unwrap_or_else(|| panic!("Index {} for dropped Node in NodeCollection", index.0))
     }
 }
 
-impl IndexMut<usize> for NodeCollection {
+impl IndexMut<AudioNodeId> for NodeCollection {
     #[track_caller]
     #[inline(always)]
-    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+    fn index_mut(&mut self, index: AudioNodeId) -> &mut Self::Output {
         self.nodes
-            .get_mut(index)
-            .unwrap_or_else(|| panic!("Unexpected index {} for NodeCollection", index))
+            .get_mut(index.0 as usize)
+            .unwrap_or_else(|| panic!("Unexpected index {} for NodeCollection", index.0))
             .as_mut()
-            .unwrap_or_else(|| panic!("Index {} for dropped Node in NodeCollection", index))
+            .unwrap_or_else(|| panic!("Index {} for dropped Node in NodeCollection", index.0))
     }
 }

--- a/src/render/node_collection.rs
+++ b/src/render/node_collection.rs
@@ -1,0 +1,105 @@
+use crate::render::graph::Node;
+use std::cell::RefCell;
+use std::ops::{Index, IndexMut};
+
+pub struct NodeCollection {
+    nodes: Vec<Option<RefCell<Node>>>,
+}
+
+impl NodeCollection {
+    pub fn new() -> Self {
+        let mut instance = Self {
+            nodes: Vec::with_capacity(64),
+        };
+        instance.ensure_capacity(64);
+        instance
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+
+    #[inline(always)]
+    fn ensure_capacity(&mut self, new_len: usize) {
+        self.nodes
+            .resize_with(new_len.max(self.nodes.len()), || None);
+    }
+
+    #[inline(always)]
+    pub fn insert(&mut self, index: usize, value: RefCell<Node>) {
+        self.ensure_capacity(index + 1);
+        self.nodes[index] = Some(value);
+    }
+
+    #[inline(always)]
+    pub fn remove(&mut self, index: usize) -> RefCell<Node> {
+        self.nodes
+            .get_mut(index)
+            .expect("Unexpected remove index for NodeCollection")
+            .take()
+            .expect("Unable to remove non-existing Node in NodeCollection")
+    }
+
+    #[inline(always)]
+    pub fn keys(&self) -> impl Iterator<Item = usize> + '_ {
+        self.nodes
+            .iter()
+            .enumerate()
+            .filter_map(|(i, v)| v.as_ref().and(Some(i)))
+    }
+
+    #[inline(always)]
+    pub fn values_mut(&mut self) -> impl Iterator<Item = &mut RefCell<Node>> {
+        self.nodes.iter_mut().filter_map(Option::as_mut)
+    }
+
+    #[inline(always)]
+    pub fn get(&mut self, index: usize) -> Option<&RefCell<Node>> {
+        self.nodes[index].as_ref()
+    }
+
+    #[inline(always)]
+    pub fn get_mut(&mut self, index: usize) -> Option<&mut RefCell<Node>> {
+        self.nodes[index].as_mut()
+    }
+
+    #[inline(always)]
+    pub fn retain<F>(&mut self, mut f: F)
+    where
+        F: FnMut(usize, &mut RefCell<Node>) -> bool,
+    {
+        self.nodes.iter_mut().enumerate().for_each(|(i, opt)| {
+            if let Some(v) = opt.as_mut() {
+                if !f(i, v) {
+                    *opt = None;
+                }
+            }
+        })
+    }
+}
+
+impl Index<usize> for NodeCollection {
+    type Output = RefCell<Node>;
+
+    #[track_caller]
+    #[inline(always)]
+    fn index(&self, index: usize) -> &Self::Output {
+        self.nodes
+            .get(index)
+            .unwrap_or_else(|| panic!("Unexpected index {} for NodeCollection", index))
+            .as_ref()
+            .unwrap_or_else(|| panic!("Index {} for dropped Node in NodeCollection", index))
+    }
+}
+
+impl IndexMut<usize> for NodeCollection {
+    #[track_caller]
+    #[inline(always)]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        self.nodes
+            .get_mut(index)
+            .unwrap_or_else(|| panic!("Unexpected index {} for NodeCollection", index))
+            .as_mut()
+            .unwrap_or_else(|| panic!("Index {} for dropped Node in NodeCollection", index))
+    }
+}

--- a/src/render/node_collection.rs
+++ b/src/render/node_collection.rs
@@ -54,7 +54,7 @@ impl NodeCollection {
     }
 
     #[inline(always)]
-    pub fn get(&mut self, index: usize) -> Option<&RefCell<Node>> {
+    pub fn get(&self, index: usize) -> Option<&RefCell<Node>> {
         self.nodes[index].as_ref()
     }
 

--- a/src/render/processor.rs
+++ b/src/render/processor.rs
@@ -154,7 +154,7 @@ impl<'a> AudioParamValues<'a> {
     /// provide a slice of length equal to the render quantum size (default: 128)
     #[allow(clippy::missing_panics_doc)]
     pub fn get(&self, index: &AudioParamId) -> impl Deref<Target = [f32]> + '_ {
-        DerefAudioRenderQuantumChannel(self.nodes[index.0 as usize].borrow())
+        DerefAudioRenderQuantumChannel(self.nodes[index.into()].borrow())
     }
 
     pub(crate) fn listener_params(&self) -> [impl Deref<Target = [f32]> + '_; 9] {

--- a/src/render/thread.rs
+++ b/src/render/thread.rs
@@ -95,6 +95,7 @@ impl RenderThread {
             match msg {
                 RegisterNode {
                     id: node_id,
+                    reclaim_id,
                     node,
                     inputs,
                     outputs,
@@ -102,6 +103,7 @@ impl RenderThread {
                 } => {
                     self.graph.as_mut().unwrap().add_node(
                         node_id,
+                        reclaim_id,
                         node,
                         inputs,
                         outputs,


### PR DESCRIPTION
Don't mind the unreadable code, I'm seeing +-10% performance gains in some benchmarks.

A big todo is to reuse deallocated node slots, or the Vec may grow indefinitely for long running processes