### PR TITLE
Fix AudioParam behaviour

### DIFF
--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -188,8 +188,8 @@ impl Analyser {
             ring_buffer,
             fft_size: DEFAULT_FFT_SIZE,
             smoothing_time_constant: DEFAULT_SMOOTHING_TIME_CONSTANT,
-            min_decibels: DEFAULT_MIN_DECIBELS,
-            max_decibels: DEFAULT_MAX_DECIBELS,
+            min_decibels: f64::NEG_INFINITY,
+            max_decibels: f64::INFINITY,
             fft_planner: Mutex::new(fft_planner),
             fft_input,
             fft_scratch,
@@ -636,6 +636,7 @@ mod tests {
     #[should_panic]
     fn test_min_decibels_constraints_lt_max_decibels() {
         let mut analyser = Analyser::new();
+        analyser.set_max_decibels(DEFAULT_MAX_DECIBELS); // init value
         analyser.set_min_decibels(DEFAULT_MAX_DECIBELS);
     }
 
@@ -643,7 +644,15 @@ mod tests {
     #[should_panic]
     fn test_max_decibels_constraints_lt_min_decibels() {
         let mut analyser = Analyser::new();
+        analyser.set_min_decibels(DEFAULT_MIN_DECIBELS); // init value
         analyser.set_max_decibels(DEFAULT_MIN_DECIBELS);
+    }
+
+    #[test]
+    fn test_min_max_decibels_init() {
+        let mut analyser = Analyser::new();
+        analyser.set_min_decibels(-10.);
+        analyser.set_max_decibels(20.);
     }
 
     #[test]

--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -257,7 +257,7 @@ impl AudioBufferSourceNode {
         assert_valid_time_value(duration);
         assert!(
             !self.source_started,
-            "InvalidStateError: Cannot call `start` twice"
+            "InvalidStateError - Cannot call `start` twice"
         );
 
         self.source_started = true;

--- a/src/node/delay.rs
+++ b/src/node/delay.rs
@@ -131,13 +131,13 @@ impl AudioNode for DelayNode {
         input: usize,
     ) -> &'a dyn AudioNode {
         if self.context() != dest.context() {
-            panic!("InvalidAccessError: Attempting to connect nodes from different contexts");
+            panic!("InvalidAccessError - Attempting to connect nodes from different contexts");
         }
         if self.number_of_outputs() <= output {
-            panic!("IndexSizeError: output port {} is out of bounds", output);
+            panic!("IndexSizeError - output port {} is out of bounds", output);
         }
         if dest.number_of_inputs() <= input {
-            panic!("IndexSizeError: input port {} is out of bounds", input);
+            panic!("IndexSizeError - input port {} is out of bounds", input);
         }
 
         self.context().connect(

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -268,13 +268,13 @@ pub trait AudioNode {
         input: usize,
     ) -> &'a dyn AudioNode {
         if self.context() != dest.context() {
-            panic!("InvalidAccessError: Attempting to connect nodes from different contexts");
+            panic!("InvalidAccessError - Attempting to connect nodes from different contexts");
         }
         if self.number_of_outputs() <= output {
-            panic!("IndexSizeError: output port {} is out of bounds", output);
+            panic!("IndexSizeError - output port {} is out of bounds", output);
         }
         if dest.number_of_inputs() <= input {
-            panic!("IndexSizeError: input port {} is out of bounds", input);
+            panic!("IndexSizeError - input port {} is out of bounds", input);
         }
 
         self.context().connect(

--- a/src/param.rs
+++ b/src/param.rs
@@ -1,7 +1,7 @@
 //! AudioParam interface
 use std::any::Any;
 use std::slice::{Iter, IterMut};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{Ordering};
 use std::sync::{Arc, OnceLock};
 
 use arrayvec::ArrayVec;
@@ -276,8 +276,9 @@ pub(crate) struct AudioParamRaw {
     max_value: f32,     // immutable
     automation_rate: AutomationRate,
     automation_rate_constrained: bool,
+    current_value: Arc<AtomicF32>,
     // TODO Use `Weak` instead of `Arc`. The `AudioParamProcessor` is the owner.
-    shared_parts: Arc<AudioParamShared>,
+    // shared_parts: Arc<AudioParamShared>,
 }
 
 impl AudioNode for AudioParam {
@@ -366,7 +367,7 @@ impl AudioParam {
     //      test_exponential_ramp_a_rate_multiple_blocks
     //      test_exponential_ramp_k_rate_multiple_blocks
     pub fn value(&self) -> f32 {
-        self.raw_parts.shared_parts.load_current_value()
+        self.raw_parts.current_value.load(Ordering::Acquire)
     }
 
     /// Set the value of the `AudioParam`.
@@ -389,7 +390,7 @@ impl AudioParam {
         assert_is_finite(value);
         // current_value should always be clamped
         let clamped = value.clamp(self.raw_parts.min_value, self.raw_parts.max_value);
-        self.raw_parts.shared_parts.store_current_value(clamped);
+        self.raw_parts.current_value.store(clamped, Ordering::Release);
 
         // this event is meant to update param intrinsic value before any calculation
         // is done, will behave as SetValueAtTime with `time == block_timestamp`
@@ -640,32 +641,6 @@ impl AudioParam {
     }
 }
 
-// Atomic fields of `AudioParam` that could be safely shared between threads
-// when wrapped into an `Arc`.
-//
-// Uses the canonical ordering for handover of values, i.e. `Acquire` on load
-// and `Release` on store.
-#[derive(Debug)]
-pub(crate) struct AudioParamShared {
-    current_value: AtomicF32,
-}
-
-impl AudioParamShared {
-    pub(crate) fn new(current_value: f32) -> Self {
-        Self {
-            current_value: AtomicF32::new(current_value),
-        }
-    }
-
-    pub(crate) fn load_current_value(&self) -> f32 {
-        self.current_value.load(Ordering::Acquire)
-    }
-
-    pub(crate) fn store_current_value(&self, value: f32) {
-        self.current_value.store(value, Ordering::Release);
-    }
-}
-
 struct BlockInfos {
     block_time: f64,
     dt: f64,
@@ -681,7 +656,7 @@ pub(crate) struct AudioParamProcessor {
     max_value: f32,     // immutable
     intrinsic_value: f32,
     automation_rate: AutomationRate,
-    shared_parts: Arc<AudioParamShared>,
+    current_value: Arc<AtomicF32>,
     event_timeline: AudioParamEventTimeline,
     last_event: Option<AudioParamEvent>,
     buffer: ArrayVec<f32, RENDER_QUANTUM_SIZE>,
@@ -1498,7 +1473,7 @@ impl AudioParamProcessor {
         // Set [[current value]] to the value of paramIntrinsicValue at the
         // beginning of this render quantum.
         let clamped = self.intrinsic_value.clamp(self.min_value, self.max_value);
-        self.shared_parts.store_current_value(clamped);
+        self.current_value.store(clamped, Ordering::Release);
 
         // clear the buffer for this block
         self.buffer.clear();
@@ -1603,7 +1578,7 @@ pub(crate) fn audio_param_pair(
         ..
     } = descriptor;
 
-    let shared_parts = Arc::new(AudioParamShared::new(default_value));
+    let current_value = Arc::new(AtomicF32::new(default_value));
 
     let param = AudioParam {
         registration: registration.into(),
@@ -1613,17 +1588,17 @@ pub(crate) fn audio_param_pair(
             min_value,
             automation_rate,
             automation_rate_constrained: false,
-            shared_parts: Arc::clone(&shared_parts),
+            current_value: Arc::clone(&current_value),
         },
     };
 
     let processor = AudioParamProcessor {
         intrinsic_value: default_value,
+        current_value,
         default_value,
         min_value,
         max_value,
         automation_rate,
-        shared_parts,
         event_timeline: AudioParamEventTimeline::new(),
         last_event: None,
         buffer: ArrayVec::new(),

--- a/src/param.rs
+++ b/src/param.rs
@@ -1,7 +1,7 @@
 //! AudioParam interface
 use std::any::Any;
 use std::slice::{Iter, IterMut};
-use std::sync::atomic::{Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, OnceLock};
 
 use arrayvec::ArrayVec;
@@ -390,7 +390,9 @@ impl AudioParam {
         assert_is_finite(value);
         // current_value should always be clamped
         let clamped = value.clamp(self.raw_parts.min_value, self.raw_parts.max_value);
-        self.raw_parts.current_value.store(clamped, Ordering::Release);
+        self.raw_parts
+            .current_value
+            .store(clamped, Ordering::Release);
 
         // this event is meant to update param intrinsic value before any calculation
         // is done, will behave as SetValueAtTime with `time == block_timestamp`

--- a/src/param.rs
+++ b/src/param.rs
@@ -274,6 +274,7 @@ pub(crate) struct AudioParamRaw {
     default_value: f32, // immutable
     min_value: f32,     // immutable
     max_value: f32,     // immutable
+    automation_rate: AutomationRate,
     automation_rate_constrained: bool,
     // TODO Use `Weak` instead of `Arc`. The `AudioParamProcessor` is the owner.
     shared_parts: Arc<AudioParamShared>,
@@ -318,7 +319,7 @@ impl AudioNode for AudioParam {
 impl AudioParam {
     /// Current value of the automation rate of the AudioParam
     pub fn automation_rate(&self) -> AutomationRate {
-        self.raw_parts.shared_parts.load_automation_rate()
+        self.raw_parts.automation_rate
     }
 
     /// Update the current value of the automation rate of the AudioParam
@@ -331,7 +332,9 @@ impl AudioParam {
             panic!("InvalidStateError: automation rate cannot be changed for this param");
         }
 
+        self.automation_rate = value;
         self.registration().post_message(value);
+
         value
     }
 

--- a/src/param.rs
+++ b/src/param.rs
@@ -328,15 +328,13 @@ impl AudioParam {
     /// # Panics
     ///
     /// Some nodes have automation rate constraints and may panic when updating the value.
-    pub fn set_automation_rate(&mut self, value: AutomationRate) -> AutomationRate {
+    pub fn set_automation_rate(&mut self, value: AutomationRate) {
         if self.raw_parts.automation_rate_constrained && value != self.automation_rate() {
             panic!("InvalidStateError: automation rate cannot be changed for this param");
         }
 
         self.raw_parts.automation_rate = value;
         self.registration().post_message(value);
-
-        value
     }
 
     pub(crate) fn set_automation_rate_constrained(&mut self, value: bool) {
@@ -381,9 +379,8 @@ impl AudioParam {
     // Any exceptions that would be thrown by setValueAtTime() will also be
     // thrown by setting this attribute.
     // cf. https://www.w3.org/TR/webaudio/#dom-audioparam-value
-    pub fn set_value(&self, value: f32) -> f32 {
+    pub fn set_value(&self, value: f32) {
         self.send_event(self.set_value_raw(value));
-        value
     }
 
     fn set_value_raw(&self, value: f32) -> AudioParamEvent {


### PR DESCRIPTION
Hey, some new stuff regarding AudioParam

- Fix `AudioParam` argument parsing
- Fix AutomationRate set behaviour on control thread
- ~Fix return value for raw setters (i.e. `set_value` and `set_automation_rate`)~~
- Fix return value for raw `set_value` setter
- Some refactoring