### PR TITLE
Add async OfflineAudioContext startRendering, suspend and resume

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ crossbeam-channel = "0.5"
 cubeb = { version = "0.10", optional = true }
 dasp_sample = "0.11"
 float_eq = "1.0"
+futures = { version = "0.3.29", default-features = false, features = ["std"] }
 hound = "3.5"
 hrtf = "0.8.1"
 llq = "0.1.1"
@@ -36,6 +37,7 @@ vecmath = "1.0"
 no_denormals = "0.1.2"
 
 [dev-dependencies]
+futures = { version = "0.3.29", features = ["executor"] }
 alloc_counter = "0.0.4"
 criterion = "0.5.1"
 env_logger = "0.10"

--- a/src/context/offline.rs
+++ b/src/context/offline.rs
@@ -12,6 +12,9 @@ use crate::{assert_valid_sample_rate, RENDER_QUANTUM_SIZE};
 use futures::channel::oneshot;
 use futures::sink::SinkExt;
 
+pub(crate) type OfflineAudioContextCallback =
+    dyn FnOnce(&mut OfflineAudioContext) + Send + Sync + 'static;
+
 /// The `OfflineAudioContext` doesn't render the audio to the device hardware; instead, it generates
 /// it, as fast as it can, and outputs the result to an `AudioBuffer`.
 // the naming comes from the web audio specification
@@ -30,8 +33,11 @@ pub struct OfflineAudioContext {
 struct OfflineAudioContextRenderer {
     /// the rendering 'thread', fully controlled by the offline context
     renderer: RenderThread,
-    /// callbacks to run at certain render quanta (via `suspend`)
-    suspend_callbacks: HashMap<usize, oneshot::Sender<()>>,
+    /// promises to resolve at certain render quanta (via `suspend`)
+    suspend_promises: HashMap<usize, oneshot::Sender<()>>,
+    /// callbacks to run at certain render quanta (via `suspend_sync`)
+    suspend_callbacks: HashMap<usize, Box<OfflineAudioContextCallback>>,
+    /// channel to listen for `resume` calls on a suspended context
     resume_receiver: futures::channel::mpsc::Receiver<()>,
 }
 
@@ -90,6 +96,7 @@ impl OfflineAudioContext {
 
         let renderer = OfflineAudioContextRenderer {
             renderer,
+            suspend_promises: HashMap::new(),
             suspend_callbacks: HashMap::new(),
             resume_receiver,
         };
@@ -107,17 +114,33 @@ impl OfflineAudioContext {
     /// This function will block the current thread and returns the rendered `AudioBuffer`
     /// synchronously.
     ///
+    /// This method will only adhere to scheduled suspensions via [`Self::suspend_at_sync`] and
+    /// will ignore those provided via [`Self::suspend_at`].
+    ///
     /// # Panics
     ///
     /// Panics if this method is called multiple times
     pub fn start_rendering_sync(&mut self) -> AudioBuffer {
-        todo!()
+        let renderer = match self.renderer.lock().unwrap().take() {
+            None => panic!("InvalidStateError: Cannot call `startRendering` twice"),
+            Some(v) => v,
+        };
+        let OfflineAudioContextRenderer {
+            renderer,
+            suspend_callbacks,
+            ..
+        } = renderer;
+
+        renderer.render_audiobuffer_sync(self.length, suspend_callbacks, self)
     }
 
     /// Given the current connections and scheduled changes, starts rendering audio.
     ///
     /// Rendering is purely CPU bound and contains no `await` points, so calling this method will
     /// block the executor until completion or until the context is suspended.
+    ///
+    /// This method will only adhere to scheduled suspensions via [`Self::suspend_at`] and will
+    /// ignore those provided via [`Self::suspend_at_sync`].
     ///
     /// # Panics
     ///
@@ -129,13 +152,15 @@ impl OfflineAudioContext {
             Some(v) => v,
         };
 
+        let OfflineAudioContextRenderer {
+            renderer,
+            suspend_promises,
+            resume_receiver,
+            ..
+        } = renderer;
+
         renderer
-            .renderer
-            .render_audiobuffer(
-                self.length,
-                renderer.suspend_callbacks,
-                renderer.resume_receiver,
-            )
+            .render_audiobuffer(self.length, suspend_promises, resume_receiver)
             .await
     }
 
@@ -148,7 +173,7 @@ impl OfflineAudioContext {
     }
 
     /// Schedules a suspension of the time progression in the audio context at the specified time
-    /// and runs a callback.
+    /// and returns a promise
     ///
     /// The specified time is quantized and rounded up to the render quantum size.
     ///
@@ -160,6 +185,34 @@ impl OfflineAudioContext {
     /// - is less than or equal to the current time or
     /// - is greater than or equal to the total render duration or
     /// - is scheduled by another suspend for the same time
+    ///
+    /// # Example usage
+    ///
+    /// ```rust
+    /// use futures::{executor, join};
+    /// use futures::future::FutureExt;
+    /// use std::sync::Arc;
+    ///
+    /// use web_audio_api::context::BaseAudioContext;
+    /// use web_audio_api::context::OfflineAudioContext;
+    /// use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
+    ///
+    /// let context = Arc::new(OfflineAudioContext::new(1, 512, 44_100.));
+    /// let context_clone = Arc::clone(&context.clone());
+    ///
+    /// let suspend_promise = context.suspend_at(128. / 44_100.).then(|_| async move {
+    ///     let mut src = context_clone.create_constant_source();
+    ///     src.connect(&context_clone.destination());
+    ///     src.start();
+    ///     context_clone.resume().await;
+    /// });
+    ///
+    /// let render_promise = context.start_rendering();
+    ///
+    /// let buffer = executor::block_on(async move { join!(suspend_promise, render_promise).1 });
+    /// assert_eq!(buffer.number_of_channels(), 1);
+    /// assert_eq!(buffer.length(), 512);
+    /// ```
     pub async fn suspend_at(&self, suspend_time: f64) {
         let quantum = (suspend_time * self.base.sample_rate() as f64 / RENDER_QUANTUM_SIZE as f64)
             .ceil() as usize;
@@ -171,7 +224,7 @@ impl OfflineAudioContext {
             let mut lock = self.renderer.lock().unwrap();
             let renderer = lock.as_mut().unwrap();
 
-            match renderer.suspend_callbacks.entry(quantum) {
+            match renderer.suspend_promises.entry(quantum) {
                 Entry::Occupied(_) => panic!(
                     "InvalidStateError: cannot suspend multiple times at the same render quantum"
                 ),
@@ -182,6 +235,63 @@ impl OfflineAudioContext {
         } // lock is dropped
 
         receiver.await.unwrap()
+    }
+
+    /// Schedules a suspension of the time progression in the audio context at the specified time
+    /// and runs a callback.
+    ///
+    /// This is a synchronous version of [`Self::suspend_at`] that runs the provided callback at
+    /// the `suspendTime`. The rendering resumes automatically after the callback has run, so there
+    /// is no `resume_sync` method.
+    ///
+    /// The specified time is quantized and rounded up to the render quantum size.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the quantized frame number
+    ///
+    /// - is negative or
+    /// - is less than or equal to the current time or
+    /// - is greater than or equal to the total render duration or
+    /// - is scheduled by another suspend for the same time
+    ///
+    /// # Example usage
+    ///
+    /// ```rust
+    /// use web_audio_api::context::BaseAudioContext;
+    /// use web_audio_api::context::OfflineAudioContext;
+    /// use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
+    ///
+    /// let mut context = OfflineAudioContext::new(1, 512, 44_100.);
+    ///
+    /// context.suspend_at_sync(128. / 44_100., |context| {
+    ///     let mut src = context.create_constant_source();
+    ///     src.connect(&context.destination());
+    ///     src.start();
+    /// });
+    ///
+    /// let buffer = context.start_rendering_sync();
+    /// assert_eq!(buffer.number_of_channels(), 1);
+    /// assert_eq!(buffer.length(), 512);
+    /// ```
+    pub fn suspend_at_sync<F: FnOnce(&mut Self) + Send + Sync + 'static>(
+        &mut self,
+        suspend_time: f64,
+        callback: F,
+    ) {
+        let quantum = (suspend_time * self.base.sample_rate() as f64 / RENDER_QUANTUM_SIZE as f64)
+            .ceil() as usize;
+
+        let mut lock = self.renderer.lock().unwrap();
+        let renderer = lock.as_mut().unwrap();
+        match renderer.suspend_callbacks.entry(quantum) {
+            Entry::Occupied(_) => panic!(
+                "InvalidStateError: cannot suspend multiple times at the same render quantum"
+            ),
+            Entry::Vacant(e) => {
+                e.insert(Box::new(callback));
+            }
+        }
     }
 
     /// Resumes the progression of the OfflineAudioContext's currentTime when it has been suspended
@@ -224,7 +334,43 @@ mod tests {
     }
 
     #[test]
-    fn render_suspend_resume() {
+    fn test_suspend_sync() {
+        let len = RENDER_QUANTUM_SIZE * 4;
+        let sample_rate = 48000_f64;
+
+        let mut context = OfflineAudioContext::new(1, len, sample_rate as f32);
+
+        context.suspend_at_sync(RENDER_QUANTUM_SIZE as f64 / sample_rate, |context| {
+            let mut src = context.create_constant_source();
+            src.connect(&context.destination());
+            src.start();
+        });
+
+        context.suspend_at_sync((3 * RENDER_QUANTUM_SIZE) as f64 / sample_rate, |context| {
+            context.destination().disconnect();
+        });
+
+        let output = context.start_rendering_sync();
+
+        assert_float_eq!(
+            output.get_channel_data(0)[..RENDER_QUANTUM_SIZE],
+            &[0.; RENDER_QUANTUM_SIZE][..],
+            abs_all <= 0.
+        );
+        assert_float_eq!(
+            output.get_channel_data(0)[RENDER_QUANTUM_SIZE..3 * RENDER_QUANTUM_SIZE],
+            &[1.; 2 * RENDER_QUANTUM_SIZE][..],
+            abs_all <= 0.
+        );
+        assert_float_eq!(
+            output.get_channel_data(0)[3 * RENDER_QUANTUM_SIZE..4 * RENDER_QUANTUM_SIZE],
+            &[0.; RENDER_QUANTUM_SIZE][..],
+            abs_all <= 0.
+        );
+    }
+
+    #[test]
+    fn render_suspend_resume_async() {
         use futures::executor;
         use futures::future::FutureExt;
         use futures::join;

--- a/src/context/offline.rs
+++ b/src/context/offline.rs
@@ -120,6 +120,7 @@ impl OfflineAudioContext {
     /// # Panics
     ///
     /// Panics if this method is called multiple times
+    #[must_use]
     pub fn start_rendering_sync(&mut self) -> AudioBuffer {
         let renderer = match self.renderer.lock().unwrap().take() {
             None => panic!("InvalidStateError: Cannot call `startRendering` twice"),

--- a/src/context/offline.rs
+++ b/src/context/offline.rs
@@ -9,8 +9,7 @@ use crate::context::{BaseAudioContext, ConcreteBaseAudioContext};
 use crate::render::RenderThread;
 use crate::{assert_valid_sample_rate, RENDER_QUANTUM_SIZE};
 
-pub(crate) type OfflineAudioContextCallback =
-    dyn FnOnce(&mut OfflineAudioContext) + Send + Sync + 'static;
+pub(crate) type OfflineAudioContextCallback = dyn FnOnce(&mut OfflineAudioContext);
 
 /// The `OfflineAudioContext` doesn't render the audio to the device hardware; instead, it generates
 /// it, as fast as it can, and outputs the result to an `AudioBuffer`.
@@ -127,11 +126,7 @@ impl OfflineAudioContext {
     /// - is less than or equal to the current time or
     /// - is greater than or equal to the total render duration or
     /// - is scheduled by another suspend for the same time
-    pub fn suspend_at<F: FnOnce(&mut Self) + Send + Sync + 'static>(
-        &mut self,
-        suspend_time: f64,
-        callback: F,
-    ) {
+    pub fn suspend_at<F: FnOnce(&mut Self) + 'static>(&mut self, suspend_time: f64, callback: F) {
         let quantum = (suspend_time * self.base.sample_rate() as f64 / RENDER_QUANTUM_SIZE as f64)
             .ceil() as usize;
         match self.suspend_callbacks.entry(quantum) {

--- a/src/context/offline.rs
+++ b/src/context/offline.rs
@@ -9,7 +9,8 @@ use crate::context::{BaseAudioContext, ConcreteBaseAudioContext};
 use crate::render::RenderThread;
 use crate::{assert_valid_sample_rate, RENDER_QUANTUM_SIZE};
 
-pub(crate) type OfflineAudioContextCallback = dyn FnOnce(&mut OfflineAudioContext);
+pub(crate) type OfflineAudioContextCallback =
+    dyn FnOnce(&mut OfflineAudioContext) + Send + Sync + 'static;
 
 /// The `OfflineAudioContext` doesn't render the audio to the device hardware; instead, it generates
 /// it, as fast as it can, and outputs the result to an `AudioBuffer`.
@@ -126,7 +127,11 @@ impl OfflineAudioContext {
     /// - is less than or equal to the current time or
     /// - is greater than or equal to the total render duration or
     /// - is scheduled by another suspend for the same time
-    pub fn suspend_at<F: FnOnce(&mut Self) + 'static>(&mut self, suspend_time: f64, callback: F) {
+    pub fn suspend_at<F: FnOnce(&mut Self) + Send + Sync + 'static>(
+        &mut self,
+        suspend_time: f64,
+        callback: F,
+    ) {
         let quantum = (suspend_time * self.base.sample_rate() as f64 / RENDER_QUANTUM_SIZE as f64)
             .ceil() as usize;
         match self.suspend_callbacks.entry(quantum) {

--- a/src/context/offline.rs
+++ b/src/context/offline.rs
@@ -198,7 +198,7 @@ impl OfflineAudioContext {
     /// use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
     ///
     /// let context = Arc::new(OfflineAudioContext::new(1, 512, 44_100.));
-    /// let context_clone = Arc::clone(&context.clone());
+    /// let context_clone = Arc::clone(&context);
     ///
     /// let suspend_promise = context.suspend_at(128. / 44_100.).then(|_| async move {
     ///     let mut src = context_clone.create_constant_source();
@@ -376,7 +376,7 @@ mod tests {
         use futures::join;
 
         let context = Arc::new(OfflineAudioContext::new(1, 512, 44_100.));
-        let context_clone = Arc::clone(&context.clone());
+        let context_clone = Arc::clone(&context);
 
         let suspend_promise = context.suspend_at(128. / 44_100.).then(|_| async move {
             let mut src = context_clone.create_constant_source();

--- a/src/node/waveshaper.rs
+++ b/src/node/waveshaper.rs
@@ -600,7 +600,7 @@ mod tests {
 
         let shaper = WaveShaperNode::new(&context, options);
 
-        context.start_rendering_sync();
+        let _ = context.start_rendering_sync();
 
         assert_eq!(shaper.curve(), Some(&[1.0][..]));
         assert_eq!(shaper.oversample(), OverSampleType::X2);
@@ -624,7 +624,7 @@ mod tests {
         shaper.set_curve(vec![2.0]);
         shaper.set_oversample(OverSampleType::X4);
 
-        context.start_rendering_sync();
+        let _ = context.start_rendering_sync();
 
         assert_eq!(shaper.curve(), Some(&[2.0][..]));
         assert_eq!(shaper.oversample(), OverSampleType::X4);
@@ -647,7 +647,7 @@ mod tests {
         shaper.set_curve(vec![2.0]);
         shaper.set_oversample(OverSampleType::X4);
 
-        context.start_rendering_sync();
+        let _ = context.start_rendering_sync();
 
         assert_eq!(shaper.curve(), Some(&[2.0][..]));
         assert_eq!(shaper.oversample(), OverSampleType::X4);

--- a/src/render/thread.rs
+++ b/src/render/thread.rs
@@ -14,7 +14,7 @@ use futures::stream::StreamExt;
 
 use super::AudioRenderQuantum;
 use crate::buffer::{AudioBuffer, AudioBufferOptions};
-use crate::context::AudioNodeId;
+use crate::context::{AudioNodeId, OfflineAudioContext};
 use crate::events::EventDispatch;
 use crate::message::ControlMessage;
 use crate::node::ChannelInterpretation;
@@ -179,8 +179,75 @@ impl RenderThread {
     }
 
     // Render method of the `OfflineAudioContext::start_rendering_sync`
+    //
     // This method is not spec compliant and obviously marked as synchronous, so we
     // don't launch a thread.
+    //
+    // cf. https://webaudio.github.io/web-audio-api/#dom-offlineaudiocontext-startrendering
+    pub fn render_audiobuffer_sync(
+        mut self,
+        length: usize,
+        mut suspend_callbacks: HashMap<usize, Box<crate::context::OfflineAudioContextCallback>>,
+        context: &mut OfflineAudioContext,
+    ) -> AudioBuffer {
+        let options = AudioBufferOptions {
+            number_of_channels: self.number_of_channels,
+            length,
+            sample_rate: self.sample_rate,
+        };
+
+        let mut buffer = AudioBuffer::new(options);
+        let num_frames = (length + RENDER_QUANTUM_SIZE - 1) / RENDER_QUANTUM_SIZE;
+
+        for quantum in 0..num_frames {
+            // Suspend at given times and run callbacks
+            if let Some(callback) = suspend_callbacks.remove(&quantum) {
+                (callback)(context)
+            }
+
+            // Handle addition/removal of nodes/edges
+            self.handle_control_messages();
+
+            // Update time
+            let current_frame = self
+                .frames_played
+                .fetch_add(RENDER_QUANTUM_SIZE as u64, Ordering::SeqCst);
+            let current_time = current_frame as f64 / self.sample_rate as f64;
+
+            let scope = RenderScope {
+                current_frame,
+                current_time,
+                sample_rate: self.sample_rate,
+                event_sender: self.event_sender.clone(),
+                node_id: Cell::new(AudioNodeId(0)), // placeholder value
+            };
+
+            // Render audio graph
+            let graph = self.graph.as_mut().unwrap();
+
+            // For x64 and aarch, process with denormal floats disabled (for performance, #194)
+            #[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
+            let rendered = no_denormals::no_denormals(|| graph.render(&scope));
+            #[cfg(not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")))]
+            let rendered = graph.render(&scope);
+
+            rendered.channels().iter().enumerate().for_each(
+                |(channel_number, rendered_channel)| {
+                    buffer.copy_to_channel_with_offset(
+                        rendered_channel,
+                        channel_number,
+                        current_frame as usize,
+                    );
+                },
+            );
+        }
+
+        buffer
+    }
+
+    // Render method of the `OfflineAudioContext::start_rendering`
+    //
+    // This is the async interface, as compared to render_audiobuffer_sync
     //
     // cf. https://webaudio.github.io/web-audio-api/#dom-offlineaudiocontext-startrendering
     pub async fn render_audiobuffer(

--- a/tests/offline.rs
+++ b/tests/offline.rs
@@ -242,39 +242,3 @@ fn test_cycle_breaker() {
         abs_all <= 0.
     );
 }
-
-#[test]
-fn test_suspend() {
-    let len = RENDER_QUANTUM_SIZE * 4;
-    let sample_rate = 48000_f64;
-
-    let mut context = OfflineAudioContext::new(1, len, sample_rate as f32);
-
-    context.suspend_at(RENDER_QUANTUM_SIZE as f64 / sample_rate, |context| {
-        let mut src = context.create_constant_source();
-        src.connect(&context.destination());
-        src.start();
-    });
-
-    context.suspend_at((3 * RENDER_QUANTUM_SIZE) as f64 / sample_rate, |context| {
-        context.destination().disconnect();
-    });
-
-    let output = context.start_rendering_sync();
-
-    assert_float_eq!(
-        output.get_channel_data(0)[..RENDER_QUANTUM_SIZE],
-        &[0.; RENDER_QUANTUM_SIZE][..],
-        abs_all <= 0.
-    );
-    assert_float_eq!(
-        output.get_channel_data(0)[RENDER_QUANTUM_SIZE..3 * RENDER_QUANTUM_SIZE],
-        &[1.; 2 * RENDER_QUANTUM_SIZE][..],
-        abs_all <= 0.
-    );
-    assert_float_eq!(
-        output.get_channel_data(0)[3 * RENDER_QUANTUM_SIZE..4 * RENDER_QUANTUM_SIZE],
-        &[0.; RENDER_QUANTUM_SIZE][..],
-        abs_all <= 0.
-    );
-}


### PR DESCRIPTION
Todo:

- [x] Decide if we like the `sync` interface this way
- [x] Check if it solves our node-binding issues
- [x] Address performance regression (caused by checking the need to suspend every quantum)