### PR TITLE
Introduce AudioProcessor::before_drop pre-destructor hook

### DIFF
--- a/src/node/constant_source.rs
+++ b/src/node/constant_source.rs
@@ -255,6 +255,13 @@ impl AudioProcessor for ConstantSourceRenderer {
 
         log::warn!("ConstantSourceRenderer: Dropping incoming message {msg:?}");
     }
+
+    fn before_drop(&mut self, scope: &AudioWorkletGlobalScope) {
+        if !self.ended_triggered && scope.current_time >= self.start_time {
+            scope.send_ended_event();
+            self.ended_triggered = true;
+        }
+    }
 }
 
 #[cfg(test)]
@@ -263,6 +270,9 @@ mod tests {
     use crate::node::{AudioNode, AudioScheduledSourceNode};
 
     use float_eq::assert_float_eq;
+
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
 
     use super::*;
 
@@ -368,5 +378,73 @@ mod tests {
         src.start();
         src.stop();
         src.stop();
+    }
+
+    #[test]
+    fn test_ended_event() {
+        let mut context = OfflineAudioContext::new(2, 44_100, 44_100.);
+        let mut src = context.create_constant_source();
+        src.start_at(0.);
+        src.stop_at(0.5);
+
+        let ended = Arc::new(AtomicBool::new(false));
+        let ended_clone = Arc::clone(&ended);
+        src.set_onended(move |_event| {
+            ended_clone.store(true, Ordering::Relaxed);
+        });
+
+        let _ = context.start_rendering_sync();
+        assert!(ended.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn test_no_ended_event() {
+        let mut context = OfflineAudioContext::new(2, 44_100, 44_100.);
+        let src = context.create_constant_source();
+
+        // do not start the node
+
+        let ended = Arc::new(AtomicBool::new(false));
+        let ended_clone = Arc::clone(&ended);
+        src.set_onended(move |_event| {
+            ended_clone.store(true, Ordering::Relaxed);
+        });
+
+        let _ = context.start_rendering_sync();
+        assert!(!ended.load(Ordering::Relaxed)); // should not have triggered
+    }
+
+    #[test]
+    fn test_exact_ended_event() {
+        let mut context = OfflineAudioContext::new(2, 44_100, 44_100.);
+        let mut src = context.create_constant_source();
+        src.start_at(0.);
+        src.stop_at(1.); // end right at the end of the offline buffer
+
+        let ended = Arc::new(AtomicBool::new(false));
+        let ended_clone = Arc::clone(&ended);
+        src.set_onended(move |_event| {
+            ended_clone.store(true, Ordering::Relaxed);
+        });
+
+        let _ = context.start_rendering_sync();
+        assert!(ended.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn test_implicit_ended_event() {
+        let mut context = OfflineAudioContext::new(2, 44_100, 44_100.);
+        let mut src = context.create_constant_source();
+        src.start_at(0.);
+        // no explicit stop, so we stop at end of offline context
+
+        let ended = Arc::new(AtomicBool::new(false));
+        let ended_clone = Arc::clone(&ended);
+        src.set_onended(move |_event| {
+            ended_clone.store(true, Ordering::Relaxed);
+        });
+
+        let _ = context.start_rendering_sync();
+        assert!(ended.load(Ordering::Relaxed));
     }
 }

--- a/src/render/graph.rs
+++ b/src/render/graph.rs
@@ -503,6 +503,7 @@ impl Graph {
                 let mut node = self.nodes.remove(*index).into_inner();
                 self.reclaim_id_channel
                     .push(node.reclaim_id.take().unwrap());
+                node.processor.before_drop(scope);
                 drop(node);
 
                 // And remove it from the ordering after we have processed all nodes
@@ -535,6 +536,13 @@ impl Graph {
 
         // Return the output buffer of destination node
         &self.nodes.get_unchecked_mut(AudioNodeId(0)).outputs[0]
+    }
+
+    pub fn before_drop(&mut self, scope: &AudioWorkletGlobalScope) {
+        self.nodes.iter_mut().for_each(|(id, node)| {
+            scope.node_id.set(id);
+            node.get_mut().processor.before_drop(scope);
+        });
     }
 }
 

--- a/src/render/node_collection.rs
+++ b/src/render/node_collection.rs
@@ -58,6 +58,14 @@ impl NodeCollection {
     }
 
     #[inline(always)]
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (AudioNodeId, &mut RefCell<Node>)> {
+        self.nodes
+            .iter_mut()
+            .enumerate()
+            .filter_map(|(i, v)| v.as_mut().map(|m| (AudioNodeId(i as u64), m)))
+    }
+
+    #[inline(always)]
     pub fn contains(&self, index: AudioNodeId) -> bool {
         self.nodes[index.0 as usize].is_some()
     }

--- a/src/render/processor.rs
+++ b/src/render/processor.rs
@@ -172,6 +172,8 @@ pub trait AudioProcessor: Send {
     fn has_side_effects(&self) -> bool {
         false
     }
+
+    fn before_drop(&mut self, _scope: &AudioWorkletGlobalScope) {}
 }
 
 impl std::fmt::Debug for dyn AudioProcessor {

--- a/src/render/thread.rs
+++ b/src/render/thread.rs
@@ -320,7 +320,7 @@ impl RenderThread {
         // Update time
         let current_frame = self
             .frames_played
-            .fetch_add(RENDER_QUANTUM_SIZE as u64, Ordering::SeqCst);
+            .fetch_add(RENDER_QUANTUM_SIZE as u64, Ordering::Relaxed);
         let current_time = current_frame as f64 / self.sample_rate as f64;
 
         let scope = AudioWorkletGlobalScope {
@@ -372,7 +372,7 @@ impl RenderThread {
             let max_duration = RENDER_QUANTUM_SIZE as f64 / self.sample_rate as f64;
             let load_value = duration / max_duration;
             let render_timestamp =
-                self.frames_played.load(Ordering::SeqCst) as f64 / self.sample_rate as f64;
+                self.frames_played.load(Ordering::Relaxed) as f64 / self.sample_rate as f64;
             let load_value_data = AudioRenderCapacityLoad {
                 render_timestamp,
                 load_value,
@@ -431,7 +431,7 @@ impl RenderThread {
             // update time
             let current_frame = self
                 .frames_played
-                .fetch_add(RENDER_QUANTUM_SIZE as u64, Ordering::SeqCst);
+                .fetch_add(RENDER_QUANTUM_SIZE as u64, Ordering::Relaxed);
             let current_time = current_frame as f64 / self.sample_rate as f64;
 
             let scope = AudioWorkletGlobalScope {


### PR DESCRIPTION
This allows the processor to send some final events, or move some items to the garbage collector thread. This will help with https://github.com/orottier/web-audio-api-rs/pull/368 

In this commit we use the before_drop hook to ensure that the ended event is sent for all AudioScheduledSourceNodes when the stop time is implicit. This fixes https://github.com/orottier/web-audio-api-rs/issues/489

