### PR TITLE
fix: implement clear_onstatechange and fix some event types

### DIFF
--- a/src/context/base.rs
+++ b/src/context/base.rs
@@ -309,7 +309,7 @@ pub trait BaseAudioContext {
     fn set_onstatechange<F: FnMut(Event) + Send + 'static>(&self, mut callback: F) {
         let callback = move |_| {
             callback(Event {
-                type_: "onstatechange",
+                type_: "statechange",
             })
         };
 
@@ -317,6 +317,10 @@ pub trait BaseAudioContext {
             EventType::StateChange,
             EventHandler::Multiple(Box::new(callback)),
         );
+    }
+
+    fn clear_onstatechange(&self) {
+        self.base().clear_event_handler(EventType::StateChange);
     }
 
     #[cfg(test)]

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -329,7 +329,7 @@ impl AudioContext {
     pub fn set_onsinkchange<F: FnMut(Event) + Send + 'static>(&self, mut callback: F) {
         let callback = move |_| {
             callback(Event {
-                type_: "onsinkchange",
+                type_: "sinkchange",
             })
         };
 


### PR DESCRIPTION
Some small fixes on issues I encountered while trying to review the EventTarget implementation