### PR TITLE
Fix - Biquad and IIR filter getFrequencyResponse return NAN for invalid frequencies

### DIFF
--- a/src/node/biquad_filter.rs
+++ b/src/node/biquad_filter.rs
@@ -1209,8 +1209,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::excessive_precision)]
-    fn test_frequency_responses_invalid_frequencies() {
+    fn test_frequency_response_invalid_frequencies() {
         let context = OfflineAudioContext::new(1, 128, 44_100.);
 
         let frequency = 2000.;

--- a/src/node/biquad_filter.rs
+++ b/src/node/biquad_filter.rs
@@ -517,8 +517,7 @@ impl BiquadFilterNode {
         // 1 + (a1 + a2*z1)*z1
         //
         // with z1 = 1/z and z = exp(j*pi*frequency). Hence z1 = exp(-j*pi*frequency)
-        for (i, freq) in frequency_hz.iter().enumerate() {
-            let freq = *freq;
+        for (i, &freq) in frequency_hz.iter().enumerate() {
             // <https://webaudio.github.io/web-audio-api/#dom-biquadfilternode-getfrequencyresponse>
             // > If a value in the frequencyHz parameter is not within [0, sampleRate/2],
             // > where sampleRate is the value of the sampleRate property of the AudioContext,


### PR DESCRIPTION
Sorry for the noise in the biquad filter tests, I just splitted each filter type in its own test function

cf. <https://webaudio.github.io/web-audio-api/#dom-biquadfilternode-getfrequencyresponse>
> If a value in the frequencyHz parameter is not within [0, sampleRate/2], where sampleRate is the value of the sampleRate property of the AudioContext, the corresponding value at the same index of the magResponse/phaseResponse array MUST be NaN.