### PR TITLE
Run benchmarks locally with criterion

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -53,11 +53,11 @@ jobs:
       - name: Revert when benches do not compile on main
         run: cargo check --benches --no-default-features || git checkout main -- benches/my_benchmark.rs
       - name: Run benchmarks for main branch
-        run: cargo bench --no-default-features
+        run: cargo bench --no-default-features --feature iai
       - name: Checkout PR branch
         run: git checkout -
       - name: Run bench against baseline
-        run: cargo bench --no-default-features | sed '0,/^test result:/d' | tee bench.txt
+        run: cargo bench --no-default-features --feature iai | sed '0,/^test result:/d' | tee bench.txt
 
       # for testing
       # - name: create mock results

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ vecmath = "1.0"
 
 [dev-dependencies]
 alloc_counter = "0.0.4"
+criterion = "0.5.1"
 env_logger = "0.10"
 iai = "0.1.1"
 rand = "0.8"
@@ -62,3 +63,4 @@ cpal = ["dep:cpal"]
 cubeb = ["dep:cubeb"]
 cpal-jack = ["cpal", "cpal/jack"]
 cpal-asio = ["cpal", "cpal/asio"]
+iai = []

--- a/benches/my_benchmark.rs
+++ b/benches/my_benchmark.rs
@@ -26,7 +26,6 @@ fn get_audio_buffer(ctx: &OfflineAudioContext) -> AudioBuffer {
     static BUFFER: OnceLock<AudioBuffer> = OnceLock::new();
     BUFFER
         .get_or_init(|| {
-            println!("decoding now");
             let file = File::open("samples/think-stereo-48000.wav").unwrap();
             ctx.decode_audio_data_sync(file).unwrap()
         })

--- a/benches/my_benchmark.rs
+++ b/benches/my_benchmark.rs
@@ -277,9 +277,7 @@ fn criterion_sine_gain(c: &mut Criterion) {
 }
 #[cfg(not(feature = "iai"))]
 fn criterion_sine_gain_delay(c: &mut Criterion) {
-    c.bench_function("bench_sine_gain_delay", |b| {
-        b.iter(bench_sine_gain_delay)
-    });
+    c.bench_function("bench_sine_gain_delay", |b| b.iter(bench_sine_gain_delay));
 }
 #[cfg(not(feature = "iai"))]
 fn criterion_buffer_src(c: &mut Criterion) {
@@ -287,15 +285,11 @@ fn criterion_buffer_src(c: &mut Criterion) {
 }
 #[cfg(not(feature = "iai"))]
 fn criterion_buffer_src_delay(c: &mut Criterion) {
-    c.bench_function("bench_buffer_src_delay", |b| {
-        b.iter(bench_buffer_src_delay)
-    });
+    c.bench_function("bench_buffer_src_delay", |b| b.iter(bench_buffer_src_delay));
 }
 #[cfg(not(feature = "iai"))]
 fn criterion_buffer_src_iir(c: &mut Criterion) {
-    c.bench_function("bench_buffer_src_iir", |b| {
-        b.iter(bench_buffer_src_iir)
-    });
+    c.bench_function("bench_buffer_src_iir", |b| b.iter(bench_buffer_src_iir));
 }
 #[cfg(not(feature = "iai"))]
 fn criterion_buffer_src_biquad(c: &mut Criterion) {

--- a/benches/my_benchmark.rs
+++ b/benches/my_benchmark.rs
@@ -259,69 +259,69 @@ iai::main!(
 
 #[cfg(not(feature = "iai"))]
 fn criterion_ctor(c: &mut Criterion) {
-    c.bench_function("bench_ctor", |b| b.iter(|| bench_ctor()));
+    c.bench_function("bench_ctor", |b| b.iter(bench_ctor));
 }
 #[cfg(not(feature = "iai"))]
 fn criterion_audio_buffer_decode(c: &mut Criterion) {
     c.bench_function("bench_audio_buffer_decode", |b| {
-        b.iter(|| bench_audio_buffer_decode())
+        b.iter(bench_audio_buffer_decode)
     });
 }
 #[cfg(not(feature = "iai"))]
 fn criterion_sine(c: &mut Criterion) {
-    c.bench_function("bench_sine", |b| b.iter(|| bench_sine()));
+    c.bench_function("bench_sine", |b| b.iter(bench_sine));
 }
 #[cfg(not(feature = "iai"))]
 fn criterion_sine_gain(c: &mut Criterion) {
-    c.bench_function("bench_sine_gain", |b| b.iter(|| bench_sine_gain()));
+    c.bench_function("bench_sine_gain", |b| b.iter(bench_sine_gain));
 }
 #[cfg(not(feature = "iai"))]
 fn criterion_sine_gain_delay(c: &mut Criterion) {
     c.bench_function("bench_sine_gain_delay", |b| {
-        b.iter(|| bench_sine_gain_delay())
+        b.iter(bench_sine_gain_delay)
     });
 }
 #[cfg(not(feature = "iai"))]
 fn criterion_buffer_src(c: &mut Criterion) {
-    c.bench_function("bench_buffer_src", |b| b.iter(|| bench_buffer_src()));
+    c.bench_function("bench_buffer_src", |b| b.iter(bench_buffer_src));
 }
 #[cfg(not(feature = "iai"))]
 fn criterion_buffer_src_delay(c: &mut Criterion) {
     c.bench_function("bench_buffer_src_delay", |b| {
-        b.iter(|| bench_buffer_src_delay())
+        b.iter(bench_buffer_src_delay)
     });
 }
 #[cfg(not(feature = "iai"))]
 fn criterion_buffer_src_iir(c: &mut Criterion) {
     c.bench_function("bench_buffer_src_iir", |b| {
-        b.iter(|| bench_buffer_src_iir())
+        b.iter(bench_buffer_src_iir)
     });
 }
 #[cfg(not(feature = "iai"))]
 fn criterion_buffer_src_biquad(c: &mut Criterion) {
     c.bench_function("bench_buffer_src_biquad", |b| {
-        b.iter(|| bench_buffer_src_biquad())
+        b.iter(bench_buffer_src_biquad)
     });
 }
 #[cfg(not(feature = "iai"))]
 fn criterion_stereo_positional(c: &mut Criterion) {
     c.bench_function("bench_stereo_positional", |b| {
-        b.iter(|| bench_stereo_positional())
+        b.iter(bench_stereo_positional)
     });
 }
 #[cfg(not(feature = "iai"))]
 fn criterion_stereo_panning_automation(c: &mut Criterion) {
     c.bench_function("bench_stereo_panning_automation", |b| {
-        b.iter(|| bench_stereo_panning_automation())
+        b.iter(bench_stereo_panning_automation)
     });
 }
 #[cfg(not(feature = "iai"))]
 fn criterion_analyser_node(c: &mut Criterion) {
-    c.bench_function("bench_analyser_node", |b| b.iter(|| bench_analyser_node()));
+    c.bench_function("bench_analyser_node", |b| b.iter(bench_analyser_node));
 }
 #[cfg(not(feature = "iai"))]
 fn criterion_hrtf_panners(c: &mut Criterion) {
-    c.bench_function("bench_hrtf_panners", |b| b.iter(|| bench_hrtf_panners()));
+    c.bench_function("bench_hrtf_panners", |b| b.iter(bench_hrtf_panners));
 }
 
 #[cfg(not(feature = "iai"))]

--- a/benches/my_benchmark.rs
+++ b/benches/my_benchmark.rs
@@ -1,4 +1,8 @@
+#[cfg(feature = "iai")]
 use iai::black_box;
+
+#[cfg(not(feature = "iai"))]
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 use web_audio_api::context::BaseAudioContext;
 use web_audio_api::context::OfflineAudioContext;
@@ -217,6 +221,7 @@ pub fn bench_hrtf_panners() {
     assert_eq!(ctx.start_rendering_sync().length(), SAMPLES);
 }
 
+#[cfg(feature = "iai")]
 iai::main!(
     bench_ctor,
     bench_sine,
@@ -231,3 +236,84 @@ iai::main!(
     bench_analyser_node,
     bench_hrtf_panners,
 );
+
+#[cfg(not(feature = "iai"))]
+fn criterion_ctor(c: &mut Criterion) {
+    c.bench_function("bench_ctor", |b| b.iter(|| bench_ctor()));
+}
+#[cfg(not(feature = "iai"))]
+fn criterion_sine(c: &mut Criterion) {
+    c.bench_function("bench_sine", |b| b.iter(|| bench_sine()));
+}
+#[cfg(not(feature = "iai"))]
+fn criterion_sine_gain(c: &mut Criterion) {
+    c.bench_function("bench_sine_gain", |b| b.iter(|| bench_sine_gain()));
+}
+#[cfg(not(feature = "iai"))]
+fn criterion_sine_gain_delay(c: &mut Criterion) {
+    c.bench_function("bench_sine_gain_delay", |b| {
+        b.iter(|| bench_sine_gain_delay())
+    });
+}
+#[cfg(not(feature = "iai"))]
+fn criterion_buffer_src(c: &mut Criterion) {
+    c.bench_function("bench_buffer_src", |b| b.iter(|| bench_buffer_src()));
+}
+#[cfg(not(feature = "iai"))]
+fn criterion_buffer_src_delay(c: &mut Criterion) {
+    c.bench_function("bench_buffer_src_delay", |b| {
+        b.iter(|| bench_buffer_src_delay())
+    });
+}
+#[cfg(not(feature = "iai"))]
+fn criterion_buffer_src_iir(c: &mut Criterion) {
+    c.bench_function("bench_buffer_src_iir", |b| {
+        b.iter(|| bench_buffer_src_iir())
+    });
+}
+#[cfg(not(feature = "iai"))]
+fn criterion_buffer_src_biquad(c: &mut Criterion) {
+    c.bench_function("bench_buffer_src_biquad", |b| {
+        b.iter(|| bench_buffer_src_biquad())
+    });
+}
+#[cfg(not(feature = "iai"))]
+fn criterion_stereo_positional(c: &mut Criterion) {
+    c.bench_function("bench_stereo_positional", |b| {
+        b.iter(|| bench_stereo_positional())
+    });
+}
+#[cfg(not(feature = "iai"))]
+fn criterion_stereo_panning_automation(c: &mut Criterion) {
+    c.bench_function("bench_stereo_panning_automation", |b| {
+        b.iter(|| bench_stereo_panning_automation())
+    });
+}
+#[cfg(not(feature = "iai"))]
+fn criterion_analyser_node(c: &mut Criterion) {
+    c.bench_function("bench_analyser_node", |b| b.iter(|| bench_analyser_node()));
+}
+#[cfg(not(feature = "iai"))]
+fn criterion_hrtf_panners(c: &mut Criterion) {
+    c.bench_function("bench_hrtf_panners", |b| b.iter(|| bench_hrtf_panners()));
+}
+
+#[cfg(not(feature = "iai"))]
+criterion_group!(
+    benches,
+    criterion_ctor,
+    criterion_sine,
+    criterion_sine_gain,
+    criterion_sine_gain_delay,
+    criterion_buffer_src,
+    criterion_buffer_src_delay,
+    criterion_buffer_src_iir,
+    criterion_buffer_src_biquad,
+    criterion_stereo_positional,
+    criterion_stereo_panning_automation,
+    criterion_analyser_node,
+    criterion_hrtf_panners
+);
+
+#[cfg(not(feature = "iai"))]
+criterion_main!(benches);

--- a/benches/my_benchmark.rs
+++ b/benches/my_benchmark.rs
@@ -15,6 +15,7 @@ use std::sync::OnceLock;
 const SAMPLE_RATE: f32 = 48000.;
 const DURATION: usize = 10;
 const SAMPLES: usize = SAMPLE_RATE as usize * DURATION;
+const SAMPLES_SHORT: usize = SAMPLE_RATE as usize; // only 1 second for heavy benchmarks
 
 /// Load an audio buffer and cache the result
 ///
@@ -220,7 +221,7 @@ pub fn bench_analyser_node() {
 }
 
 pub fn bench_hrtf_panners() {
-    let ctx = OfflineAudioContext::new(2, black_box(SAMPLES), SAMPLE_RATE);
+    let ctx = OfflineAudioContext::new(2, black_box(SAMPLES_SHORT), SAMPLE_RATE);
 
     let mut panner1 = ctx.create_panner();
     panner1.set_panning_model(PanningModelType::HRTF);
@@ -237,7 +238,7 @@ pub fn bench_hrtf_panners() {
     osc.connect(&panner2);
     osc.start();
 
-    assert_eq!(ctx.start_rendering_sync().length(), SAMPLES);
+    assert_eq!(ctx.start_rendering_sync().length(), SAMPLES_SHORT);
 }
 
 #[cfg(feature = "iai")]


### PR DESCRIPTION
Fixes #188 

You can now run `cargo bench` locally to run the same benches as we run in CI.
It's a lot of boilerplate currently, I'm still looking for improvements.
Also we need to move to unify  examples/benchmarks.rs in here.