### PR TITLE
Run diagnostics on live AudioContext

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -36,8 +36,14 @@ pub(crate) const LISTENER_AUDIO_PARAM_IDS: [AudioParamId; 9] = [
 /// Unique identifier for audio nodes.
 ///
 /// Used for internal bookkeeping.
-#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
+#[derive(Hash, PartialEq, Eq, Clone, Copy)]
 pub(crate) struct AudioNodeId(pub u64);
+
+impl std::fmt::Debug for AudioNodeId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "AudioNodeId({})", self.0)
+    }
+}
 
 /// Unique identifier for audio params.
 ///

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -345,6 +345,7 @@ impl AudioContext {
     }
 
     #[allow(clippy::missing_panics_doc)]
+    #[doc(hidden)] // Method signature might change in the future
     pub fn run_diagnostics<F: Fn(String) + Send + 'static>(&self, callback: F) {
         let mut buffer = Vec::with_capacity(32 * 1024);
         {

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use std::sync::Mutex;
 
 use crate::context::{AudioContextState, BaseAudioContext, ConcreteBaseAudioContext};
-use crate::events::{EventDispatch, EventHandler, EventType};
+use crate::events::{EventDispatch, EventHandler, EventPayload, EventType};
 use crate::io::{self, AudioBackendManager, ControlThreadInit, RenderThreadInit};
 use crate::media_devices::{enumerate_devices_sync, MediaDeviceInfoKind};
 use crate::media_streams::{MediaStream, MediaStreamTrack};
@@ -342,6 +342,26 @@ impl AudioContext {
     /// Unset the callback to run when the audio sink has changed
     pub fn clear_onsinkchange(&self) {
         self.base().clear_event_handler(EventType::SinkChange);
+    }
+
+    #[allow(clippy::missing_panics_doc)]
+    pub fn run_diagnostics<F: Fn(String) + Send + 'static>(&self, callback: F) {
+        let callback = move |v| match v {
+            EventPayload::Diagnostics(v) => {
+                let s = String::from_utf8(v).unwrap();
+                callback(s);
+            }
+            _ => unreachable!(),
+        };
+
+        self.base().set_event_handler(
+            EventType::Diagnostics,
+            EventHandler::Once(Box::new(callback)),
+        );
+
+        let buffer = Vec::with_capacity(32 * 1024);
+        self.base()
+            .send_control_msg(ControlMessage::RunDiagnostics { buffer });
     }
 
     /// Suspends the progression of time in the audio context.

--- a/src/events.rs
+++ b/src/events.rs
@@ -21,6 +21,7 @@ pub(crate) enum EventType {
     SinkChange,
     RenderCapacity,
     ProcessorError(AudioNodeId),
+    Diagnostics,
 }
 
 /// The Error Event interface
@@ -39,6 +40,7 @@ pub(crate) enum EventPayload {
     None,
     RenderCapacity(AudioRenderCapacityEvent),
     ProcessorError(ErrorEvent),
+    Diagnostics(Vec<u8>),
 }
 
 pub(crate) struct EventDispatch {
@@ -72,6 +74,13 @@ impl EventDispatch {
         EventDispatch {
             type_: EventType::ProcessorError(id),
             payload: EventPayload::ProcessorError(value),
+        }
+    }
+
+    pub fn diagnostics(value: Vec<u8>) -> Self {
+        EventDispatch {
+            type_: EventType::Diagnostics,
+            payload: EventPayload::Diagnostics(value),
         }
     }
 }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -133,6 +133,11 @@ pub(crate) fn build_input(options: AudioContextOptions) -> MediaStream {
 
 /// Interface for audio backends
 pub(crate) trait AudioBackendManager: Send + Sync + 'static {
+    /// Name of the concrete implementation - for debug purposes
+    fn name(&self) -> &'static str {
+        std::any::type_name::<Self>()
+    }
+
     /// Setup a new output stream (speakers)
     fn build_output(options: AudioContextOptions, render_thread_init: RenderThreadInit) -> Self
     where

--- a/src/message.rs
+++ b/src/message.rs
@@ -52,4 +52,7 @@ pub(crate) enum ControlMessage {
         id: AudioNodeId,
         msg: llq::Node<Box<dyn Any + Send>>,
     },
+
+    /// Request a diagnostic report of the audio graph
+    RunDiagnostics { buffer: Vec<u8> },
 }

--- a/src/render/graph.rs
+++ b/src/render/graph.rs
@@ -11,6 +11,7 @@ use crate::node::ChannelConfig;
 use crate::render::RenderScope;
 
 /// Connection between two audio nodes
+#[derive(Debug)]
 struct OutgoingEdge {
     /// index of the current Nodes output port
     self_index: usize,
@@ -40,6 +41,19 @@ pub struct Node {
     has_inputs_connected: bool,
     /// Indicates if the node can act as a cycle breaker (only DelayNode for now)
     cycle_breaker: bool,
+}
+
+impl std::fmt::Debug for Node {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Node")
+            .field("id", &self.reclaim_id.as_ref().map(|n| &**n))
+            .field("processor", &self.processor)
+            .field("channel_config", &self.channel_config)
+            .field("outgoing_edges", &self.outgoing_edges)
+            .field("free_when_finished", &self.free_when_finished)
+            .field("cycle_breaker", &self.cycle_breaker)
+            .finish_non_exhaustive()
+    }
 }
 
 impl Node {
@@ -92,6 +106,15 @@ pub(crate) struct Graph {
     in_cycle: Vec<AudioNodeId>,
     /// Topological sorting helper
     cycle_breakers: Vec<AudioNodeId>,
+}
+
+impl std::fmt::Debug for Graph {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Graph")
+            .field("nodes", &self.nodes)
+            .field("ordered", &self.ordered)
+            .finish_non_exhaustive()
+    }
 }
 
 impl Graph {

--- a/src/render/graph.rs
+++ b/src/render/graph.rs
@@ -11,7 +11,6 @@ use crate::node::ChannelConfig;
 use crate::render::RenderScope;
 
 /// Connection between two audio nodes
-#[derive(Debug)]
 struct OutgoingEdge {
     /// index of the current Nodes output port
     self_index: usize,
@@ -19,6 +18,21 @@ struct OutgoingEdge {
     other_id: AudioNodeId,
     /// index of the other Nodes input port
     other_index: usize,
+}
+
+impl std::fmt::Debug for OutgoingEdge {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut format = f.debug_struct("OutgoingEdge");
+        format
+            .field("self_index", &self.self_index)
+            .field("other_id", &self.other_id);
+        if self.other_index == usize::MAX {
+            format.field("other_index", &"HIDDEN");
+        } else {
+            format.field("other_index", &self.other_index);
+        }
+        format.finish()
+    }
 }
 
 /// Renderer Node in the Audio Graph
@@ -46,7 +60,7 @@ pub struct Node {
 impl std::fmt::Debug for Node {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Node")
-            .field("id", &self.reclaim_id.as_ref().map(|n| &**n))
+            .field("id", &self.reclaim_id.as_deref())
             .field("processor", &self.processor)
             .field("channel_config", &self.channel_config)
             .field("outgoing_edges", &self.outgoing_edges)

--- a/src/render/node_collection.rs
+++ b/src/render/node_collection.rs
@@ -4,6 +4,7 @@ use crate::render::graph::Node;
 use std::cell::RefCell;
 use std::ops::{Index, IndexMut};
 
+#[derive(Debug)]
 pub(crate) struct NodeCollection {
     nodes: Vec<Option<RefCell<Node>>>,
 }

--- a/src/render/processor.rs
+++ b/src/render/processor.rs
@@ -120,7 +120,7 @@ pub trait AudioProcessor: Send {
     /// Return the name of the actual AudioProcessor type
     #[doc(hidden)] // not meant to be user facing
     fn name(&self) -> &'static str {
-        return std::any::type_name::<Self>();
+        std::any::type_name::<Self>()
     }
 }
 

--- a/src/render/processor.rs
+++ b/src/render/processor.rs
@@ -116,6 +116,18 @@ pub trait AudioProcessor: Send {
     fn onmessage(&mut self, msg: &mut dyn Any) {
         log::warn!("Ignoring incoming message");
     }
+
+    /// Return the name of the actual AudioProcessor type
+    #[doc(hidden)] // not meant to be user facing
+    fn name(&self) -> &'static str {
+        return std::any::type_name::<Self>();
+    }
+}
+
+impl std::fmt::Debug for dyn AudioProcessor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct(self.name()).finish_non_exhaustive()
+    }
 }
 
 struct DerefAudioRenderQuantumChannel<'a>(std::cell::Ref<'a, Node>);
@@ -159,5 +171,33 @@ impl<'a> AudioParamValues<'a> {
 
     pub(crate) fn listener_params(&self) -> [impl Deref<Target = [f32]> + '_; 9] {
         crate::context::LISTENER_AUDIO_PARAM_IDS.map(|p| self.get(&p))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestNode;
+
+    impl AudioProcessor for TestNode {
+        fn process(
+            &mut self,
+            _inputs: &[AudioRenderQuantum],
+            _outputs: &mut [AudioRenderQuantum],
+            _params: AudioParamValues<'_>,
+            _scope: &RenderScope,
+        ) -> bool {
+            todo!()
+        }
+    }
+
+    #[test]
+    fn test_debug_fmt() {
+        let proc = &TestNode as &dyn AudioProcessor;
+        assert_eq!(
+            &format!("{:?}", proc),
+            "web_audio_api::render::processor::tests::TestNode { .. }"
+        );
     }
 }

--- a/src/render/thread.rs
+++ b/src/render/thread.rs
@@ -24,6 +24,7 @@ use super::graph::Graph;
 pub(crate) struct RenderThread {
     graph: Option<Graph>,
     sample_rate: f32,
+    buffer_size: usize,
     /// number of channels of the backend stream, i.e. sound card number of
     /// channels clamped to MAX_CHANNELS
     number_of_channels: usize,
@@ -46,6 +47,17 @@ unsafe impl Sync for Graph {}
 unsafe impl Send for RenderThread {}
 unsafe impl Sync for RenderThread {}
 
+impl std::fmt::Debug for RenderThread {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RenderThread")
+            .field("sample_rate", &self.sample_rate)
+            .field("buffer_size", &self.buffer_size)
+            .field("frames_played", &self.frames_played.load(Ordering::Relaxed))
+            .field("number_of_channels", &self.number_of_channels)
+            .finish_non_exhaustive()
+    }
+}
+
 impl RenderThread {
     pub fn new(
         sample_rate: f32,
@@ -56,6 +68,7 @@ impl RenderThread {
         Self {
             graph: None,
             sample_rate,
+            buffer_size: 0,
             number_of_channels,
             frames_played,
             receiver: Some(receiver),
@@ -150,29 +163,16 @@ impl RenderThread {
                 }
                 RunDiagnostics { mut buffer } => {
                     if let Some(sender) = self.event_sender.as_ref() {
-                        self.write_diagnostics(&mut buffer);
-                        let dispatch = EventDispatch::diagnostics(buffer);
+                        use std::io::Write;
+                        writeln!(&mut buffer, "{:#?}", &self).ok();
+                        writeln!(&mut buffer, "{:?}", &self.graph).ok();
                         sender
-                            .try_send(dispatch)
+                            .try_send(EventDispatch::diagnostics(buffer))
                             .expect("Unable to send diagnostics - channel is full");
                     }
                 }
             }
         }
-    }
-
-    pub fn write_diagnostics(&self, buffer: &mut Vec<u8>) {
-        use std::io::Write;
-
-        writeln!(
-            buffer,
-            "current frame: {}",
-            self.frames_played.load(Ordering::Relaxed)
-        )
-        .ok();
-        writeln!(buffer, "sample rate: {}", self.sample_rate).ok();
-        writeln!(buffer, "number of channels: {}", self.number_of_channels).ok();
-        writeln!(buffer, "graph: {:?}", &self.graph).ok(); // use {:#?} for newlines between items
     }
 
     // Render method of the `OfflineAudioContext::start_rendering_sync`
@@ -259,6 +259,8 @@ impl RenderThread {
     }
 
     fn render_inner<S: FromSample<f32> + Clone>(&mut self, mut output_buffer: &mut [S]) {
+        self.buffer_size = output_buffer.len();
+
         // There may be audio frames left over from the previous render call,
         // if the cpal buffer size did not align with our internal RENDER_QUANTUM_SIZE
         if let Some((offset, prev_rendered)) = self.buffer_offset.take() {


### PR DESCRIPTION
Usage: `context.run_diagnostics(|s| println!("Diagnostics:\n{}", s));`
It will generate a report on the next render quantum, in a somewhat realtime safe manner.
This will hopefully aid debugging of e.g. #396 