### PR TITLE
AudioParam end time calculation, use round instead of ceil

### DIFF
--- a/src/param.rs
+++ b/src/param.rs
@@ -1060,7 +1060,7 @@ impl AudioParamProcessor {
 
         // fill buffer with current intrinsic value until `event.time`
         if infos.is_a_rate {
-            let end_index = ((time - infos.block_time).max(0.) / infos.dt) as usize;
+            let end_index = ((time - infos.block_time).max(0.) / infos.dt).round() as usize;
             let end_index_clipped = end_index.min(infos.count);
 
             for _ in self.buffer.len()..end_index_clipped {

--- a/src/param.rs
+++ b/src/param.rs
@@ -1110,8 +1110,8 @@ impl AudioParamProcessor {
 
         if infos.is_a_rate {
             let start_index = self.buffer.len();
-            // we need to `round()` because if `end_time` is between two samples
-            // we actually want the sample before `end_time` to be computed
+            // TODO use ceil() or round() when `end_time` is between two samples?
+            // <https://github.com/orottier/web-audio-api-rs/pull/460>
             let end_index = ((end_time - infos.block_time).max(0.) / infos.dt).round() as usize;
             let end_index_clipped = end_index.min(infos.count);
 
@@ -1212,8 +1212,8 @@ impl AudioParamProcessor {
 
         if infos.is_a_rate {
             let start_index = self.buffer.len();
-            // we need to `round()` because if `end_time` is between two samples
-            // we actually want the sample before `end_time` to be computed
+            // TODO use ceil() or round() when `end_time` is between two samples?
+            // <https://github.com/orottier/web-audio-api-rs/pull/460>
             let end_index = ((end_time - infos.block_time).max(0.) / infos.dt).round() as usize;
             let end_index_clipped = end_index.min(infos.count);
 
@@ -1337,8 +1337,8 @@ impl AudioParamProcessor {
 
         if infos.is_a_rate {
             let start_index = self.buffer.len();
-            // we need to `round()` because if `end_time` is between two samples
-            // we actually want the sample before `end_time` to be computed
+            // TODO use ceil() or round() when `end_time` is between two samples?
+            // <https://github.com/orottier/web-audio-api-rs/pull/460>
             let end_index = ((end_time - infos.block_time).max(0.) / infos.dt).round() as usize;
             let end_index_clipped = end_index.min(infos.count);
 
@@ -1437,8 +1437,8 @@ impl AudioParamProcessor {
 
         if infos.is_a_rate {
             let start_index = self.buffer.len();
-            // we need to `round()` because if `end_time` is between two samples
-            // we actually want the sample before `end_time` to be computed
+            // TODO use ceil() or round() when `end_time` is between two samples?
+            // <https://github.com/orottier/web-audio-api-rs/pull/460>
             let end_index = ((end_time - infos.block_time).max(0.) / infos.dt).round() as usize;
             let end_index_clipped = end_index.min(infos.count);
 

--- a/src/param.rs
+++ b/src/param.rs
@@ -1110,9 +1110,9 @@ impl AudioParamProcessor {
 
         if infos.is_a_rate {
             let start_index = self.buffer.len();
-            // we need to `ceil()` because if `end_time` is between two samples
+            // we need to `round()` because if `end_time` is between two samples
             // we actually want the sample before `end_time` to be computed
-            let end_index = ((end_time - infos.block_time).max(0.) / infos.dt).ceil() as usize;
+            let end_index = ((end_time - infos.block_time).max(0.) / infos.dt).round() as usize;
             let end_index_clipped = end_index.min(infos.count);
 
             // compute "real" value according to `t` then clamp it
@@ -1212,10 +1212,9 @@ impl AudioParamProcessor {
 
         if infos.is_a_rate {
             let start_index = self.buffer.len();
-            // we need to `ceil()` because if `end_time` is between two samples
+            // we need to `round()` because if `end_time` is between two samples
             // we actually want the sample before `end_time` to be computed
-            // @todo - more tests
-            let end_index = ((end_time - infos.block_time).max(0.) / infos.dt).ceil() as usize;
+            let end_index = ((end_time - infos.block_time).max(0.) / infos.dt).round() as usize;
             let end_index_clipped = end_index.min(infos.count);
 
             if end_index_clipped > start_index {
@@ -1338,10 +1337,9 @@ impl AudioParamProcessor {
 
         if infos.is_a_rate {
             let start_index = self.buffer.len();
-            // we need to `ceil()` because if `end_time` is between two samples
+            // we need to `round()` because if `end_time` is between two samples
             // we actually want the sample before `end_time` to be computed
-            // @todo - more tests
-            let end_index = ((end_time - infos.block_time).max(0.) / infos.dt).ceil() as usize;
+            let end_index = ((end_time - infos.block_time).max(0.) / infos.dt).round() as usize;
             let end_index_clipped = end_index.min(infos.count);
 
             if end_index_clipped > start_index {
@@ -1439,10 +1437,9 @@ impl AudioParamProcessor {
 
         if infos.is_a_rate {
             let start_index = self.buffer.len();
-            // we need to `ceil()` because if `end_time` is between two samples
+            // we need to `round()` because if `end_time` is between two samples
             // we actually want the sample before `end_time` to be computed
-            // @todo - more tests
-            let end_index = ((end_time - infos.block_time).max(0.) / infos.dt).ceil() as usize;
+            let end_index = ((end_time - infos.block_time).max(0.) / infos.dt).round() as usize;
             let end_index_clipped = end_index.min(infos.count);
 
             if end_index_clipped > start_index {


### PR DESCRIPTION
```
  RESULTS:
  - # pass: 1587 (+174)
  - # fail: 180
  - # type error issues: 9
```