### PR TITLE
Fix: do not assume curve is centered around zero

### DIFF
--- a/src/node/waveshaper.rs
+++ b/src/node/waveshaper.rs
@@ -393,11 +393,6 @@ impl AudioProcessor for WaveShaperRenderer {
         let input = &inputs[0];
         let output = &mut outputs[0];
 
-        if input.is_silent() {
-            output.make_silent();
-            return false;
-        }
-
         *output = input.clone();
 
         if let Some(curve) = &self.curve {

--- a/src/node/waveshaper.rs
+++ b/src/node/waveshaper.rs
@@ -396,7 +396,7 @@ impl AudioProcessor for WaveShaperRenderer {
         let input = &inputs[0];
         let output = &mut outputs[0];
 
-        if input.is_silent() & self.can_propagate_silence {
+        if input.is_silent() && self.can_propagate_silence {
             output.make_silent();
             return false;
         }


### PR DESCRIPTION
This fixes the `the-waveshapernode-interface/silent-inputs.html` wpt test
