### PR TITLE
RenderCapacity - return owned value

### DIFF
--- a/src/capacity.rs
+++ b/src/capacity.rs
@@ -65,6 +65,7 @@ impl AudioRenderCapacityEvent {
 /// Ideally the load value is below 1.0, meaning that it took less time to render the audio than it
 /// took to play it out. An audio buffer underrun happens when this load value is greater than 1.0: the
 /// system could not render audio fast enough for real-time.
+#[derive(Clone)]
 pub struct AudioRenderCapacity {
     context: ConcreteBaseAudioContext,
     receiver: Receiver<AudioRenderCapacityLoad>,

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -268,6 +268,12 @@ impl AudioContext {
         self.backend_manager.lock().unwrap().sink_id().to_owned()
     }
 
+    /// Returns an [`AudioRenderCapacity`] instance associated with an AudioContext.
+    #[must_use]
+    pub fn render_capacity(&self) -> AudioRenderCapacity {
+        self.render_capacity.clone()
+    }
+
     /// Update the current audio output device.
     ///
     /// The provided `sink_id` string must match a device name `enumerate_devices_sync`.
@@ -711,12 +717,6 @@ impl AudioContext {
     ) -> node::MediaElementAudioSourceNode {
         let opts = node::MediaElementAudioSourceOptions { media_element };
         node::MediaElementAudioSourceNode::new(self, opts)
-    }
-
-    /// Returns an [`AudioRenderCapacity`] instance associated with an AudioContext.
-    #[must_use]
-    pub fn render_capacity(&self) -> &AudioRenderCapacity {
-        &self.render_capacity
     }
 }
 


### PR DESCRIPTION
Started to have a look to create the JS bindings for `RenderCapacity` and found this was returned as reference, which has been found always very complicated to wrap

Also look a bit more more consistent in terms of API according to listener and destination.

Let me know if you see any issue with that
