### PR TITLE
Change ScriptProcessorNode::onaudioprocess API - use owned buffer value

### DIFF
--- a/examples/script_processor.rs
+++ b/examples/script_processor.rs
@@ -28,7 +28,7 @@ fn main() {
     });
 
     let node = context.create_script_processor(512, 1, 1);
-    node.set_onaudioprocess(|e| {
+    node.set_onaudioprocess(|mut e| {
         let mut rng = rand::thread_rng();
         e.output_buffer
             .get_channel_data_mut(0)

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -88,9 +88,8 @@ impl From<u8> for AudioContextState {
 /// Only when implementing the AudioNode trait manually, this struct is of any concern.
 ///
 /// This object allows for communication with the render thread and dynamic lifetime management.
-//
-// The only way to construct this object is by calling [`BaseAudioContext::register`]
-#[derive(Clone)]
+// The only way to construct this object is by calling [`BaseAudioContext::register`].
+// This struct should not derive Clone because of the Drop handler.
 pub struct AudioContextRegistration {
     /// the audio context in which nodes and connections lives
     context: ConcreteBaseAudioContext,

--- a/src/events.rs
+++ b/src/events.rs
@@ -52,6 +52,15 @@ pub struct AudioProcessingEvent {
     /// The time when the audio will be played in the same time coordinate system as the
     /// AudioContext's currentTime.
     pub playback_time: f64,
+    pub(crate) registration: Option<Arc<crate::context::AudioContextRegistration>>,
+}
+
+impl Drop for AudioProcessingEvent {
+    fn drop(&mut self) {
+        if let Some(registration) = self.registration.take() {
+            registration.post_message(self.output_buffer.clone());
+        }
+    }
 }
 
 /// The OfflineAudioCompletionEvent Event interface

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,3 +1,4 @@
+use crate::context::ConcreteBaseAudioContext;
 use crate::context::{AudioContextState, AudioNodeId};
 use crate::{AudioBuffer, AudioRenderCapacityEvent};
 
@@ -52,13 +53,17 @@ pub struct AudioProcessingEvent {
     /// The time when the audio will be played in the same time coordinate system as the
     /// AudioContext's currentTime.
     pub playback_time: f64,
-    pub(crate) registration: Option<Arc<crate::context::AudioContextRegistration>>,
+    pub(crate) registration: Option<(ConcreteBaseAudioContext, AudioNodeId)>,
 }
 
 impl Drop for AudioProcessingEvent {
     fn drop(&mut self) {
-        if let Some(registration) = self.registration.take() {
-            registration.post_message(self.output_buffer.clone());
+        if let Some((context, id)) = self.registration.take() {
+            let wrapped = crate::message::ControlMessage::NodeMessage {
+                id,
+                msg: llq::Node::new(Box::new(self.output_buffer.clone())),
+            };
+            context.send_control_msg(wrapped);
         }
     }
 }

--- a/src/node/script_processor.rs
+++ b/src/node/script_processor.rs
@@ -342,7 +342,7 @@ mod tests {
         // 2 input channels, 2 output channels
         let node = context.create_script_processor(BUFFER_SIZE, 2, 2);
         node.connect(&context.destination());
-        node.set_onaudioprocess(|e| {
+        node.set_onaudioprocess(|mut e| {
             // left output buffer is left input * 2
             e.output_buffer
                 .get_channel_data_mut(0)

--- a/src/render/processor.rs
+++ b/src/render/processor.rs
@@ -68,6 +68,7 @@ impl AudioWorkletGlobalScope {
             input_buffer,
             output_buffer,
             playback_time,
+            registration: None,
         };
         let dispatch = EventDispatch::audio_processing(self.node_id.get(), event);
         let _ = self.event_sender.try_send(dispatch);


### PR DESCRIPTION
This is easier for the node bindings. We hook into the Drop call of the event to ship the output buffer to the render thread.

TODO: I found a gnarly bug where the ScriptProcessorRenderer would be cleared from the audio graph erroneously. AudioContextRegistration should not be allowed to implement Clone because it has a very meaningful Drop implementation. That's why I now resort to an `Arc` hack to prevent the Drop method to run.

@b-ma could you check if this solves your issues? I will look into the clone/drop bug of AudioContextRegistration in the meantime