### PR TITLE
Try to prevent pre-commit hook failing on `cubeb`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,15 @@ repos:
   - repo: https://github.com/doublify/pre-commit-rust
     rev: v1.0
     hooks:
+      - id: cargo-check
+        args:
+          [
+            --locked,
+            --workspace,
+            --features,
+            cubeb,
+            --all-targets,
+          ]
       - id: fmt
         args: [--all, --]
       - id: clippy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,14 +57,7 @@ repos:
     rev: v1.0
     hooks:
       - id: cargo-check
-        args:
-          [
-            --locked,
-            --workspace,
-            --features,
-            cubeb,
-            --all-targets,
-          ]
+        args: [--locked, --workspace, --features, cubeb, --all-targets]
       - id: fmt
         args: [--all, --]
       - id: clippy


### PR DESCRIPTION
If we run cargo check first, cubeb should be built properly and can be used for the next steps.

Might fix #383