### PR TITLE
WPT fixes: channel splitter/merger error msg, offline ctx channel count mode

### DIFF
--- a/src/node/channel_merger.rs
+++ b/src/node/channel_merger.rs
@@ -4,10 +4,30 @@ use crate::context::{AudioContextRegistration, BaseAudioContext};
 use crate::render::{
     AudioParamValues, AudioProcessor, AudioRenderQuantum, AudioWorkletGlobalScope,
 };
+use crate::MAX_CHANNELS;
 
 use super::{
     AudioNode, ChannelConfig, ChannelConfigOptions, ChannelCountMode, ChannelInterpretation,
 };
+
+/// Assert that the given number of channels is valid for a ChannelMergerNode
+///
+/// # Panics
+///
+/// This function will panic if:
+/// - the given number of channels is outside the [1, 32] range,
+/// 32 being defined by the MAX_CHANNELS constant.
+///
+#[track_caller]
+#[inline(always)]
+pub(crate) fn assert_valid_number_of_channels(number_of_channels: usize) {
+    assert!(
+        number_of_channels > 0 && number_of_channels <= MAX_CHANNELS,
+        "IndexSizeError - Invalid number of channels: {:?} is outside range [1, {:?}]",
+        number_of_channels,
+        MAX_CHANNELS
+    );
+}
 
 /// Assert that the channel count is valid for the ChannelMergerNode
 /// see <https://webaudio.github.io/web-audio-api/#audionode-channelcount-constraints>
@@ -104,7 +124,7 @@ impl AudioNode for ChannelMergerNode {
 impl ChannelMergerNode {
     pub fn new<C: BaseAudioContext>(context: &C, options: ChannelMergerOptions) -> Self {
         context.base().register(move |registration| {
-            crate::assert_valid_number_of_channels(options.number_of_inputs);
+            assert_valid_number_of_channels(options.number_of_inputs);
 
             assert_valid_channel_count(options.channel_config.count);
             assert_valid_channel_count_mode(options.channel_config.count_mode);

--- a/src/node/channel_splitter.rs
+++ b/src/node/channel_splitter.rs
@@ -4,10 +4,30 @@ use crate::context::{AudioContextRegistration, BaseAudioContext};
 use crate::render::{
     AudioParamValues, AudioProcessor, AudioRenderQuantum, AudioWorkletGlobalScope,
 };
+use crate::MAX_CHANNELS;
 
 use super::{
     AudioNode, ChannelConfig, ChannelConfigOptions, ChannelCountMode, ChannelInterpretation,
 };
+
+/// Assert that the given number of channels is valid for a ChannelMergerNode
+///
+/// # Panics
+///
+/// This function will panic if:
+/// - the given number of channels is outside the [1, 32] range,
+/// 32 being defined by the MAX_CHANNELS constant.
+///
+#[track_caller]
+#[inline(always)]
+pub(crate) fn assert_valid_number_of_channels(number_of_channels: usize) {
+    assert!(
+        number_of_channels > 0 && number_of_channels <= MAX_CHANNELS,
+        "IndexSizeError - Invalid number of channels: {:?} is outside range [1, {:?}]",
+        number_of_channels,
+        MAX_CHANNELS
+    );
+}
 
 /// Assert that the channel count mode is valid for the ChannelSplitterNode
 /// see <https://webaudio.github.io/web-audio-api/#audionode-channelcountmode-constraints>
@@ -112,7 +132,7 @@ impl AudioNode for ChannelSplitterNode {
 impl ChannelSplitterNode {
     pub fn new<C: BaseAudioContext>(context: &C, mut options: ChannelSplitterOptions) -> Self {
         context.base().register(move |registration| {
-            crate::assert_valid_number_of_channels(options.number_of_outputs);
+            assert_valid_number_of_channels(options.number_of_outputs);
             options.channel_config.count = options.number_of_outputs;
 
             assert_valid_channel_count_mode(options.channel_config.count_mode);

--- a/src/node/destination.rs
+++ b/src/node/destination.rs
@@ -74,7 +74,7 @@ impl AudioNode for AudioDestinationNode {
         // OfflineAudioContext, then the channel count mode cannot be changed.
         // An InvalidStateError exception MUST be thrown for any attempt to change the value.
         assert!(
-            !self.registration.context().offline(),
+            !self.registration.context().offline() || v == ChannelCountMode::Explicit,
             "InvalidStateError - AudioDestinationNode has channel count mode constraints",
         );
 

--- a/src/node/destination.rs
+++ b/src/node/destination.rs
@@ -55,11 +55,24 @@ impl AudioNode for AudioDestinationNode {
     }
 
     fn set_channel_count(&self, v: usize) {
+        // <https://webaudio.github.io/web-audio-api/#AudioDestinationNode>
+        // numberOfChannels is the number of channels specified when constructing the
+        // OfflineAudioContext. This value may not be changed; a NotSupportedError exception MUST
+        // be thrown if channelCount is changed to a different value.
+        //
+        // <https://webaudio.github.io/web-audio-api/#dom-audionode-channelcount>
+        // The channel count cannot be changed. An InvalidStateError exception MUST be thrown for
+        // any attempt to change the value.
+        //
+        // TODO spec issue: NotSupportedError or InvalidStateError?
         assert!(
             !self.registration.context().offline() || v == self.max_channel_count(),
             "NotSupportedError - not allowed to change OfflineAudioContext destination channel count"
         );
 
+        // <https://webaudio.github.io/web-audio-api/#dom-audionode-channelcount>
+        // The channel count MUST be between 1 and maxChannelCount. An IndexSizeError exception
+        // MUST be thrown for any attempt to set the count outside this range.
         assert!(
             v <= self.max_channel_count(),
             "IndexSizeError - channel count cannot be greater than maxChannelCount ({})",
@@ -70,7 +83,11 @@ impl AudioNode for AudioDestinationNode {
     }
 
     fn set_channel_count_mode(&self, v: ChannelCountMode) {
-        // [spec] If the AudioDestinationNode is the destination node of an
+        // <https://webaudio.github.io/web-audio-api/#AudioDestinationNode>
+        // For an OfflineAudioContext, the defaults are [..] channelCountMode: "explicit"
+        //
+        // <https://webaudio.github.io/web-audio-api/#dom-audionode-channelcountmode>
+        // If the AudioDestinationNode is the destination node of an
         // OfflineAudioContext, then the channel count mode cannot be changed.
         // An InvalidStateError exception MUST be thrown for any attempt to change the value.
         assert!(


### PR DESCRIPTION
Big win with the AudioNode tests because of the fixed panic in the destination node

```
  RESULTS:
  - # pass: 5199 (+190)
  - # fail: 640 (-19)
  - # type error issues: 62 (+8)
```
