### PR TITLE
Fix: do not upmix inputs to the AudioNode channelCount beforehand

### DIFF
--- a/src/node/biquad_filter.rs
+++ b/src/node/biquad_filter.rs
@@ -649,7 +649,11 @@ impl AudioProcessor for BiquadFilterRenderer {
         };
 
         for (channel_number, output_channel) in output.channels_mut().iter_mut().enumerate() {
-            let input_channel = input.channel_data(channel_number);
+            let input_channel = if input.is_silent() {
+                input.channel_data(0)
+            } else {
+                input.channel_data(channel_number)
+            };
             // retrieve state from previous block
             let mut x1 = self.x1[channel_number];
             let mut x2 = self.x2[channel_number];

--- a/src/node/biquad_filter.rs
+++ b/src/node/biquad_filter.rs
@@ -2,6 +2,7 @@
 use std::any::Any;
 use std::f64::consts::{PI, SQRT_2};
 
+use arrayvec::ArrayVec;
 use num_complex::Complex;
 
 use crate::context::{AudioContextRegistration, AudioParamId, BaseAudioContext};
@@ -396,10 +397,7 @@ impl BiquadFilterNode {
                 frequency: f_proc,
                 q: q_proc,
                 type_,
-                x1: Vec::with_capacity(MAX_CHANNELS),
-                x2: Vec::with_capacity(MAX_CHANNELS),
-                y1: Vec::with_capacity(MAX_CHANNELS),
-                y2: Vec::with_capacity(MAX_CHANNELS),
+                xy: ArrayVec::new(),
             };
 
             let node = Self {
@@ -549,10 +547,7 @@ struct BiquadFilterRenderer {
     /// `BiquadFilterType`
     type_: BiquadFilterType,
     // keep filter state for each channel
-    x1: Vec<f64>,
-    x2: Vec<f64>,
-    y1: Vec<f64>,
-    y2: Vec<f64>,
+    xy: ArrayVec<[f64; 4], MAX_CHANNELS>,
 }
 
 impl AudioProcessor for BiquadFilterRenderer {
@@ -572,10 +567,10 @@ impl AudioProcessor for BiquadFilterRenderer {
         if input.is_silent() {
             let mut ended = true;
 
-            if self.x1.iter().any(|&v| v.is_normal())
-                || self.x2.iter().any(|&v| v.is_normal())
-                || self.y1.iter().any(|&v| v.is_normal())
-                || self.y2.iter().any(|&v| v.is_normal())
+            if self
+                .xy
+                .iter()
+                .any(|v| v.iter().copied().any(f64::is_normal))
             {
                 ended = false;
             }
@@ -595,16 +590,16 @@ impl AudioProcessor for BiquadFilterRenderer {
             // see https://webaudio.github.io/web-audio-api/#channels-tail-time
             let num_channels = input.number_of_channels();
 
-            if num_channels != self.x1.len() {
-                self.x1.resize(num_channels, 0.);
-                self.x2.resize(num_channels, 0.);
-                self.y1.resize(num_channels, 0.);
-                self.y2.resize(num_channels, 0.);
+            if num_channels != self.xy.len() {
+                self.xy.truncate(num_channels);
+                for _ in self.xy.len()..num_channels {
+                    self.xy.push([0.; 4]);
+                }
             }
 
             output.set_number_of_channels(num_channels);
         } else {
-            let num_channels = self.x1.len();
+            let num_channels = self.xy.len();
             output.set_number_of_channels(num_channels);
         }
 
@@ -655,10 +650,9 @@ impl AudioProcessor for BiquadFilterRenderer {
                 input.channel_data(channel_number)
             };
             // retrieve state from previous block
-            let mut x1 = self.x1[channel_number];
-            let mut x2 = self.x2[channel_number];
-            let mut y1 = self.y1[channel_number];
-            let mut y2 = self.y2[channel_number];
+            let (mut x1, mut x2, mut y1, mut y2) = match self.xy[channel_number] {
+                [x1, x2, y1, y2] => (x1, x2, y1, y2),
+            };
 
             output_channel
                 .iter_mut()
@@ -680,10 +674,7 @@ impl AudioProcessor for BiquadFilterRenderer {
                 });
 
             // store channel state for next block
-            self.x1[channel_number] = x1;
-            self.x2[channel_number] = x2;
-            self.y1[channel_number] = y1;
-            self.y2[channel_number] = y2;
+            self.xy[channel_number] = [x1, x2, y1, y2];
         }
 
         true

--- a/src/node/iir_filter.rs
+++ b/src/node/iir_filter.rs
@@ -1,5 +1,7 @@
 //! The IIR filter control and renderer parts
+use arrayvec::ArrayVec;
 use num_complex::Complex;
+
 use std::f64::consts::PI;
 
 use crate::context::{AudioContextRegistration, BaseAudioContext};
@@ -254,7 +256,7 @@ struct IirFilterRenderer {
     /// Normalized filter's coeffs -- `(b[n], a[n])`
     norm_coeffs: Vec<(f64, f64)>,
     /// filter's states
-    states: Vec<Vec<f64>>,
+    states: ArrayVec<Vec<f64>, MAX_CHANNELS>,
 }
 
 impl IirFilterRenderer {
@@ -292,7 +294,11 @@ impl IirFilterRenderer {
         });
 
         let coeffs_len = norm_coeffs.len();
-        let states = vec![Vec::<f64>::with_capacity(MAX_CHANNELS); coeffs_len];
+
+        // eagerly assume stereo input, will adjust during rendering if needed
+        let mut states = ArrayVec::new();
+        states.push(vec![0.; coeffs_len]);
+        states.push(vec![0.; coeffs_len]);
 
         Self {
             norm_coeffs,
@@ -340,15 +346,16 @@ impl AudioProcessor for IirFilterRenderer {
             // see https://webaudio.github.io/web-audio-api/#channels-tail-time
             let num_channels = input.number_of_channels();
 
-            if num_channels != self.states[0].len() {
-                self.states
-                    .iter_mut()
-                    .for_each(|state| state.resize(num_channels, 0.));
+            if num_channels != self.states.len() {
+                self.states.truncate(num_channels);
+                for _ in self.states.len()..num_channels {
+                    self.states.push(vec![0.; self.norm_coeffs.len()]);
+                }
             }
 
             output.set_number_of_channels(num_channels);
         } else {
-            let num_channels = self.states[0].len();
+            let num_channels = self.states.len();
             output.set_number_of_channels(num_channels);
         }
 
@@ -359,17 +366,18 @@ impl AudioProcessor for IirFilterRenderer {
             } else {
                 input.channel_data(channel_number)
             };
+            let channel_state = &mut self.states[channel_number];
 
             for (&i, o) in input_channel.iter().zip(output_channel.iter_mut()) {
                 let input = f64::from(i);
                 let b0 = self.norm_coeffs[0].0;
-                let last_state = self.states[0][channel_number];
+                let last_state = channel_state[0];
                 let output = b0.mul_add(input, last_state);
 
                 // update states for next call
                 for (i, (b, a)) in self.norm_coeffs.iter().skip(1).enumerate() {
-                    let state = self.states[i + 1][channel_number];
-                    self.states[i][channel_number] = b * input - a * output + state;
+                    let state = channel_state[i + 1];
+                    channel_state[i] = b * input - a * output + state;
                 }
 
                 #[cfg(debug_assertions)]

--- a/src/node/iir_filter.rs
+++ b/src/node/iir_filter.rs
@@ -353,12 +353,13 @@ impl AudioProcessor for IirFilterRenderer {
         }
 
         // apply filter
-        for (channel_number, (input_channel, output_channel)) in input
-            .channels()
-            .iter()
-            .zip(output.channels_mut())
-            .enumerate()
-        {
+        for (channel_number, output_channel) in output.channels_mut().iter_mut().enumerate() {
+            let input_channel = if input.is_silent() {
+                input.channel_data(0)
+            } else {
+                input.channel_data(channel_number)
+            };
+
             for (&i, o) in input_channel.iter().zip(output_channel.iter_mut()) {
                 let input = f64::from(i);
                 let b0 = self.norm_coeffs[0].0;

--- a/src/node/panner.rs
+++ b/src/node/panner.rs
@@ -1142,7 +1142,6 @@ mod tests {
         let panner = PannerNode::new(&context, options);
         assert_eq!(panner.panning_model(), PanningModelType::EqualPower);
         panner.position_y().set_value(1.); // sound comes from above
-        panner.set_channel_count(1);
 
         src.connect(&panner);
         panner.connect(&context.destination());
@@ -1181,8 +1180,11 @@ mod tests {
         listener.up_y().set_value(0.);
         listener.up_z().set_value(1.);
 
-        // 128 input samples of value 1.
-        let input = AudioBuffer::from(vec![vec![1.; RENDER_QUANTUM_SIZE]], sample_rate);
+        // 128 input samples of value 1, stereo
+        let input = AudioBuffer::from(
+            vec![vec![1.; RENDER_QUANTUM_SIZE], vec![1.; RENDER_QUANTUM_SIZE]],
+            sample_rate,
+        );
         let mut src = AudioBufferSourceNode::new(&context, AudioBufferSourceOptions::default());
         src.set_buffer(input);
         src.start();

--- a/src/render/graph.rs
+++ b/src/render/graph.rs
@@ -417,14 +417,6 @@ impl Graph {
             // acquire a mutable borrow of the current processing node
             let mut node = nodes[*index].borrow_mut();
 
-            // make sure all input buffers have the correct number of channels, this might not be
-            // the case if the node has no inputs connected or the channel count has just changed
-            let interpretation = node.channel_config.interpretation();
-            let count = node.channel_config.count();
-            node.inputs
-                .iter_mut()
-                .for_each(|i| i.mix(count, interpretation));
-
             // let the current node process (catch any panics that may occur)
             let params = AudioParamValues::from(nodes);
             scope.node_id.set(*index);

--- a/tests/mixing.rs
+++ b/tests/mixing.rs
@@ -93,7 +93,7 @@ fn test_stereo_to_discrete_stereo() {
 
     assert_eq!(output.number_of_channels(), 2);
     assert_float_eq!(output.get_channel_data(0), ONES, abs_all <= 0.);
-    assert_float_eq!(output.get_channel_data(1), ONES, abs_all <= 0.);
+    assert_float_eq!(output.get_channel_data(1), ZEROES, abs_all <= 0.);
 }
 
 #[test]


### PR DESCRIPTION
The upmixing will happen when the inputs are mixed together, and only when needed. This prevent unnecessary upmixes to stereo for many nodes with channelCountMode Max and ClampedMax.

This is pretty wild, it improves the wpt results with big margin. Mostly due to the PannerNode now picking mono-to-stereo by default - which fixes many assertions in the suite

```
  RESULTS:
  - # pass: 4306 (+327)
  - # fail: 780 (-327)
  - # type error issues: 59
```