### PR TITLE
Assert `AudioScheduledSourceNode` node start and stop arguments are valid

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,8 +185,8 @@ pub(crate) fn assert_valid_number_of_channels(number_of_channels: usize) {
     }
 }
 
-/// Assert that the given channel number is valid according the number of channel
-/// of an Audio asset (e.g. [`AudioBuffer`])
+/// Assert that the given channel number is valid according to the number of channels
+/// of an Audio asset (e.g. [`AudioBuffer`]).
 ///
 /// # Panics
 ///
@@ -203,6 +203,27 @@ pub(crate) fn assert_valid_channel_number(channel_number: usize, number_of_chann
         );
     }
 }
+
+/// Assert that the given value number is a valid time informations, i.e. greater
+/// than or equal to zero and finite.
+///
+/// # Panics
+///
+/// This function will panic if:
+/// - the given value is not finite and lower than zero
+///
+#[track_caller]
+#[inline(always)]
+pub(crate) fn assert_valid_time_value(value: f64) {
+    if !value.is_finite() {
+        panic!("TypeError - The provided time value is non-finite.");
+    }
+
+    if value < 0. {
+        panic!("RangeError - The provided time value ({:?}) cannot be negative", value);
+    }
+}
+
 
 pub(crate) trait AudioBufferIter: Iterator<Item = FallibleBuffer> + Send + 'static {}
 
@@ -264,5 +285,23 @@ mod tests {
     fn test_valid_number_of_channels() {
         assert_valid_number_of_channels(1);
         assert_valid_number_of_channels(32);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_time_value_non_finite() {
+        assert_valid_time_value(f64::NAN);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_time_value_negative() {
+        assert_valid_time_value(-1.);
+    }
+
+    #[test]
+    fn test_valid_time_value() {
+        assert_valid_time_value(0.);
+        assert_valid_time_value(1.);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,7 @@ pub(crate) fn assert_valid_channel_number(channel_number: usize, number_of_chann
     }
 }
 
-/// Assert that the given value number is a valid time informations, i.e. greater
+/// Assert that the given value number is a valid time information, i.e. greater
 /// than or equal to zero and finite.
 ///
 /// # Panics

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,10 +220,12 @@ pub(crate) fn assert_valid_time_value(value: f64) {
     }
 
     if value < 0. {
-        panic!("RangeError - The provided time value ({:?}) cannot be negative", value);
+        panic!(
+            "RangeError - The provided time value ({:?}) cannot be negative",
+            value
+        );
     }
 }
-
 
 pub(crate) trait AudioBufferIter: Iterator<Item = FallibleBuffer> + Send + 'static {}
 

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -366,18 +366,6 @@ pub trait AudioNode {
     }
 }
 
-#[track_caller]
-#[inline(always)]
-pub(create) fn assert_greater_then_f64(value: f64, minimum_bound: f64) {
-    if !value.is_finite() {
-        panic!("TypeError - The provided value is non-finite.");
-    }
-
-    if value < 0. {
-        panic!("RangeError - The offset value ({:?}) is less than the minimum bound (0).", value, minimum_bound);
-    }
-}
-
 /// Interface of source nodes, controlling start and stop times.
 /// The node will emit silence before it is started, and after it has ended.
 pub trait AudioScheduledSourceNode: AudioNode {
@@ -487,27 +475,5 @@ impl<R: AudioBufferIter> AudioProcessor for MediaStreamRenderer<R> {
         }
 
         !self.finished
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    #[should_panic]
-    fn test_assert_positive_f64_1() {
-        assert_positive_f64(f64::NAN);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_assert_positive_f64_1() {
-        assert_positive_f64(-1.);
-    }
-
-    #[test]
-    fn test_assert_positive_f64_1() {
-        assert_positive_f64(1.);
     }
 }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -366,6 +366,18 @@ pub trait AudioNode {
     }
 }
 
+#[track_caller]
+#[inline(always)]
+pub(create) fn assert_greater_then_f64(value: f64, minimum_bound: f64) {
+    if !value.is_finite() {
+        panic!("TypeError - The provided value is non-finite.");
+    }
+
+    if value < 0. {
+        panic!("RangeError - The offset value ({:?}) is less than the minimum bound (0).", value, minimum_bound);
+    }
+}
+
 /// Interface of source nodes, controlling start and stop times.
 /// The node will emit silence before it is started, and after it has ended.
 pub trait AudioScheduledSourceNode: AudioNode {
@@ -475,5 +487,27 @@ impl<R: AudioBufferIter> AudioProcessor for MediaStreamRenderer<R> {
         }
 
         !self.finished
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic]
+    fn test_assert_positive_f64_1() {
+        assert_positive_f64(f64::NAN);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_assert_positive_f64_1() {
+        assert_positive_f64(-1.);
+    }
+
+    #[test]
+    fn test_assert_positive_f64_1() {
+        assert_positive_f64(1.);
     }
 }

--- a/src/node/panner.rs
+++ b/src/node/panner.rs
@@ -174,7 +174,7 @@ enum ControlMessage {
 #[inline(always)]
 fn assert_valid_channel_count(count: usize) {
     if count > 2 {
-        panic!("NotSupportedError: PannerNode channel count cannot be greater than two");
+        panic!("NotSupportedError - PannerNode channel count cannot be greater than two");
     }
 }
 
@@ -189,7 +189,7 @@ fn assert_valid_channel_count(count: usize) {
 #[inline(always)]
 fn assert_valid_channel_count_mode(mode: ChannelCountMode) {
     if mode == ChannelCountMode::Max {
-        panic!("NotSupportedError: PannerNode channel count mode cannot be set to max");
+        panic!("NotSupportedError - PannerNode channel count mode cannot be set to max");
     }
 }
 

--- a/src/node/stereo_panner.rs
+++ b/src/node/stereo_panner.rs
@@ -44,7 +44,7 @@ impl Default for StereoPannerOptions {
 #[inline(always)]
 fn assert_valid_channel_count(count: usize) {
     if count > 2 {
-        panic!("NotSupportedError: StereoPannerNode channel count cannot be greater than two");
+        panic!("NotSupportedError - StereoPannerNode channel count cannot be greater than two");
     }
 }
 
@@ -59,7 +59,7 @@ fn assert_valid_channel_count(count: usize) {
 #[inline(always)]
 fn assert_valid_channel_count_mode(mode: ChannelCountMode) {
     if mode == ChannelCountMode::Max {
-        panic!("NotSupportedError: StereoPannerNode channel count mode cannot be set to max");
+        panic!("NotSupportedError - StereoPannerNode channel count mode cannot be set to max");
     }
 }
 


### PR DESCRIPTION
Ensure values given to start and stop are valid according to spec and wpt

cf. 
- https://webaudio.github.io/web-audio-api/#AudioScheduledSourceNode-methods
- https://webaudio.github.io/web-audio-api/#AudioBufferSourceNode-methods
