### PR TITLE
Set BaseAudioContext::state by render thread to signal device readiness

### DIFF
--- a/src/context/concrete_base.rs
+++ b/src/context/concrete_base.rs
@@ -147,6 +147,7 @@ impl BaseAudioContext for ConcreteBaseAudioContext {
 
 impl ConcreteBaseAudioContext {
     /// Creates a `BaseAudioContext` instance
+    #[allow(clippy::too_many_arguments)] // TODO refactor with builder pattern
     pub(super) fn new(
         sample_rate: f32,
         max_channel_count: usize,

--- a/src/context/concrete_base.rs
+++ b/src/context/concrete_base.rs
@@ -91,8 +91,8 @@ struct ConcreteBaseAudioContextInner {
     listener_params: Option<AudioListenerParams>,
     /// Denotes if this AudioContext is offline or not
     offline: bool,
-    /// Describes the current state of the `ConcreteBaseAudioContext`
-    state: AtomicU8,
+    /// Current state of the `ConcreteBaseAudioContext`, shared with the RenderThread
+    state: Arc<AtomicU8>,
     /// Stores the event handlers
     event_loop: EventLoop,
     /// Sender for events that will be handled by the EventLoop
@@ -150,6 +150,7 @@ impl ConcreteBaseAudioContext {
     pub(super) fn new(
         sample_rate: f32,
         max_channel_count: usize,
+        state: Arc<AtomicU8>,
         frames_played: Arc<AtomicU64>,
         render_channel: Sender<ControlMessage>,
         event_channel: Option<(Sender<EventDispatch>, Receiver<EventDispatch>)>,
@@ -175,7 +176,7 @@ impl ConcreteBaseAudioContext {
             queued_audio_listener_msgs: Mutex::new(Vec::new()),
             listener_params: None,
             offline,
-            state: AtomicU8::new(AudioContextState::Suspended as u8),
+            state,
             event_loop: event_loop.clone(),
             event_send,
         };
@@ -263,7 +264,6 @@ impl ConcreteBaseAudioContext {
         if self.state() != AudioContextState::Closed {
             let result = self.inner.render_channel.read().unwrap().send(msg);
             if result.is_err() {
-                self.set_state(AudioContextState::Closed);
                 log::warn!("Discarding control message - render thread is closed");
             }
         }
@@ -333,14 +333,14 @@ impl ConcreteBaseAudioContext {
     /// Returns state of current context
     #[must_use]
     pub(super) fn state(&self) -> AudioContextState {
-        self.inner.state.load(Ordering::SeqCst).into()
+        self.inner.state.load(Ordering::Acquire).into()
     }
 
     /// Updates state of current context
     pub(super) fn set_state(&self, state: AudioContextState) {
         let current_state = self.state();
         if current_state != state {
-            self.inner.state.store(state as u8, Ordering::SeqCst);
+            self.inner.state.store(state as u8, Ordering::Release);
             let _ = self.send_event(EventDispatch::state_change());
         }
     }

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -390,8 +390,8 @@ impl AudioContext {
         // First, pause rendering via a control message
         let (sender, receiver) = oneshot::channel();
         let notify = OneshotNotify::Async(sender);
-        let suspend_msg = ControlMessage::Suspend { notify };
-        self.base.send_control_msg(suspend_msg);
+        self.base
+            .send_control_msg(ControlMessage::Suspend { notify });
 
         // Wait for the render thread to have processed the suspend message.
         // The AudioContextState will be updated by the render thread.
@@ -417,8 +417,8 @@ impl AudioContext {
         // Then, ask to resume rendering via a control message
         let (sender, receiver) = oneshot::channel();
         let notify = OneshotNotify::Async(sender);
-        let suspend_msg = ControlMessage::Resume { notify };
-        self.base.send_control_msg(suspend_msg);
+        self.base
+            .send_control_msg(ControlMessage::Resume { notify });
 
         // Wait for the render thread to have processed the resume message
         // The AudioContextState will be updated by the render thread.
@@ -437,8 +437,7 @@ impl AudioContext {
         // First, stop rendering via a control message
         let (sender, receiver) = oneshot::channel();
         let notify = OneshotNotify::Async(sender);
-        let suspend_msg = ControlMessage::Close { notify };
-        self.base.send_control_msg(suspend_msg);
+        self.base.send_control_msg(ControlMessage::Close { notify });
 
         // Wait for the render thread to have processed the suspend message.
         // The AudioContextState will be updated by the render thread.
@@ -471,8 +470,8 @@ impl AudioContext {
         // First, pause rendering via a control message
         let (sender, receiver) = crossbeam_channel::bounded(0);
         let notify = OneshotNotify::Sync(sender);
-        let suspend_msg = ControlMessage::Suspend { notify };
-        self.base.send_control_msg(suspend_msg);
+        self.base
+            .send_control_msg(ControlMessage::Suspend { notify });
 
         // Wait for the render thread to have processed the suspend message.
         // The AudioContextState will be updated by the render thread.
@@ -501,8 +500,8 @@ impl AudioContext {
         // Then, ask to resume rendering via a control message
         let (sender, receiver) = crossbeam_channel::bounded(0);
         let notify = OneshotNotify::Sync(sender);
-        let suspend_msg = ControlMessage::Resume { notify };
-        self.base.send_control_msg(suspend_msg);
+        self.base
+            .send_control_msg(ControlMessage::Resume { notify });
 
         // Wait for the render thread to have processed the resume message
         // The AudioContextState will be updated by the render thread.
@@ -524,8 +523,7 @@ impl AudioContext {
         // First, stop rendering via a control message
         let (sender, receiver) = crossbeam_channel::bounded(0);
         let notify = OneshotNotify::Sync(sender);
-        let suspend_msg = ControlMessage::Close { notify };
-        self.base.send_control_msg(suspend_msg);
+        self.base.send_control_msg(ControlMessage::Close { notify });
 
         // Wait for the render thread to have processed the suspend message.
         // The AudioContextState will be updated by the render thread.

--- a/src/io/cpal.rs
+++ b/src/io/cpal.rs
@@ -123,6 +123,7 @@ impl AudioBackendManager for CpalBackend {
         log::info!("Audio Output Host: cpal {:?}", host.id());
 
         let RenderThreadInit {
+            state,
             frames_played,
             ctrl_msg_recv,
             load_value_send,
@@ -190,6 +191,7 @@ impl AudioBackendManager for CpalBackend {
             sample_rate,
             preferred_config.channels as usize,
             ctrl_msg_recv.clone(),
+            Arc::clone(&state),
             Arc::clone(&frames_played),
         );
         renderer.set_event_channels(load_value_send.clone(), event_send.clone());
@@ -231,6 +233,7 @@ impl AudioBackendManager for CpalBackend {
                     sample_rate,
                     supported_config.channels as usize,
                     ctrl_msg_recv,
+                    state,
                     frames_played,
                 );
                 renderer.set_event_channels(load_value_send, event_send);

--- a/src/io/cubeb.rs
+++ b/src/io/cubeb.rs
@@ -151,6 +151,7 @@ impl AudioBackendManager for CubebBackend {
         Self: Sized,
     {
         let RenderThreadInit {
+            state,
             frames_played,
             ctrl_msg_recv,
             load_value_send,
@@ -186,6 +187,7 @@ impl AudioBackendManager for CubebBackend {
             sample_rate,
             number_of_channels,
             ctrl_msg_recv,
+            state,
             frames_played,
         );
         renderer.set_event_channels(load_value_send, event_send);

--- a/src/io/none.rs
+++ b/src/io/none.rs
@@ -71,14 +71,20 @@ impl AudioBackendManager for NoneBackend {
         let sample_rate = options.sample_rate.unwrap_or(48000.);
 
         let RenderThreadInit {
+            state,
             frames_played,
             ctrl_msg_recv,
             load_value_send,
             event_send,
         } = render_thread_init;
 
-        let mut render_thread =
-            RenderThread::new(sample_rate, MAX_CHANNELS, ctrl_msg_recv, frames_played);
+        let mut render_thread = RenderThread::new(
+            sample_rate,
+            MAX_CHANNELS,
+            ctrl_msg_recv,
+            state,
+            frames_played,
+        );
         render_thread.set_event_channels(load_value_send, event_send);
         render_thread.spawn_garbage_collector_thread();
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -40,7 +40,7 @@ pub(crate) enum ControlMessage {
     MarkCycleBreaker { id: AudioNodeId },
 
     /// Shut down and recycle the audio graph
-    Shutdown {
+    CloseAndRecycle {
         sender: crossbeam_channel::Sender<Graph>,
     },
 
@@ -52,6 +52,9 @@ pub(crate) enum ControlMessage {
 
     /// Resume audio processing after suspending
     Resume { notify: OneshotNotify },
+
+    /// Stop audio processing
+    Close { notify: OneshotNotify },
 
     /// Generic message to be handled by AudioProcessor
     NodeMessage {

--- a/tests/online.rs
+++ b/tests/online.rs
@@ -106,10 +106,10 @@ fn test_none_sink_id() {
     assert_eq!(context.sink_id(), "none");
 
     context.suspend_sync();
-    assert_eq!(context.state(), AudioContextState::Suspended);
 
     // give event thread some time to pick up events
     std::thread::sleep(std::time::Duration::from_millis(20));
+    assert_eq!(context.state(), AudioContextState::Suspended);
     assert_eq!(state_changes.load(Ordering::Relaxed), 2); // suspended
 
     context.resume_sync();
@@ -120,6 +120,7 @@ fn test_none_sink_id() {
     assert_eq!(state_changes.load(Ordering::Relaxed), 3); // resumed
 
     context.close_sync();
+    std::thread::sleep(std::time::Duration::from_millis(20));
     assert_eq!(context.state(), AudioContextState::Closed);
 
     // give event thread some time to pick up events

--- a/tests/online.rs
+++ b/tests/online.rs
@@ -106,25 +106,18 @@ fn test_none_sink_id() {
     assert_eq!(context.sink_id(), "none");
 
     context.suspend_sync();
-
-    // give event thread some time to pick up events
-    std::thread::sleep(std::time::Duration::from_millis(20));
     assert_eq!(context.state(), AudioContextState::Suspended);
     assert_eq!(state_changes.load(Ordering::Relaxed), 2); // suspended
 
     context.resume_sync();
     assert_eq!(context.state(), AudioContextState::Running);
-
-    // give event thread some time to pick up events
-    std::thread::sleep(std::time::Duration::from_millis(20));
     assert_eq!(state_changes.load(Ordering::Relaxed), 3); // resumed
 
     context.close_sync();
-    std::thread::sleep(std::time::Duration::from_millis(20));
-    assert_eq!(context.state(), AudioContextState::Closed);
 
     // give event thread some time to pick up events
     std::thread::sleep(std::time::Duration::from_millis(20));
+    assert_eq!(context.state(), AudioContextState::Closed);
     assert!(sink_stable.load(Ordering::SeqCst));
     assert_eq!(state_changes.load(Ordering::Relaxed), 4); // closed
 }

--- a/tests/online.rs
+++ b/tests/online.rs
@@ -9,6 +9,7 @@ use web_audio_api::context::{
 use web_audio_api::node::AudioNode;
 
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::time::Duration;
 use web_audio_api::MAX_CHANNELS;
 
 fn require_send_sync_static<T: Send + Sync + 'static>(_: T) {}
@@ -94,7 +95,7 @@ fn test_none_sink_id() {
     });
 
     // give event thread some time to pick up events
-    std::thread::sleep(std::time::Duration::from_millis(20));
+    std::thread::sleep(Duration::from_millis(5));
     assert_eq!(state_changes.load(Ordering::Relaxed), 1); // started
 
     // changing sink_id to 'none' again should make no changes
@@ -107,15 +108,24 @@ fn test_none_sink_id() {
 
     context.suspend_sync();
     assert_eq!(context.state(), AudioContextState::Suspended);
+
+    // give event thread some time to pick up events
+    std::thread::sleep(Duration::from_millis(5));
     assert_eq!(state_changes.load(Ordering::Relaxed), 2); // suspended
 
     context.resume_sync();
     assert_eq!(context.state(), AudioContextState::Running);
+
+    // give event thread some time to pick up events
+    std::thread::sleep(Duration::from_millis(5));
     assert_eq!(state_changes.load(Ordering::Relaxed), 3); // resumed
 
     context.close_sync();
     assert_eq!(context.state(), AudioContextState::Closed);
     assert!(sink_stable.load(Ordering::SeqCst));
+
+    // give event thread some time to pick up events
+    std::thread::sleep(Duration::from_millis(5));
     assert_eq!(state_changes.load(Ordering::Relaxed), 4); // closed
 }
 
@@ -160,7 +170,7 @@ fn test_panner_node_drop_panic() {
     drop(panner);
 
     // allow the audio render thread to boot and handle adding and dropping the panner
-    std::thread::sleep(std::time::Duration::from_millis(200));
+    std::thread::sleep(Duration::from_millis(200));
 
     // creating a new panner node should not crash the render thread
     let mut _panner = context.create_panner();
@@ -168,7 +178,7 @@ fn test_panner_node_drop_panic() {
     // A crashed thread will not fail the test (only if the main thread panics).
     // Instead inspect if there is progression of time in the audio context.
     let time = context.current_time();
-    std::thread::sleep(std::time::Duration::from_millis(200));
+    std::thread::sleep(Duration::from_millis(200));
     assert!(context.current_time() >= time + 0.15);
 }
 
@@ -187,7 +197,7 @@ fn test_audioparam_outlives_audionode() {
 
     // Start the audio graph, and give some time to drop the gain node (it has no inputs connected
     // so dynamic lifetime will drop the node);
-    std::thread::sleep(std::time::Duration::from_millis(200));
+    std::thread::sleep(Duration::from_millis(200));
 
     // We still have a handle to the param, so that should not be removed from the audio graph.
     // So by updating the value, the render thread should not crash.
@@ -196,7 +206,7 @@ fn test_audioparam_outlives_audionode() {
     // A crashed thread will not fail the test (only if the main thread panics).
     // Instead inspect if there is progression of time in the audio context.
     let time = context.current_time();
-    std::thread::sleep(std::time::Duration::from_millis(200));
+    std::thread::sleep(Duration::from_millis(200));
     assert!(context.current_time() >= time + 0.15);
 }
 
@@ -214,7 +224,7 @@ fn test_closed() {
     drop(context);
 
     // allow some time for the render thread to drop
-    std::thread::sleep(std::time::Duration::from_millis(10));
+    std::thread::sleep(Duration::from_millis(10));
 
     node.disconnect(); // should not panic
 }

--- a/tests/online.rs
+++ b/tests/online.rs
@@ -114,9 +114,6 @@ fn test_none_sink_id() {
     assert_eq!(state_changes.load(Ordering::Relaxed), 3); // resumed
 
     context.close_sync();
-
-    // give event thread some time to pick up events
-    std::thread::sleep(std::time::Duration::from_millis(20));
     assert_eq!(context.state(), AudioContextState::Closed);
     assert!(sink_stable.load(Ordering::SeqCst));
     assert_eq!(state_changes.load(Ordering::Relaxed), 4); // closed


### PR DESCRIPTION
    - A context is instantiated in Suspended state
    - Online context will change to Running at the first render quantum
    - Online context will change to Closed when the render thread is dropped after a `close` call
    - Online context suspend/resume state is still managed by the control thread - TODO
    - Offline context will change to Running after startRendering
    - Offline context will set state to suspended when suspending, running when resumed
    - Offline context will set change to closed when rendering has finished

Fixes #410  #416  #101

It probably also fixes https://github.com/ircam-ismm/node-web-audio-api/pull/61#issuecomment-1871977771
> One thing that I found that is more a concern on the rust side, is that the first "resume" statechange event is sometimes triggered, sometimes not. I think this some kind of race condition but this is a bit weird from a user perspective.

Todo

- [x] find a solution for online AudioContext resume/suspend to signal device 'readiness'. Possible solution: first pause audio rendering by sending a ctrl msg to suspend the audio graph. When that message is handled, then emit the state_change event and update the state and suspend the cpal stream. Similar setup for resuming.
- [x] close_sync on online AudioContext is not truly sync. We don't guarantee the operation has finished before the function returns. Solution: use a channel to communicate if we are done
- [ ] implement oncomplete for offline context - tricky! to be addressed in #411 
- [x] add async methods for suspend/resume/close on online AudioContext