### PR TITLE
AudioNode disconnect methods

### DIFF
--- a/examples/constant_source.rs
+++ b/examples/constant_source.rs
@@ -33,7 +33,7 @@ fn main() {
     // left branch
     let gain_left = context.create_gain();
     gain_left.gain().set_value(0.);
-    gain_left.connect_at(&merger, 0, 0);
+    gain_left.connect_from_output_to_input(&merger, 0, 0);
 
     let mut src_left = context.create_oscillator();
     src_left.frequency().set_value(200.);
@@ -43,7 +43,7 @@ fn main() {
     // right branch
     let gain_right = context.create_gain();
     gain_right.gain().set_value(0.);
-    gain_right.connect_at(&merger, 0, 1);
+    gain_right.connect_from_output_to_input(&merger, 0, 1);
 
     let mut src_right = context.create_oscillator();
     src_right.frequency().set_value(300.);

--- a/examples/merger.rs
+++ b/examples/merger.rs
@@ -46,9 +46,9 @@ fn main() {
     let merger = context.create_channel_merger(2);
 
     // connect left osc to left input of the merger
-    left.connect_at(&merger, 0, 0);
+    left.connect_from_output_to_input(&merger, 0, 0);
     // connect right osc to left input of the merger
-    right.connect_at(&merger, 0, 1);
+    right.connect_from_output_to_input(&merger, 0, 1);
 
     // Connect the merger to speakers
     merger.connect(&context.destination());

--- a/examples/multichannel.rs
+++ b/examples/multichannel.rs
@@ -57,7 +57,7 @@ fn main() {
         let now = context.current_time();
 
         let mut osc = context.create_oscillator();
-        osc.connect_at(&merger, 0, output_channel);
+        osc.connect_from_output_to_input(&merger, 0, output_channel);
         osc.frequency().set_value(200.);
         osc.start_at(now);
         osc.stop_at(now + 1.);

--- a/src/context/concrete_base.rs
+++ b/src/context/concrete_base.rs
@@ -294,7 +294,7 @@ impl ConcreteBaseAudioContext {
             return;
         }
 
-        // Inform render thread that the control thread AudioNode no langer has any handles
+        // Inform render thread that the control thread AudioNode no longer has any handles
         let message = ControlMessage::ControlHandleDropped { id };
         self.send_control_msg(message);
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -28,10 +28,12 @@ pub(crate) enum ControlMessage {
     },
 
     /// Clear the connection between two given nodes in the audio graph
-    DisconnectNode { from: AudioNodeId, to: AudioNodeId },
-
-    /// Disconnect this node from the audio graph (drop all its connections)
-    DisconnectAll { from: AudioNodeId },
+    DisconnectNode {
+        from: AudioNodeId,
+        to: AudioNodeId,
+        input: usize,
+        output: usize,
+    },
 
     /// Notify the render thread this node is dropped in the control thread
     ControlHandleDropped { id: AudioNodeId },

--- a/src/node/audio_node.rs
+++ b/src/node/audio_node.rs
@@ -245,7 +245,7 @@ pub trait AudioNode {
     /// This function will panic when
     /// - the AudioContext of the source and destination does not match
     fn connect<'a>(&self, dest: &'a dyn AudioNode) -> &'a dyn AudioNode {
-        self.connect_at(dest, 0, 0)
+        self.connect_from_output_to_input(dest, 0, 0)
     }
 
     /// Connect a specific output of this AudioNode to a specific input of another node.
@@ -256,7 +256,7 @@ pub trait AudioNode {
     /// - the AudioContext of the source and destination does not match
     /// - if the input port is out of bounds for the destination node
     /// - if the output port is out of bounds for the source node
-    fn connect_at<'a>(
+    fn connect_from_output_to_input<'a>(
         &self,
         dest: &'a dyn AudioNode,
         output: usize,
@@ -340,7 +340,7 @@ pub trait AudioNode {
     /// - the AudioContext of the source and destination does not match
     /// - if the output port is out of bounds for the source node
     /// - the source node was not connected to the destination node
-    fn disconnect_dest_output(&self, dest: &dyn AudioNode, output: usize) {
+    fn disconnect_dest_from_output(&self, dest: &dyn AudioNode, output: usize) {
         assert!(
             self.context() == dest.context(),
             "InvalidAccessError - Attempting to disconnect nodes from different contexts"
@@ -370,7 +370,12 @@ pub trait AudioNode {
     /// - if the input port is out of bounds for the destination node
     /// - if the output port is out of bounds for the source node
     /// - the source node was not connected to the destination node
-    fn disconnect_dest_output_input(&self, dest: &dyn AudioNode, output: usize, input: usize) {
+    fn disconnect_dest_from_output_to_input(
+        &self,
+        dest: &dyn AudioNode,
+        output: usize,
+        input: usize,
+    ) {
         assert!(
             self.context() == dest.context(),
             "InvalidAccessError - Attempting to disconnect nodes from different contexts"

--- a/src/node/audio_node.rs
+++ b/src/node/audio_node.rs
@@ -306,6 +306,12 @@ pub trait AudioNode {
         self.context().disconnect(self.registration().id());
     }
 
+    /// Disconnects all outgoing connections at the given output port from the AudioNode.
+    fn disconnect_at(&self, output: usize) {
+        self.context()
+            .disconnect_at(self.registration().id(), output);
+    }
+
     /// The number of inputs feeding into the AudioNode. For source nodes, this will be 0.
     fn number_of_inputs(&self) -> usize;
 

--- a/src/node/audio_node.rs
+++ b/src/node/audio_node.rs
@@ -288,28 +288,112 @@ pub trait AudioNode {
         dest
     }
 
+    /// Disconnects all outgoing connections from the AudioNode.
+    fn disconnect(&self) {
+        self.context()
+            .disconnect(self.registration().id(), None, None, None);
+    }
+
     /// Disconnects all outputs of the AudioNode that go to a specific destination AudioNode.
-    fn disconnect_from<'a>(&self, dest: &'a dyn AudioNode) -> &'a dyn AudioNode {
+    ///
+    /// # Panics
+    ///
+    /// This function will panic when
+    /// - the AudioContext of the source and destination does not match
+    /// - the source node was not connected to the destination node
+    fn disconnect_dest(&self, dest: &dyn AudioNode) {
         assert!(
             self.context() == dest.context(),
             "InvalidAccessError - Attempting to disconnect nodes from different contexts"
         );
 
-        self.context()
-            .disconnect_from(self.registration().id(), dest.registration().id());
-
-        dest
-    }
-
-    /// Disconnects all outgoing connections from the AudioNode.
-    fn disconnect(&self) {
-        self.context().disconnect(self.registration().id());
+        self.context().disconnect(
+            self.registration().id(),
+            None,
+            Some(dest.registration().id()),
+            None,
+        );
     }
 
     /// Disconnects all outgoing connections at the given output port from the AudioNode.
-    fn disconnect_at(&self, output: usize) {
+    ///
+    /// # Panics
+    ///
+    /// This function will panic when
+    /// - if the output port is out of bounds for this node
+    fn disconnect_output(&self, output: usize) {
+        assert!(
+            self.number_of_outputs() > output,
+            "IndexSizeError - output port {} is out of bounds",
+            output
+        );
+
         self.context()
-            .disconnect_at(self.registration().id(), output);
+            .disconnect(self.registration().id(), Some(output), None, None);
+    }
+
+    /// Disconnects a specific output of the AudioNode to a specific destination AudioNode
+    ///
+    /// # Panics
+    ///
+    /// This function will panic when
+    /// - the AudioContext of the source and destination does not match
+    /// - if the output port is out of bounds for the source node
+    /// - the source node was not connected to the destination node
+    fn disconnect_dest_output(&self, dest: &dyn AudioNode, output: usize) {
+        assert!(
+            self.context() == dest.context(),
+            "InvalidAccessError - Attempting to disconnect nodes from different contexts"
+        );
+
+        assert!(
+            self.number_of_outputs() > output,
+            "IndexSizeError - output port {} is out of bounds",
+            output
+        );
+
+        self.context().disconnect(
+            self.registration().id(),
+            Some(output),
+            Some(dest.registration().id()),
+            None,
+        );
+    }
+
+    /// Disconnects a specific output of the AudioNode to a specific input of some destination
+    /// AudioNode
+    ///
+    /// # Panics
+    ///
+    /// This function will panic when
+    /// - the AudioContext of the source and destination does not match
+    /// - if the input port is out of bounds for the destination node
+    /// - if the output port is out of bounds for the source node
+    /// - the source node was not connected to the destination node
+    fn disconnect_dest_output_input(&self, dest: &dyn AudioNode, output: usize, input: usize) {
+        assert!(
+            self.context() == dest.context(),
+            "InvalidAccessError - Attempting to disconnect nodes from different contexts"
+        );
+
+        assert!(
+            self.number_of_outputs() > output,
+            "IndexSizeError - output port {} is out of bounds",
+            output
+        );
+
+        assert!(
+            dest.number_of_inputs() > input,
+            "IndexSizeError - input port {} is out of bounds",
+            input
+        );
+
+        self.context().disconnect(
+            self.registration().id(),
+            Some(output),
+            Some(dest.registration().id()),
+            Some(input),
+        );
     }
 
     /// The number of inputs feeding into the AudioNode. For source nodes, this will be 0.

--- a/src/node/channel_merger.rs
+++ b/src/node/channel_merger.rs
@@ -213,12 +213,12 @@ mod tests {
 
         let mut src1 = context.create_constant_source();
         src1.offset().set_value(2.);
-        src1.connect_at(&merger, 0, 0);
+        src1.connect_from_output_to_input(&merger, 0, 0);
         src1.start();
 
         let mut src2 = context.create_constant_source();
         src2.offset().set_value(3.);
-        src2.connect_at(&merger, 0, 1);
+        src2.connect_from_output_to_input(&merger, 0, 1);
         src2.start();
 
         let buffer = context.start_rendering_sync();
@@ -242,12 +242,12 @@ mod tests {
 
         let mut src1 = context.create_constant_source();
         src1.offset().set_value(2.);
-        src1.connect_at(&merger, 0, 0);
+        src1.connect_from_output_to_input(&merger, 0, 0);
         src1.start();
 
         let mut src2 = context.create_constant_source();
         src2.offset().set_value(3.);
-        src2.connect_at(&merger, 0, 1);
+        src2.connect_from_output_to_input(&merger, 0, 1);
         src2.start();
 
         context.suspend_sync(disconnect_at, move |_| src2.disconnect());

--- a/src/node/channel_splitter.rs
+++ b/src/node/channel_splitter.rs
@@ -265,7 +265,7 @@ mod tests {
         let splitter = context.create_channel_splitter(2);
 
         // connect the 2nd output to the destination
-        splitter.connect_at(&context.destination(), 1, 0);
+        splitter.connect_from_output_to_input(&context.destination(), 1, 0);
 
         // create buffer with sample value 1. left, value -1. right
         let audio_buffer = AudioBuffer::from(vec![vec![1.], vec![-1.]], 48000.);

--- a/src/node/delay.rs
+++ b/src/node/delay.rs
@@ -127,7 +127,7 @@ impl AudioNode for DelayNode {
     }
 
     /// Connect a specific output of this AudioNode to a specific input of another node.
-    fn connect_at<'a>(
+    fn connect_from_output_to_input<'a>(
         &self,
         dest: &'a dyn AudioNode,
         output: usize,
@@ -212,7 +212,7 @@ impl AudioNode for DelayNode {
     /// - the AudioContext of the source and destination does not match
     /// - if the output port is out of bounds for the source node
     /// - the source node was not connected to the destination node
-    fn disconnect_dest_output(&self, dest: &dyn AudioNode, output: usize) {
+    fn disconnect_dest_from_output(&self, dest: &dyn AudioNode, output: usize) {
         assert!(
             self.context() == dest.context(),
             "InvalidAccessError - Attempting to disconnect nodes from different contexts"
@@ -242,7 +242,12 @@ impl AudioNode for DelayNode {
     /// - if the input port is out of bounds for the destination node
     /// - if the output port is out of bounds for the source node
     /// - the source node was not connected to the destination node
-    fn disconnect_dest_output_input(&self, dest: &dyn AudioNode, output: usize, input: usize) {
+    fn disconnect_dest_from_output_to_input(
+        &self,
+        dest: &dyn AudioNode,
+        output: usize,
+        input: usize,
+    ) {
         assert!(
             self.context() == dest.context(),
             "InvalidAccessError - Attempting to disconnect nodes from different contexts"

--- a/src/node/delay.rs
+++ b/src/node/delay.rs
@@ -160,22 +160,112 @@ impl AudioNode for DelayNode {
         dest
     }
 
+    /// Disconnects all outgoing connections from the AudioNode.
+    fn disconnect(&self) {
+        self.context()
+            .disconnect(self.reader_registration.id(), None, None, None);
+    }
+
     /// Disconnects all outputs of the AudioNode that go to a specific destination AudioNode.
-    fn disconnect_from<'a>(&self, dest: &'a dyn AudioNode) -> &'a dyn AudioNode {
+    ///
+    /// # Panics
+    ///
+    /// This function will panic when
+    /// - the AudioContext of the source and destination does not match
+    /// - the source node was not connected to the destination node
+    fn disconnect_dest(&self, dest: &dyn AudioNode) {
         assert!(
             self.context() == dest.context(),
             "InvalidAccessError - Attempting to disconnect nodes from different contexts"
         );
 
-        self.context()
-            .disconnect_from(self.reader_registration.id(), dest.registration().id());
-
-        dest
+        self.context().disconnect(
+            self.reader_registration.id(),
+            None,
+            Some(dest.registration().id()),
+            None,
+        );
     }
 
-    /// Disconnects all outgoing connections from the AudioNode.
-    fn disconnect(&self) {
-        self.context().disconnect(self.reader_registration.id());
+    /// Disconnects all outgoing connections at the given output port from the AudioNode.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic when
+    /// - if the output port is out of bounds for this node
+    fn disconnect_output(&self, output: usize) {
+        assert!(
+            self.number_of_outputs() > output,
+            "IndexSizeError - output port {} is out of bounds",
+            output
+        );
+
+        self.context()
+            .disconnect(self.reader_registration.id(), Some(output), None, None);
+    }
+
+    /// Disconnects a specific output of the AudioNode to a specific destination AudioNode
+    ///
+    /// # Panics
+    ///
+    /// This function will panic when
+    /// - the AudioContext of the source and destination does not match
+    /// - if the output port is out of bounds for the source node
+    /// - the source node was not connected to the destination node
+    fn disconnect_dest_output(&self, dest: &dyn AudioNode, output: usize) {
+        assert!(
+            self.context() == dest.context(),
+            "InvalidAccessError - Attempting to disconnect nodes from different contexts"
+        );
+
+        assert!(
+            self.number_of_outputs() > output,
+            "IndexSizeError - output port {} is out of bounds",
+            output
+        );
+
+        self.context().disconnect(
+            self.reader_registration.id(),
+            Some(output),
+            Some(dest.registration().id()),
+            None,
+        );
+    }
+
+    /// Disconnects a specific output of the AudioNode to a specific input of some destination
+    /// AudioNode
+    ///
+    /// # Panics
+    ///
+    /// This function will panic when
+    /// - the AudioContext of the source and destination does not match
+    /// - if the input port is out of bounds for the destination node
+    /// - if the output port is out of bounds for the source node
+    /// - the source node was not connected to the destination node
+    fn disconnect_dest_output_input(&self, dest: &dyn AudioNode, output: usize, input: usize) {
+        assert!(
+            self.context() == dest.context(),
+            "InvalidAccessError - Attempting to disconnect nodes from different contexts"
+        );
+
+        assert!(
+            self.number_of_outputs() > output,
+            "IndexSizeError - output port {} is out of bounds",
+            output
+        );
+
+        assert!(
+            dest.number_of_inputs() > input,
+            "IndexSizeError - input port {} is out of bounds",
+            input
+        );
+
+        self.context().disconnect(
+            self.reader_registration.id(),
+            Some(output),
+            Some(dest.registration().id()),
+            Some(input),
+        );
     }
 }
 

--- a/src/render/thread.rs
+++ b/src/render/thread.rs
@@ -151,11 +151,16 @@ impl RenderThread {
                     .unwrap()
                     .add_edge((from, output), (to, input));
             }
-            DisconnectNode { from, to } => {
-                self.graph.as_mut().unwrap().remove_edge(from, to);
-            }
-            DisconnectAll { from } => {
-                self.graph.as_mut().unwrap().remove_edges_from(from);
+            DisconnectNode {
+                from,
+                output,
+                to,
+                input,
+            } => {
+                self.graph
+                    .as_mut()
+                    .unwrap()
+                    .remove_edge((from, output), (to, input));
             }
             ControlHandleDropped { id } => {
                 self.graph.as_mut().unwrap().mark_control_handle_dropped(id);


### PR DESCRIPTION
Fixes #471 

As you can see we get quite a few methods extra, this is conform https://webaudio.github.io/web-audio-api/#AudioNode . Unlike connect, disconnect does not have optional arguments (instead, we treat a missing value as wildcard when disconnecting). I'm up for debate for new names though, or possibly exposing the `Option` arguments...

We now bookkeep connection on the control side, and throw when one tries to disconnect a non-existent connection.

Bonus fix: disconnect without args would previously clear all connections of a node, but the spec mandates that only outgoing connections are cleared!

The node-lib needs some work after merging this to support stuff like `node.disconnect(number)`