### PR TITLE
Fix: AudioParam initial values should be visible immediately

### DIFF
--- a/src/node/constant_source.rs
+++ b/src/node/constant_source.rs
@@ -235,6 +235,16 @@ mod tests {
 
     use float_eq::assert_float_eq;
 
+    use super::*;
+
+    #[test]
+    fn test_audioparam_value_applies_immediately() {
+        let context = OfflineAudioContext::new(1, 128, 48000.);
+        let options = ConstantSourceOptions { offset: 12. };
+        let src = ConstantSourceNode::new(&context, options);
+        assert_float_eq!(src.offset.value(), 12., abs_all <= 0.);
+    }
+
     #[test]
     fn test_start_stop() {
         let sample_rate = 48000.;

--- a/src/node/delay.rs
+++ b/src/node/delay.rs
@@ -236,7 +236,7 @@ impl DelayNode {
                 };
                 let (param, proc) = context.create_audio_param(param_opts, &reader_registration);
 
-                param.set_value_at_time(options.delay_time as f32, 0.);
+                param.set_value(options.delay_time as f32);
 
                 let reader_render = DelayReader {
                     delay_time: proc,
@@ -659,6 +659,17 @@ mod tests {
     use crate::node::AudioScheduledSourceNode;
 
     use super::*;
+
+    #[test]
+    fn test_audioparam_value_applies_immediately() {
+        let context = OfflineAudioContext::new(1, 128, 48000.);
+        let options = DelayOptions {
+            delay_time: 0.12,
+            ..Default::default()
+        };
+        let src = DelayNode::new(&context, options);
+        assert_float_eq!(src.delay_time.value(), 0.12, abs_all <= 0.);
+    }
 
     #[test]
     fn test_sample_accurate() {

--- a/src/node/gain.rs
+++ b/src/node/gain.rs
@@ -60,7 +60,7 @@ impl GainNode {
             };
             let (param, proc) = context.create_audio_param(param_opts, &registration);
 
-            param.set_value_at_time(options.gain, 0.);
+            param.set_value(options.gain);
 
             let render = GainRenderer { gain: proc };
 
@@ -139,5 +139,23 @@ impl AudioProcessor for GainRenderer {
         }
 
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::OfflineAudioContext;
+    use float_eq::assert_float_eq;
+
+    #[test]
+    fn test_audioparam_value_applies_immediately() {
+        let context = OfflineAudioContext::new(1, 128, 48000.);
+        let options = GainOptions {
+            gain: 0.12,
+            ..Default::default()
+        };
+        let src = GainNode::new(&context, options);
+        assert_float_eq!(src.gain.value(), 0.12, abs_all <= 0.);
     }
 }

--- a/src/node/panner.rs
+++ b/src/node/panner.rs
@@ -429,9 +429,9 @@ impl PannerNode {
             let (param_px, render_px) = context.create_audio_param(PARAM_OPTS, &registration);
             let (param_py, render_py) = context.create_audio_param(PARAM_OPTS, &registration);
             let (param_pz, render_pz) = context.create_audio_param(PARAM_OPTS, &registration);
-            param_px.set_value_at_time(position_x, 0.);
-            param_py.set_value_at_time(position_y, 0.);
-            param_pz.set_value_at_time(position_z, 0.);
+            param_px.set_value(position_x);
+            param_py.set_value(position_y);
+            param_pz.set_value(position_z);
 
             // orientation params
             let orientation_x_opts = AudioParamDescriptor {
@@ -442,9 +442,9 @@ impl PannerNode {
                 context.create_audio_param(orientation_x_opts, &registration);
             let (param_oy, render_oy) = context.create_audio_param(PARAM_OPTS, &registration);
             let (param_oz, render_oz) = context.create_audio_param(PARAM_OPTS, &registration);
-            param_ox.set_value_at_time(orientation_x, 0.);
-            param_oy.set_value_at_time(orientation_y, 0.);
-            param_oz.set_value_at_time(orientation_z, 0.);
+            param_ox.set_value(orientation_x);
+            param_oy.set_value(orientation_y);
+            param_oz.set_value(orientation_z);
 
             let render = PannerRenderer {
                 position_x: render_px,
@@ -1058,6 +1058,17 @@ mod tests {
     use crate::AudioBuffer;
 
     use super::*;
+
+    #[test]
+    fn test_audioparam_value_applies_immediately() {
+        let context = OfflineAudioContext::new(1, 128, 48000.);
+        let options = PannerOptions {
+            position_x: 12.,
+            ..Default::default()
+        };
+        let src = PannerNode::new(&context, options);
+        assert_float_eq!(src.position_x.value(), 12., abs_all <= 0.);
+    }
 
     #[test]
     fn test_equal_power_mono_to_stereo() {


### PR DESCRIPTION
So use set_value instead of set_value_at_time in the node constructors

```
  RESULTS:
  - # pass: 3979 (+9)
  - # fail: 1107 (-9)
  - # type error issues: 59
```