### PR TITLE
fix: unwanted panic at Analiser initialization

### DIFF
--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -188,8 +188,8 @@ impl Analyser {
             ring_buffer,
             fft_size: DEFAULT_FFT_SIZE,
             smoothing_time_constant: DEFAULT_SMOOTHING_TIME_CONSTANT,
-            min_decibels: DEFAULT_MIN_DECIBELS,
-            max_decibels: DEFAULT_MAX_DECIBELS,
+            min_decibels: f64::NEG_INFINITY,
+            max_decibels: f64::INFINITY,
             fft_planner: Mutex::new(fft_planner),
             fft_input,
             fft_scratch,
@@ -636,6 +636,7 @@ mod tests {
     #[should_panic]
     fn test_min_decibels_constraints_lt_max_decibels() {
         let mut analyser = Analyser::new();
+        analyser.set_max_decibels(DEFAULT_MAX_DECIBELS); // init value
         analyser.set_min_decibels(DEFAULT_MAX_DECIBELS);
     }
 
@@ -643,7 +644,15 @@ mod tests {
     #[should_panic]
     fn test_max_decibels_constraints_lt_min_decibels() {
         let mut analyser = Analyser::new();
+        analyser.set_min_decibels(DEFAULT_MIN_DECIBELS); // init value
         analyser.set_max_decibels(DEFAULT_MIN_DECIBELS);
+    }
+
+    #[test]
+    fn test_min_max_decibels_init() {
+        let mut analyser = Analyser::new();
+        analyser.set_min_decibels(-10.);
+        analyser.set_max_decibels(20.);
     }
 
     #[test]

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -60,24 +60,13 @@ fn assert_valid_smoothing_time_constant(smoothing_time_constant: f64) {
     }
 }
 
-// [spec] If the value of this attribute is set to a value more than or equal
-// to maxDecibels, an IndexSizeError exception MUST be thrown.
-fn assert_valid_min_decibels(min_decibels: f64, max_decibels: f64) {
+// [spec] If the value of minDecibels is set to a value more than or equal to maxDecibels, an
+// IndexSizeError exception MUST be thrown.
+fn assert_valid_decibels(min_decibels: f64, max_decibels: f64) {
     if min_decibels >= max_decibels {
         panic!(
             "IndexSizeError - Invalid min decibels: {:?} is greater than or equals to max decibels {:?}",
             min_decibels, max_decibels
-        );
-    }
-}
-
-// [spec] If the value of this attribute is set to a value less than or equal to
-// minDecibels, an IndexSizeError exception MUST be thrown.
-fn assert_valid_max_decibels(max_decibels: f64, min_decibels: f64) {
-    if max_decibels <= min_decibels {
-        panic!(
-            "IndexSizeError - Invalid max decibels: {:?} is lower than or equals to min decibels {:?}",
-            max_decibels, min_decibels
         );
     }
 }
@@ -188,8 +177,8 @@ impl Analyser {
             ring_buffer,
             fft_size: DEFAULT_FFT_SIZE,
             smoothing_time_constant: DEFAULT_SMOOTHING_TIME_CONSTANT,
-            min_decibels: f64::NEG_INFINITY,
-            max_decibels: f64::INFINITY,
+            min_decibels: DEFAULT_MIN_DECIBELS,
+            max_decibels: DEFAULT_MAX_DECIBELS,
             fft_planner: Mutex::new(fft_planner),
             fft_input,
             fft_scratch,
@@ -237,18 +226,16 @@ impl Analyser {
         self.min_decibels
     }
 
-    pub fn set_min_decibels(&mut self, value: f64) {
-        assert_valid_min_decibels(value, self.max_decibels());
-        self.min_decibels = value;
-    }
-
     pub fn max_decibels(&self) -> f64 {
         self.max_decibels
     }
 
-    pub fn set_max_decibels(&mut self, value: f64) {
-        assert_valid_max_decibels(value, self.min_decibels());
-        self.max_decibels = value;
+    pub fn set_decibels(&mut self, min: f64, max: f64) {
+        // set them together to avoid invalid intermediate min/max combinations
+        assert_valid_decibels(min, max);
+
+        self.min_decibels = min;
+        self.min_decibels = max;
     }
 
     pub fn frequency_bin_count(&self) -> usize {
@@ -636,23 +623,14 @@ mod tests {
     #[should_panic]
     fn test_min_decibels_constraints_lt_max_decibels() {
         let mut analyser = Analyser::new();
-        analyser.set_max_decibels(DEFAULT_MAX_DECIBELS); // init value
-        analyser.set_min_decibels(DEFAULT_MAX_DECIBELS);
+        analyser.set_decibels(DEFAULT_MAX_DECIBELS, analyser.max_decibels());
     }
 
     #[test]
     #[should_panic]
     fn test_max_decibels_constraints_lt_min_decibels() {
         let mut analyser = Analyser::new();
-        analyser.set_min_decibels(DEFAULT_MIN_DECIBELS); // init value
-        analyser.set_max_decibels(DEFAULT_MIN_DECIBELS);
-    }
-
-    #[test]
-    fn test_min_max_decibels_init() {
-        let mut analyser = Analyser::new();
-        analyser.set_min_decibels(-10.);
-        analyser.set_max_decibels(20.);
+        analyser.set_decibels(analyser.min_decibels(), DEFAULT_MIN_DECIBELS);
     }
 
     #[test]

--- a/src/node/analyser.rs
+++ b/src/node/analyser.rs
@@ -112,8 +112,7 @@ impl AnalyserNode {
             let mut analyser = Analyser::new();
             analyser.set_fft_size(fft_size);
             analyser.set_smoothing_time_constant(smoothing_time_constant);
-            analyser.set_min_decibels(min_decibels);
-            analyser.set_max_decibels(max_decibels);
+            analyser.set_decibels(min_decibels, max_decibels);
 
             let render = AnalyserRenderer {
                 ring_buffer: analyser.get_ring_buffer_clone(),
@@ -184,7 +183,7 @@ impl AnalyserNode {
     /// This function panics if the value is set to a value more than or equal
     /// to max decibels.
     pub fn set_min_decibels(&mut self, value: f64) {
-        self.analyser.set_min_decibels(value);
+        self.analyser.set_decibels(value, self.max_decibels());
     }
 
     /// Maximum power value in the scaling range for the FFT analysis data for
@@ -204,7 +203,7 @@ impl AnalyserNode {
     /// This function panics if the value is set to a value less than or equal
     /// to min decibels.
     pub fn set_max_decibels(&mut self, value: f64) {
-        self.analyser.set_max_decibels(value);
+        self.analyser.set_decibels(self.min_decibels(), value);
     }
 
     /// Number of bins in the FFT results, is half the FFT size

--- a/src/node/analyser.rs
+++ b/src/node/analyser.rs
@@ -289,7 +289,10 @@ impl AudioProcessor for AnalyserRenderer {
 
 #[cfg(test)]
 mod tests {
-    use crate::context::{AudioContext, AudioContextOptions, BaseAudioContext};
+    use super::*;
+    use crate::context::{
+        AudioContext, AudioContextOptions, BaseAudioContext, OfflineAudioContext,
+    };
     use crate::node::{AudioNode, AudioScheduledSourceNode};
     use float_eq::assert_float_eq;
 
@@ -323,5 +326,16 @@ mod tests {
 
         // should contain the most recent frames available
         assert_float_eq!(&buffer[..], &[1.; 128][..], abs_all <= 0.);
+    }
+
+    #[test]
+    fn test_construct_decibels() {
+        let context = OfflineAudioContext::new(1, 128, 44_100.);
+        let options = AnalyserOptions {
+            min_decibels: -10.,
+            max_decibels: 20.,
+            ..AnalyserOptions::default()
+        };
+        let _ = AnalyserNode::new(&context, options);
     }
 }


### PR DESCRIPTION
There was an issue when initializing the Analyser node, e.g.:

```js
new AnalyserNode(c, {"minDecibels":-10,"maxDecibels":20})
```

Maybe not the cleanest way to go, I wonder if the default values should live in the `node/analyser.rs` and configure the inner analyzer from outside. What do you think?