### PR TITLE
Fix - Add upper bound for valid sample rates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,10 +137,12 @@ impl AtomicF64 {
 #[track_caller]
 #[inline(always)]
 pub(crate) fn assert_valid_sample_rate(sample_rate: f32) {
+    // Arbitrary cutoffs defined as:
+    // min_sample_rate = min_required_in_spec / 2
+    // max_sample_rate = max_required_in_spec * 2
     let min_sample_rate = 4_000.;
     let max_sample_rate = 192_000.;
-    // 1000 Hertz is a just a random cutoff, but it helps a if someone accidentally puts a
-    // timestamp in the sample_rate variable
+
     assert!(
         sample_rate >= min_sample_rate && sample_rate <= max_sample_rate,
         "NotSupportedError - Invalid sample rate: {:?}, should be in the range [{:?}, {:?}]",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,10 +138,10 @@ impl AtomicF64 {
 #[inline(always)]
 pub(crate) fn assert_valid_sample_rate(sample_rate: f32) {
     // Arbitrary cutoffs defined as:
-    // min_sample_rate = min_required_in_spec / 2
-    // max_sample_rate = max_required_in_spec * 2
-    let min_sample_rate = 4_000.;
-    let max_sample_rate = 192_000.;
+    // min_sample_rate = min_required_in_spec / 4
+    // max_sample_rate = max_required_in_spec * 4
+    let min_sample_rate = 2_000.;
+    let max_sample_rate = 384_000.;
 
     assert!(
         sample_rate >= min_sample_rate && sample_rate <= max_sample_rate,
@@ -237,13 +237,17 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_invalid_sample_rate_too_small() {
-        assert_valid_sample_rate(3_000.);
+        // invalid lower value used in wpt check
+        // <the-audio-api/the-audiocontext-interface/audiocontextoptions.html>
+        assert_valid_sample_rate(1.);
     }
 
     #[test]
     #[should_panic]
     fn test_invalid_sample_rate_too_big() {
-        assert_valid_sample_rate(300_000.);
+        // invalid upper value used in wpt check
+        // <the-audio-api/the-audiocontext-interface/audiocontextoptions.html>
+        assert_valid_sample_rate(1_000_000.);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,22 +125,28 @@ impl AtomicF64 {
 /// voice based applications, e.g. see phone bandwidth) and 96000Hz (for very high
 /// quality audio applications and spectrum manipulation).
 /// Most common sample rates for musical applications are 44100 and 48000.
-/// - see <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createbuffer-samplerate>
+///
+/// - see <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-samplerate>
+/// > An implementation MUST support sample rates in at least the range 8000 to 96000.
 ///
 /// # Panics
 ///
 /// This function will panic if:
-/// - the given sample rate is zero
+/// - the given sample rate is lower than 4000 or greater than 192000
 ///
 #[track_caller]
 #[inline(always)]
 pub(crate) fn assert_valid_sample_rate(sample_rate: f32) {
+    let min_sample_rate = 4_000.;
+    let max_sample_rate = 192_000.;
     // 1000 Hertz is a just a random cutoff, but it helps a if someone accidentally puts a
     // timestamp in the sample_rate variable
     assert!(
-        sample_rate > 1000.,
-        "NotSupportedError - Invalid sample rate: {:?}, should be greater than 1000",
-        sample_rate
+        sample_rate >= min_sample_rate && sample_rate <= max_sample_rate,
+        "NotSupportedError - Invalid sample rate: {:?}, should be in the range [{:?}, {:?}]",
+        sample_rate,
+        min_sample_rate,
+        max_sample_rate,
     );
 }
 
@@ -228,20 +234,14 @@ mod tests {
 
     #[test]
     #[should_panic]
-    fn test_invalid_sample_rate_zero() {
-        assert_valid_sample_rate(0.);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_invalid_sample_rate_subzero() {
-        assert_valid_sample_rate(-48000.);
-    }
-
-    #[test]
-    #[should_panic]
     fn test_invalid_sample_rate_too_small() {
-        assert_valid_sample_rate(100.);
+        assert_valid_sample_rate(3_000.);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_sample_rate_too_big() {
+        assert_valid_sample_rate(300_000.);
     }
 
     #[test]

--- a/src/node/delay.rs
+++ b/src/node/delay.rs
@@ -669,7 +669,7 @@ mod tests {
 
     #[test]
     fn test_audioparam_value_applies_immediately() {
-        let context = OfflineAudioContext::new(1, 128, 48000.);
+        let context = OfflineAudioContext::new(1, 128, 48_000.);
         let options = DelayOptions {
             delay_time: 0.12,
             ..Default::default()
@@ -681,7 +681,7 @@ mod tests {
     #[test]
     fn test_sample_accurate() {
         for delay_in_samples in [128., 131., 197.].iter() {
-            let sample_rate = 48000.;
+            let sample_rate = 48_000.;
             let mut context = OfflineAudioContext::new(1, 256, sample_rate);
 
             let delay = context.create_delay(2.);
@@ -710,7 +710,7 @@ mod tests {
     fn test_sub_sample_accurate() {
         {
             let delay_in_samples = 128.5;
-            let sample_rate = 48000.;
+            let sample_rate = 48_000.;
             let mut context = OfflineAudioContext::new(1, 256, sample_rate);
 
             let delay = context.create_delay(2.);
@@ -737,7 +737,7 @@ mod tests {
 
         {
             let delay_in_samples = 128.8;
-            let sample_rate = 48000.;
+            let sample_rate = 48_000.;
             let mut context = OfflineAudioContext::new(1, 256, sample_rate);
 
             let delay = context.create_delay(2.);
@@ -766,7 +766,7 @@ mod tests {
     #[test]
     fn test_multichannel() {
         let delay_in_samples = 128.;
-        let sample_rate = 48000.;
+        let sample_rate = 48_000.;
         let mut context = OfflineAudioContext::new(2, 2 * 128, sample_rate);
 
         let delay = context.create_delay(2.);
@@ -799,7 +799,7 @@ mod tests {
     #[test]
     fn test_input_number_of_channels_change() {
         let delay_in_samples = 128.;
-        let sample_rate = 48000.;
+        let sample_rate = 48_000.;
         let mut context = OfflineAudioContext::new(2, 3 * 128, sample_rate);
 
         let delay = context.create_delay(2.);
@@ -843,7 +843,7 @@ mod tests {
     fn test_node_stays_alive_long_enough() {
         // make sure there are no hidden order problem
         for _ in 0..10 {
-            let sample_rate = 48000.;
+            let sample_rate = 48_000.;
             let mut context = OfflineAudioContext::new(1, 5 * 128, sample_rate);
 
             // Set up a source that starts only after 5 render quanta.
@@ -878,7 +878,7 @@ mod tests {
     #[test]
     fn test_subquantum_delay() {
         for i in 0..128 {
-            let sample_rate = 48000.;
+            let sample_rate = 48_000.;
             let mut context = OfflineAudioContext::new(1, 128, sample_rate);
 
             let delay = context.create_delay(1.);
@@ -905,7 +905,7 @@ mod tests {
 
     #[test]
     fn test_min_delay_when_in_loop() {
-        let sample_rate = 480000.;
+        let sample_rate = 48_000.;
         let mut context = OfflineAudioContext::new(1, 256, sample_rate);
 
         let delay = context.create_delay(1.);
@@ -942,7 +942,7 @@ mod tests {
         // that everything works even if order of processing is not guaranteed
         // (i.e. when delay is in a loop)
         for _ in 0..10 {
-            let sample_rate = 480000.;
+            let sample_rate = 48_000.;
             let mut context = OfflineAudioContext::new(1, 256, sample_rate);
 
             // this will be internally clamped to 128 * sample_rate
@@ -984,7 +984,7 @@ mod tests {
 
         // set delay and max delay time exactly 1 render quantum
         {
-            let sample_rate = 48000.;
+            let sample_rate = 48_000.;
             let mut context = OfflineAudioContext::new(1, 256, sample_rate);
 
             let delay = context.create_delay(1.);
@@ -1010,7 +1010,7 @@ mod tests {
 
         // set delay and max delay time exactly 2 render quantum
         {
-            let sample_rate = 48000.;
+            let sample_rate = 48_000.;
             let mut context = OfflineAudioContext::new(1, 3 * 128, sample_rate);
 
             let delay = context.create_delay(2.);
@@ -1037,7 +1037,7 @@ mod tests {
 
     #[test]
     fn test_subquantum_delay_dynamic_lifetime() {
-        let sample_rate = 48000.;
+        let sample_rate = 48_000.;
         let mut context = OfflineAudioContext::new(1, 3 * 128, sample_rate);
 
         // Setup a source that emits for 120 frames, so it deallocates after the first render


### PR DESCRIPTION
cf. wpt/webaudio/the-audio-api/the-audiocontext-interface/audiocontextoptions.html

Also modified a bit the lower bound so that we have:

```
min_sample_rate = min_required_in_spec / 2
max_sample_rate = max_required_in_spec * 2
```

This is a bit arbitrary, let me know if it's ok for you