### PR TITLE
AudioScheduledSourceNode can return tail_time false when not scheduled

### DIFF
--- a/src/context/concrete_base.rs
+++ b/src/context/concrete_base.rs
@@ -306,7 +306,7 @@ impl ConcreteBaseAudioContext {
             || LISTENER_PARAM_IDS.contains(&id.0);
 
         if !magic {
-            let message = ControlMessage::FreeWhenFinished { id };
+            let message = ControlMessage::ControlHandleDropped { id };
             self.send_control_msg(message);
         }
     }

--- a/src/message.rs
+++ b/src/message.rs
@@ -34,7 +34,7 @@ pub(crate) enum ControlMessage {
     DisconnectAll { from: AudioNodeId },
 
     /// Notify the render thread this node is dropped in the control thread
-    FreeWhenFinished { id: AudioNodeId },
+    ControlHandleDropped { id: AudioNodeId },
 
     /// Mark node as a cycle breaker (DelayNode only)
     MarkCycleBreaker { id: AudioNodeId },

--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -422,14 +422,18 @@ impl AudioProcessor for AudioBufferSourceRenderer {
         // Return early if start_time is beyond this block
         if self.start_time >= next_block_time {
             output.make_silent();
-            return true;
+            // #462 AudioScheduledSourceNodes that have not been scheduled to start can safely
+            // return tail_time false in order to be collected if their control handle drops.
+            return self.start_time != f64::MAX;
         }
 
         // If the buffer has not been set wait for it.
         let buffer = match &self.buffer {
             None => {
                 output.make_silent();
-                return true;
+                // #462 like the above arm, we can safely return tail_time false if this node has
+                // no buffer set.
+                return false;
             }
             Some(b) => b,
         };

--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -55,7 +55,7 @@ struct PlaybackInfo {
     k: f32,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 struct LoopState {
     pub is_looping: bool,
     pub start: f64,
@@ -214,7 +214,7 @@ impl AudioBufferSourceNode {
                 buffer: None,
                 detune: d_proc,
                 playback_rate: pr_proc,
-                loop_state: loop_state.clone(),
+                loop_state,
                 render_state: AudioBufferRendererState::default(),
                 ended_triggered: false,
             };
@@ -423,7 +423,7 @@ impl AudioProcessor for AudioBufferSourceRenderer {
             is_looping,
             start: loop_start,
             end: loop_end,
-        } = self.loop_state.clone();
+        } = self.loop_state;
 
         // these will only be used if `loop_` is true, so no need for `Option`
         let mut actual_loop_start = 0.;

--- a/src/node/oscillator.rs
+++ b/src/node/oscillator.rs
@@ -373,7 +373,9 @@ impl AudioProcessor for OscillatorRenderer {
 
         if self.start_time >= next_block_time {
             output.make_silent();
-            return true;
+            // #462 AudioScheduledSourceNodes that have not been scheduled to start can safely
+            // return tail_time false in order to be collected if their control handle drops.
+            return self.start_time != f64::MAX;
         } else if self.stop_time < scope.current_time {
             output.make_silent();
 

--- a/src/render/thread.rs
+++ b/src/render/thread.rs
@@ -150,8 +150,8 @@ impl RenderThread {
                 DisconnectAll { from } => {
                     self.graph.as_mut().unwrap().remove_edges_from(from);
                 }
-                FreeWhenFinished { id } => {
-                    self.graph.as_mut().unwrap().mark_free_when_finished(id);
+                ControlHandleDropped { id } => {
+                    self.graph.as_mut().unwrap().mark_control_handle_dropped(id);
                 }
                 MarkCycleBreaker { id } => {
                     self.graph.as_mut().unwrap().mark_cycle_breaker(id);


### PR DESCRIPTION
The render thread will not garbage collect them as long as the control
handle is kept. Once the control handle is dropped, and the node is
still not scheduled to start (start_at != f64::MAX) we can safely drop
the node from the audio graph.

Fixes #462

Apologies I mixed in some housekeeping