### PR TITLE
AudioBufferSourceNode: inconsistencies in fast and slow track

### DIFF
--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -745,23 +745,29 @@ impl AudioProcessor for AudioBufferSourceRenderer {
                                     {
                                         Some(val) => *val,
                                         None => {
-                                            // @todo - handle playback_rate < 0.
-                                            //
-                                            // find first sample >= to start loop point
-                                            if is_looping {
-                                                let start_playhead =
-                                                    actual_loop_start * sample_rate;
-                                                let start_index =
-                                                    if start_playhead.floor() == start_playhead {
-                                                        start_playhead as usize
-                                                    } else {
-                                                        start_playhead as usize + 1
-                                                    };
+                                            let sample = if is_looping {
+                                                if playback_rate >= 0. {
+                                                    let start_playhead =
+                                                        actual_loop_start * sample_rate;
+                                                    let start_index =
+                                                        if start_playhead.floor() == start_playhead {
+                                                            start_playhead as usize
+                                                        } else {
+                                                            start_playhead as usize + 1
+                                                        };
 
-                                                buffer_channel[start_index]
+                                                    buffer_channel[start_index]
+                                                } else {
+                                                    let end_playhead =
+                                                        actual_loop_end * sample_rate;
+                                                    let end_index = end_playhead as usize;
+                                                    buffer_channel[end_index]
+                                                }
                                             } else {
                                                 0.
-                                            }
+                                            };
+
+                                            sample
                                         }
                                     };
 

--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -52,7 +52,7 @@ impl Default for AudioBufferSourceOptions {
 #[derive(Debug, Copy, Clone)]
 struct PlaybackInfo {
     prev_frame_index: usize,
-    k: f32,
+    k: f64,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -704,7 +704,7 @@ impl AudioProcessor for AudioBufferSourceRenderer {
                     let playhead = position * sample_rate;
                     let playhead_floored = playhead.floor();
                     let prev_frame_index = playhead_floored as usize; // can't be < 0.
-                    let k = (playhead - playhead_floored) as f32;
+                    let k = playhead - playhead_floored;
 
                     // Due to how buffer_time is computed, we can still run into
                     // floating point errors and try to access a non existing index
@@ -740,10 +740,10 @@ impl AudioProcessor for AudioBufferSourceRenderer {
                                     k,
                                 }) => {
                                     // `prev_frame_index` cannot be out of bounds
-                                    let prev_sample = buffer_channel[*prev_frame_index];
+                                    let prev_sample = buffer_channel[*prev_frame_index] as f64;
                                     let next_sample = match buffer_channel.get(prev_frame_index + 1)
                                     {
-                                        Some(val) => *val,
+                                        Some(val) => *val as f64,
                                         None => {
                                             let sample = if is_looping {
                                                 if playback_rate >= 0. {
@@ -767,11 +767,11 @@ impl AudioProcessor for AudioBufferSourceRenderer {
                                                 0.
                                             };
 
-                                            sample
+                                            sample as f64
                                         }
                                     };
 
-                                    (1. - k).mul_add(prev_sample, k * next_sample)
+                                    (1. - k).mul_add(prev_sample, k * next_sample) as f32
                                 }
                                 None => 0.,
                             };

--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -749,12 +749,13 @@ impl AudioProcessor for AudioBufferSourceRenderer {
                                                 if playback_rate >= 0. {
                                                     let start_playhead =
                                                         actual_loop_start * sample_rate;
-                                                    let start_index =
-                                                        if start_playhead.floor() == start_playhead {
-                                                            start_playhead as usize
-                                                        } else {
-                                                            start_playhead as usize + 1
-                                                        };
+                                                    let start_index = if start_playhead.floor()
+                                                        == start_playhead
+                                                    {
+                                                        start_playhead as usize
+                                                    } else {
+                                                        start_playhead as usize + 1
+                                                    };
 
                                                     buffer_channel[start_index]
                                                 } else {
@@ -1292,7 +1293,7 @@ mod tests {
         expected[1] = 1.;
         expected[129] = 1.;
 
-        assert_float_eq!(channel[..], expected[..], abs_all <= 0.);
+        assert_float_eq!(channel[..], expected[..], abs_all <= 1e-10);
     }
 
     #[test]
@@ -1580,17 +1581,19 @@ mod tests {
     #[test]
     fn test_loop_out_of_bounds() {
         [
-            (-2., -1.),
-            (-1., -2.),
-            (0., 0.),
-            (-1., 2.),
-            (2., -1.),
-            (1., 1.),
-            (2., 3.),
-            (3., 2.),
+            // these will go in fast track
+            (-2., -1., 0.),
+            (-1., -2., 0.),
+            (0., 0., 0.),
+            (-1., 2., 0.),
+            // these will go in slow track
+            (2., -1., 1e-10),
+            (1., 1., 1e-10),
+            (2., 3., 1e-10),
+            (3., 2., 1e-10),
         ]
         .iter()
-        .for_each(|(loop_start, loop_end)| {
+        .for_each(|(loop_start, loop_end, error)| {
             let sample_rate = 48_000.;
             let length = sample_rate as usize / 10;
             let mut context = OfflineAudioContext::new(1, length, sample_rate);
@@ -1625,7 +1628,7 @@ mod tests {
                 expected[i] = 1.;
             }
 
-            assert_float_eq!(channel[..], expected[..], abs_all <= 0.);
+            assert_float_eq!(channel[..], expected[..], abs_all <= error);
         });
     }
 

--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -401,7 +401,6 @@ impl AudioBufferSourceRenderer {
             ControlMessage::LoopEnd(loop_end) => self.loop_state.end = *loop_end,
         }
 
-        // @todo -
         self.clamp_loop_boundaries();
     }
 
@@ -427,7 +426,7 @@ impl AudioBufferSourceRenderer {
 impl AudioProcessor for AudioBufferSourceRenderer {
     fn process(
         &mut self,
-        _inputs: &[AudioRenderQuantum], // no input...
+        _inputs: &[AudioRenderQuantum], // This node has no input
         outputs: &mut [AudioRenderQuantum],
         params: AudioParamValues<'_>,
         scope: &AudioWorkletGlobalScope,
@@ -525,10 +524,7 @@ impl AudioProcessor for AudioBufferSourceRenderer {
         // For now we just consider that we can go fast track if loop points are
         // bound to the buffer boundaries.
         //
-        // by default loop_end is equal to buffer_duration, so loop_start = 0 &&
-        // loop_end = buffer.duration should go to fast track
-
-        // @todo - test loop_end against 0 too, semantics is loop_end as not been changed
+        // By default, cf. clamp_loop_boundaries, loop_start == 0 && loop_end == buffer_duration,
         if loop_start != 0. || loop_end != buffer_duration {
             self.render_state.is_aligned = false;
         }
@@ -624,8 +620,7 @@ impl AudioProcessor for AudioBufferSourceRenderer {
             if is_looping {
                 if loop_start >= 0. && loop_end > 0. && loop_start < loop_end {
                     actual_loop_start = loop_start;
-                    // @todo - min is not required loop_end is already clamped
-                    actual_loop_end = loop_end.min(buffer_duration);
+                    actual_loop_end = loop_end;
                 } else {
                     actual_loop_start = 0.;
                     actual_loop_end = buffer_duration;


### PR DESCRIPTION
Work in progress for #525

The failing tests are passing now but it introduced / revealed another issue, `test_loop_hangs` is now failing for another reason....

The semantics of loop start and end are not clear and they are thus not applied properly in edge cases I think, I need / will take some time to review all this properly