### PR TITLE
Dynamic lifetime issues and the node collection

### DIFF
--- a/src/node/delay.rs
+++ b/src/node/delay.rs
@@ -374,6 +374,10 @@ impl AudioProcessor for DelayWriter {
         // let the node be decommisioned if it has no input left
         false
     }
+
+    fn has_side_effects(&self) -> bool {
+        true // message passing
+    }
 }
 
 impl DelayWriter {

--- a/src/node/destination.rs
+++ b/src/node/destination.rs
@@ -141,4 +141,8 @@ impl AudioProcessor for DestinationRenderer {
 
         true
     }
+
+    fn has_side_effects(&self) -> bool {
+        true // speaker output
+    }
 }

--- a/src/render/graph.rs
+++ b/src/render/graph.rs
@@ -103,7 +103,7 @@ impl Node {
         }
 
         // Node has no control handle and does have inputs connected.
-        // Drop when the processor when it has no outpus connected and does not have side effects
+        // Drop when the processor when it has no outputs connected and does not have side effects
         if !self.processor.has_side_effects() && self.outgoing_edges.is_empty() {
             return true;
         }

--- a/src/render/node_collection.rs
+++ b/src/render/node_collection.rs
@@ -2,7 +2,6 @@ use crate::context::{AudioNodeId, DESTINATION_NODE_ID};
 use crate::render::graph::Node;
 
 use std::cell::RefCell;
-use std::ops::{Index, IndexMut};
 
 #[derive(Debug)]
 pub(crate) struct NodeCollection {
@@ -59,8 +58,8 @@ impl NodeCollection {
     }
 
     #[inline(always)]
-    pub fn get(&self, index: AudioNodeId) -> Option<&RefCell<Node>> {
-        self.nodes[index.0 as usize].as_ref()
+    pub fn contains(&self, index: AudioNodeId) -> bool {
+        self.nodes[index.0 as usize].is_some()
     }
 
     #[inline(always)]
@@ -81,31 +80,17 @@ impl NodeCollection {
             }
         })
     }
-}
-
-impl Index<AudioNodeId> for NodeCollection {
-    type Output = RefCell<Node>;
 
     #[track_caller]
     #[inline(always)]
-    fn index(&self, index: AudioNodeId) -> &Self::Output {
-        self.nodes
-            .get(index.0 as usize)
-            .unwrap_or_else(|| panic!("Unexpected index {} for NodeCollection", index.0))
-            .as_ref()
-            .unwrap_or_else(|| panic!("Index {} for dropped Node in NodeCollection", index.0))
+    pub fn get_unchecked(&self, index: AudioNodeId) -> &RefCell<Node> {
+        self.nodes[index.0 as usize].as_ref().unwrap()
     }
-}
 
-impl IndexMut<AudioNodeId> for NodeCollection {
     #[track_caller]
     #[inline(always)]
-    fn index_mut(&mut self, index: AudioNodeId) -> &mut Self::Output {
-        self.nodes
-            .get_mut(index.0 as usize)
-            .unwrap_or_else(|| panic!("Unexpected index {} for NodeCollection", index.0))
-            .as_mut()
-            .unwrap_or_else(|| panic!("Index {} for dropped Node in NodeCollection", index.0))
+    pub fn get_unchecked_mut(&mut self, index: AudioNodeId) -> &mut Node {
+        self.nodes[index.0 as usize].as_mut().unwrap().get_mut()
     }
 }
 

--- a/src/render/node_collection.rs
+++ b/src/render/node_collection.rs
@@ -67,20 +67,6 @@ impl NodeCollection {
         self.nodes[index.0 as usize].as_mut()
     }
 
-    #[inline(always)]
-    pub fn retain<F>(&mut self, mut f: F)
-    where
-        F: FnMut(AudioNodeId, &mut RefCell<Node>) -> bool,
-    {
-        self.nodes.iter_mut().enumerate().for_each(|(i, opt)| {
-            if let Some(v) = opt.as_mut() {
-                if !f(AudioNodeId(i as u64), v) {
-                    *opt = None;
-                }
-            }
-        })
-    }
-
     #[track_caller]
     #[inline(always)]
     pub fn get_unchecked(&self, index: AudioNodeId) -> &RefCell<Node> {

--- a/src/render/processor.rs
+++ b/src/render/processor.rs
@@ -141,9 +141,20 @@ pub trait AudioProcessor: Send {
     }
 
     /// Return the name of the actual AudioProcessor type
-    #[doc(hidden)] // not meant to be user facing
     fn name(&self) -> &'static str {
         std::any::type_name::<Self>()
+    }
+
+    /// Indicates if this processor has 'side effects' other than producing output
+    ///
+    /// Processors without side effects can not be dropped when there are no outputs connected, and
+    /// when the control side handle no longer exists
+    ///
+    /// Side effects could include
+    /// - IO (e.g. speaker output of the destination node)
+    /// - Message passing (e.g. worklet nodes)
+    fn has_side_effects(&self) -> bool {
+        false
     }
 }
 

--- a/src/render/processor.rs
+++ b/src/render/processor.rs
@@ -195,7 +195,7 @@ impl<'a> AudioParamValues<'a> {
     /// provide a slice of length equal to the render quantum size (default: 128)
     #[allow(clippy::missing_panics_doc)]
     pub fn get(&self, index: &AudioParamId) -> impl Deref<Target = [f32]> + '_ {
-        DerefAudioRenderQuantumChannel(self.nodes[index.into()].borrow())
+        DerefAudioRenderQuantumChannel(self.nodes.get_unchecked(index.into()).borrow())
     }
 
     pub(crate) fn listener_params(&self) -> [impl Deref<Target = [f32]> + '_; 9] {

--- a/src/worklet.rs
+++ b/src/worklet.rs
@@ -431,6 +431,10 @@ impl<P: AudioWorkletProcessor> AudioProcessor for AudioWorkletRenderer<P> {
     fn onmessage(&mut self, msg: &mut dyn Any) {
         self.processor.load().onmessage(msg)
     }
+
+    fn has_side_effects(&self) -> bool {
+        true // could be IO, message passing, ..
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Apologies for the complex PR. I will let it simmer for a while and put some more thought in it, but wanted to share already.

Introduce AudioProcess::has_side_effects

A processor with no side effect will be dropped when the control handle
is gone and there are not output ports connected.

This makes the cleanup of AudioParams easier and more robust.

Relates to https://github.com/orottier/web-audio-api-rs/issues/397 and https://github.com/orottier/web-audio-api-rs/issues/468