### PR TITLE
AudioContext::try_new, propagate cpal/cubeb errors into online audio context

### DIFF
--- a/.github/workflows/msrv.yaml
+++ b/.github/workflows/msrv.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install Rust toolchain
         # Aligned with `rust-version` in `Cargo.toml`
-        uses: dtolnay/rust-toolchain@1.81
+        uses: dtolnay/rust-toolchain@1.85
 
       - name: Check out repository
         uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ include = [
     "LICENSE",
     "README.md",
 ]
-rust-version = "1.81"
+rust-version = "1.85"
 
 [dependencies]
 almost = "0.2.0"

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -171,7 +171,13 @@ impl AudioContext {
     /// stream. Use [`Self::try_new`] to handle these errors without panicking.
     #[must_use]
     pub fn new(options: AudioContextOptions) -> Self {
-        Self::try_new(options).unwrap_or_else(|e| panic!("InvalidStateError - {e}"))
+        Self::try_new(options).unwrap_or_else(|e| {
+            let message = e.to_string();
+            if message.starts_with("NotFoundError - ") {
+                panic!("{message}");
+            }
+            panic!("InvalidStateError - {message}");
+        })
     }
 
     /// Creates and returns a new `AudioContext` object.
@@ -271,7 +277,7 @@ impl AudioContext {
     /// # Errors
     ///
     /// Returns an error when the selected audio backend cannot query the output latency.
-    pub fn try_output_latency(&self) -> Result<f64, Box<dyn Error>> {
+    fn try_output_latency(&self) -> Result<f64, Box<dyn Error>> {
         Ok(self.backend_manager.lock().unwrap().output_latency()?)
     }
 

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -171,7 +171,7 @@ impl AudioContext {
     /// stream. Use [`Self::try_new`] to handle these errors without panicking.
     #[must_use]
     pub fn new(options: AudioContextOptions) -> Self {
-        Self::try_new(options).expect("InvalidStateError - Unable to create AudioContext")
+        Self::try_new(options).unwrap_or_else(|e| panic!("InvalidStateError - {e}"))
     }
 
     /// Creates and returns a new `AudioContext` object.
@@ -263,7 +263,7 @@ impl AudioContext {
     #[allow(clippy::missing_panics_doc)]
     pub fn output_latency(&self) -> f64 {
         self.try_output_latency()
-            .expect("InvalidStateError - Unable to query output latency")
+            .unwrap_or_else(|e| panic!("InvalidStateError - {e}"))
     }
 
     /// The estimation in seconds of audio output latency.
@@ -481,7 +481,7 @@ impl AudioContext {
             .lock()
             .unwrap()
             .suspend()
-            .expect("InvalidStateError - Unable to suspend audio stream");
+            .unwrap_or_else(|e| panic!("InvalidStateError - {e}"));
 
         log::debug!("Suspended audio stream");
     }
@@ -511,7 +511,7 @@ impl AudioContext {
             // Ask the audio host to resume the stream
             backend_manager_guard
                 .resume()
-                .expect("InvalidStateError - Unable to resume audio stream");
+                .unwrap_or_else(|e| panic!("InvalidStateError - {e}"));
 
             // Then, ask to resume rendering via a control message
             log::debug!("Resumed audio stream, waking audio graph");
@@ -566,7 +566,7 @@ impl AudioContext {
             .lock()
             .unwrap()
             .close()
-            .expect("InvalidStateError - Unable to close audio stream");
+            .unwrap_or_else(|e| panic!("InvalidStateError - {e}"));
 
         // Stop the AudioRenderCapacity collection thread
         self.render_capacity.stop();
@@ -613,7 +613,7 @@ impl AudioContext {
         log::debug!("Suspended audio graph. Suspending audio stream..");
         backend_manager_guard
             .suspend()
-            .expect("InvalidStateError - Unable to suspend audio stream");
+            .unwrap_or_else(|e| panic!("InvalidStateError - {e}"));
 
         log::debug!("Suspended audio stream");
     }
@@ -643,7 +643,7 @@ impl AudioContext {
         // Ask the audio host to resume the stream
         backend_manager_guard
             .resume()
-            .expect("InvalidStateError - Unable to resume audio stream");
+            .unwrap_or_else(|e| panic!("InvalidStateError - {e}"));
 
         // Then, ask to resume rendering via a control message
         log::debug!("Resumed audio stream, waking audio graph");
@@ -698,7 +698,7 @@ impl AudioContext {
         log::debug!("Suspended audio graph. Closing audio stream..");
         backend_manager_guard
             .close()
-            .expect("InvalidStateError - Unable to close audio stream");
+            .unwrap_or_else(|e| panic!("InvalidStateError - {e}"));
 
         // Stop the AudioRenderCapacity collection thread
         self.render_capacity.stop();

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -167,20 +167,34 @@ impl AudioContext {
     /// # Panics
     ///
     /// The `AudioContext` constructor will panic when an invalid `sinkId` is provided in the
-    /// `AudioContextOptions`. In a future version, a `try_new` constructor will be introduced that
-    /// never panics.
+    /// `AudioContextOptions`, or when the selected audio backend cannot create or start the output
+    /// stream. Use [`Self::try_new`] to handle these errors without panicking.
     #[must_use]
     pub fn new(options: AudioContextOptions) -> Self {
+        Self::try_new(options).expect("InvalidStateError - Unable to create AudioContext")
+    }
+
+    /// Creates and returns a new `AudioContext` object.
+    ///
+    /// This will play live audio on the requested output device and returns backend errors instead
+    /// of panicking when the stream cannot be created.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the sink id is invalid or when the selected audio backend cannot
+    /// create or start the output stream.
+    pub fn try_new(options: AudioContextOptions) -> Result<Self, Box<dyn Error>> {
         // https://webaudio.github.io/web-audio-api/#validating-sink-identifier
-        assert!(
-            is_valid_sink_id(&options.sink_id),
-            "NotFoundError - Invalid sinkId: {:?}",
-            options.sink_id
-        );
+        if !is_valid_sink_id(&options.sink_id) {
+            Err(format!(
+                "NotFoundError - Invalid sinkId: {:?}",
+                options.sink_id
+            ))?;
+        }
 
         // Set up the audio output thread
         let (control_thread_init, render_thread_init) = io::thread_init();
-        let backend = io::build_output(options, render_thread_init.clone());
+        let backend = io::build_output(options, render_thread_init.clone())?;
 
         let ControlThreadInit {
             state,
@@ -222,12 +236,12 @@ impl AudioContext {
         // construction.
         event_loop.run_in_thread();
 
-        Self {
+        Ok(Self {
             base,
             backend_manager: Mutex::new(backend),
             render_capacity,
             render_thread_init,
-        }
+        })
     }
 
     /// This represents the number of seconds of processing latency incurred by
@@ -248,7 +262,17 @@ impl AudioContext {
     #[must_use]
     #[allow(clippy::missing_panics_doc)]
     pub fn output_latency(&self) -> f64 {
-        self.backend_manager.lock().unwrap().output_latency()
+        self.try_output_latency()
+            .expect("InvalidStateError - Unable to query output latency")
+    }
+
+    /// The estimation in seconds of audio output latency.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the selected audio backend cannot query the output latency.
+    pub fn try_output_latency(&self) -> Result<f64, Box<dyn Error>> {
+        Ok(self.backend_manager.lock().unwrap().output_latency()?)
     }
 
     /// Identifier or the information of the current audio output device.
@@ -322,13 +346,13 @@ impl AudioContext {
             if original_state == AudioContextState::Suspended {
                 // We must wake up the render thread to be able to handle the shutdown.
                 // No new audio will be produced because it will receive the shutdown command first.
-                backend_manager_guard.resume();
+                backend_manager_guard.resume()?;
             }
             graph_recv.recv().unwrap()
         };
 
         log::debug!("SinkChange: closing audio stream");
-        backend_manager_guard.close();
+        backend_manager_guard.close()?;
 
         // hotswap the backend
         let options = AudioContextOptions {
@@ -338,12 +362,12 @@ impl AudioContext {
             render_size_hint: AudioContextRenderSizeCategory::default(), // todo reuse existing setting
         };
         log::debug!("SinkChange: starting audio stream");
-        *backend_manager_guard = io::build_output(options, self.render_thread_init.clone());
+        *backend_manager_guard = io::build_output(options, self.render_thread_init.clone())?;
 
         // if the previous backend state was suspend, suspend the new one before shipping the graph
         if original_state == AudioContextState::Suspended {
             log::debug!("SinkChange: suspending audio stream");
-            backend_manager_guard.suspend();
+            backend_manager_guard.suspend()?;
         }
 
         // send the audio graph to the new render thread
@@ -399,7 +423,7 @@ impl AudioContext {
             writeln!(
                 &mut buffer,
                 "output latency: {:.6}",
-                backend.output_latency()
+                backend.output_latency().unwrap_or(0.)
             )
             .ok();
         }
@@ -453,7 +477,11 @@ impl AudioContext {
 
         // Then ask the audio host to suspend the stream
         log::debug!("Suspended audio graph. Suspending audio stream..");
-        self.backend_manager.lock().unwrap().suspend();
+        self.backend_manager
+            .lock()
+            .unwrap()
+            .suspend()
+            .expect("InvalidStateError - Unable to suspend audio stream");
 
         log::debug!("Suspended audio stream");
     }
@@ -481,7 +509,9 @@ impl AudioContext {
             }
 
             // Ask the audio host to resume the stream
-            backend_manager_guard.resume();
+            backend_manager_guard
+                .resume()
+                .expect("InvalidStateError - Unable to resume audio stream");
 
             // Then, ask to resume rendering via a control message
             log::debug!("Resumed audio stream, waking audio graph");
@@ -532,7 +562,11 @@ impl AudioContext {
 
         // Then ask the audio host to close the stream
         log::debug!("Suspended audio graph. Closing audio stream..");
-        self.backend_manager.lock().unwrap().close();
+        self.backend_manager
+            .lock()
+            .unwrap()
+            .close()
+            .expect("InvalidStateError - Unable to close audio stream");
 
         // Stop the AudioRenderCapacity collection thread
         self.render_capacity.stop();
@@ -577,7 +611,9 @@ impl AudioContext {
 
         // Then ask the audio host to suspend the stream
         log::debug!("Suspended audio graph. Suspending audio stream..");
-        backend_manager_guard.suspend();
+        backend_manager_guard
+            .suspend()
+            .expect("InvalidStateError - Unable to suspend audio stream");
 
         log::debug!("Suspended audio stream");
     }
@@ -605,7 +641,9 @@ impl AudioContext {
         }
 
         // Ask the audio host to resume the stream
-        backend_manager_guard.resume();
+        backend_manager_guard
+            .resume()
+            .expect("InvalidStateError - Unable to resume audio stream");
 
         // Then, ask to resume rendering via a control message
         log::debug!("Resumed audio stream, waking audio graph");
@@ -658,7 +696,9 @@ impl AudioContext {
 
         // Then ask the audio host to close the stream
         log::debug!("Suspended audio graph. Closing audio stream..");
-        backend_manager_guard.close();
+        backend_manager_guard
+            .close()
+            .expect("InvalidStateError - Unable to close audio stream");
 
         // Stop the AudioRenderCapacity collection thread
         self.render_capacity.stop();

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -852,4 +852,18 @@ mod tests {
         };
         let _ = AudioContext::new(options);
     }
+
+    #[test]
+    fn test_try_new_invalid_sink_id() {
+        let options = AudioContextOptions {
+            sink_id: "invalid".into(),
+            ..AudioContextOptions::default()
+        };
+
+        let error = AudioContext::try_new(options).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "NotFoundError - Invalid sinkId: \"invalid\""
+        );
+    }
 }

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -29,6 +29,31 @@ fn is_valid_sink_id(sink_id: &str) -> bool {
     }
 }
 
+#[derive(Debug)]
+enum AudioContextError {
+    SinkNotFound { sink_id: String },
+    Backend { error: io::AudioBackendError },
+}
+
+impl std::fmt::Display for AudioContextError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SinkNotFound { sink_id } => {
+                write!(f, "NotFoundError - Invalid sinkId: {sink_id:?}")
+            }
+            Self::Backend { error } => write!(f, "InvalidStateError - {error}"),
+        }
+    }
+}
+
+impl Error for AudioContextError {}
+
+impl From<io::AudioBackendError> for AudioContextError {
+    fn from(error: io::AudioBackendError) -> Self {
+        Self::Backend { error }
+    }
+}
+
 /// Identify the type of playback, which affects tradeoffs
 /// between audio output latency and power consumption
 #[derive(Copy, Clone, Debug, Default)]
@@ -171,13 +196,7 @@ impl AudioContext {
     /// stream. Use [`Self::try_new`] to handle these errors without panicking.
     #[must_use]
     pub fn new(options: AudioContextOptions) -> Self {
-        Self::try_new(options).unwrap_or_else(|e| {
-            let message = e.to_string();
-            if message.starts_with("NotFoundError - ") {
-                panic!("{message}");
-            }
-            panic!("InvalidStateError - {message}");
-        })
+        Self::try_new_inner(options).unwrap_or_else(|e| panic!("{e}"))
     }
 
     /// Creates and returns a new `AudioContext` object.
@@ -190,12 +209,15 @@ impl AudioContext {
     /// Returns an error when the sink id is invalid or when the selected audio backend cannot
     /// create or start the output stream.
     pub fn try_new(options: AudioContextOptions) -> Result<Self, Box<dyn Error>> {
+        Self::try_new_inner(options).map_err(Into::into)
+    }
+
+    fn try_new_inner(options: AudioContextOptions) -> Result<Self, AudioContextError> {
         // https://webaudio.github.io/web-audio-api/#validating-sink-identifier
         if !is_valid_sink_id(&options.sink_id) {
-            Err(format!(
-                "NotFoundError - Invalid sinkId: {:?}",
-                options.sink_id
-            ))?;
+            return Err(AudioContextError::SinkNotFound {
+                sink_id: options.sink_id,
+            });
         }
 
         // Set up the audio output thread

--- a/src/io/cpal.rs
+++ b/src/io/cpal.rs
@@ -5,12 +5,15 @@ use std::sync::Mutex;
 
 use cpal::{
     traits::{DeviceTrait, HostTrait, StreamTrait},
-    BuildStreamError, Device, OutputCallbackInfo, SampleFormat, Stream, StreamConfig,
+    BuildStreamError, DefaultStreamConfigError, Device, DeviceNameError, DevicesError,
+    OutputCallbackInfo, PauseStreamError, PlayStreamError, SampleFormat, Stream, StreamConfig,
     SupportedBufferSize,
 };
 use crossbeam_channel::Receiver;
 
-use super::{AudioBackendManager, RenderThreadInit};
+use super::{
+    AudioBackendError, AudioBackendErrorKind, AudioBackendManager, BackendResult, RenderThreadInit,
+};
 
 use crate::buffer::AudioBuffer;
 use crate::context::AudioContextLatencyCategory;
@@ -39,26 +42,26 @@ mod private {
             self.0.lock().unwrap().take(); // will Drop
         }
 
-        pub fn resume(&self) -> bool {
+        pub fn resume(&self) -> BackendResult<bool> {
             if let Some(s) = self.0.lock().unwrap().as_ref() {
-                if let Err(e) = s.play() {
-                    panic!("Error resuming cpal stream: {:?}", e);
-                }
-                return true;
+                s.play()
+                    .map(|_| true)
+                    .map_err(|e| map_cpal_play_error("resume", e))?;
+                return Ok(true);
             }
 
-            false
+            Ok(false)
         }
 
-        pub fn suspend(&self) -> bool {
+        pub fn suspend(&self) -> BackendResult<bool> {
             if let Some(s) = self.0.lock().unwrap().as_ref() {
-                if let Err(e) = s.pause() {
-                    panic!("Error suspending cpal stream: {:?}", e);
-                }
-                return true;
+                s.pause()
+                    .map(|_| true)
+                    .map_err(|e| map_cpal_pause_error("suspend", e))?;
+                return Ok(true);
             }
 
-            false
+            Ok(false)
         }
     }
 
@@ -80,7 +83,9 @@ fn get_host() -> cpal::Host {
             .into_iter()
             .find(|id| *id == cpal::HostId::Jack)
         {
-            let jack_host = cpal::host_from_id(jack_id).unwrap();
+            let Ok(jack_host) = cpal::host_from_id(jack_id) else {
+                return cpal::default_host();
+            };
 
             // if jack is not running, the host can't access devices
             // fallback to default host
@@ -104,6 +109,62 @@ fn get_host() -> cpal::Host {
     cpal::default_host()
 }
 
+fn map_cpal_backend_error(
+    kind: AudioBackendErrorKind,
+    operation: &'static str,
+    err: impl std::fmt::Display,
+) -> AudioBackendError {
+    AudioBackendError::new(kind, "cpal", operation, err.to_string())
+}
+
+fn map_cpal_build_error(operation: &'static str, err: BuildStreamError) -> AudioBackendError {
+    let kind = match err {
+        BuildStreamError::DeviceNotAvailable => AudioBackendErrorKind::DeviceUnavailable,
+        BuildStreamError::StreamConfigNotSupported => AudioBackendErrorKind::NotSupported,
+        BuildStreamError::InvalidArgument => AudioBackendErrorKind::InvalidArgument,
+        BuildStreamError::StreamIdOverflow | BuildStreamError::BackendSpecific { .. } => {
+            AudioBackendErrorKind::BackendSpecific
+        }
+    };
+    map_cpal_backend_error(kind, operation, err)
+}
+
+fn map_cpal_default_config_error(
+    operation: &'static str,
+    err: DefaultStreamConfigError,
+) -> AudioBackendError {
+    let kind = match err {
+        DefaultStreamConfigError::DeviceNotAvailable => AudioBackendErrorKind::DeviceUnavailable,
+        DefaultStreamConfigError::StreamTypeNotSupported => AudioBackendErrorKind::NotSupported,
+        DefaultStreamConfigError::BackendSpecific { .. } => AudioBackendErrorKind::BackendSpecific,
+    };
+    map_cpal_backend_error(kind, operation, err)
+}
+
+fn map_cpal_play_error(operation: &'static str, err: PlayStreamError) -> AudioBackendError {
+    let kind = match err {
+        PlayStreamError::DeviceNotAvailable => AudioBackendErrorKind::DeviceUnavailable,
+        PlayStreamError::BackendSpecific { .. } => AudioBackendErrorKind::BackendSpecific,
+    };
+    map_cpal_backend_error(kind, operation, err)
+}
+
+fn map_cpal_pause_error(operation: &'static str, err: PauseStreamError) -> AudioBackendError {
+    let kind = match err {
+        PauseStreamError::DeviceNotAvailable => AudioBackendErrorKind::DeviceUnavailable,
+        PauseStreamError::BackendSpecific { .. } => AudioBackendErrorKind::BackendSpecific,
+    };
+    map_cpal_backend_error(kind, operation, err)
+}
+
+fn map_cpal_devices_error(operation: &'static str, err: DevicesError) -> AudioBackendError {
+    map_cpal_backend_error(AudioBackendErrorKind::BackendSpecific, operation, err)
+}
+
+fn map_cpal_device_name_error(operation: &'static str, err: DeviceNameError) -> AudioBackendError {
+    map_cpal_backend_error(AudioBackendErrorKind::BackendSpecific, operation, err)
+}
+
 /// Audio backend using the `cpal` library
 #[derive(Clone)]
 #[allow(unused)]
@@ -116,7 +177,10 @@ pub(crate) struct CpalBackend {
 }
 
 impl AudioBackendManager for CpalBackend {
-    fn build_output(options: AudioContextOptions, render_thread_init: RenderThreadInit) -> Self
+    fn build_output(
+        options: AudioContextOptions,
+        render_thread_init: RenderThreadInit,
+    ) -> BackendResult<Self>
     where
         Self: Sized,
     {
@@ -133,24 +197,40 @@ impl AudioBackendManager for CpalBackend {
         } = render_thread_init;
 
         let device = if options.sink_id.is_empty() {
-            host.default_output_device()
-                .expect("InvalidStateError - no output device available")
+            host.default_output_device().ok_or_else(|| {
+                AudioBackendError::new(
+                    AudioBackendErrorKind::DeviceUnavailable,
+                    "cpal",
+                    "default_output_device",
+                    "No output device available",
+                )
+            })?
         } else {
-            Self::enumerate_devices_sync()
+            Self::enumerate_devices_sync()?
                 .into_iter()
                 .find(|e| e.device_id() == options.sink_id)
-                .map(|e| *e.device().downcast::<cpal::Device>().unwrap())
-                .unwrap_or_else(|| {
-                    host.default_output_device()
-                        .expect("InvalidStateError - no output device available")
-                })
+                .and_then(|e| e.device().downcast::<cpal::Device>().ok().map(|e| *e))
+                .or_else(|| host.default_output_device())
+                .ok_or_else(|| {
+                    AudioBackendError::new(
+                        AudioBackendErrorKind::DeviceUnavailable,
+                        "cpal",
+                        "select_output_device",
+                        "No output device available",
+                    )
+                })?
         };
 
-        log::info!("Output device: {:?}", device.name());
+        log::info!(
+            "Output device: {:?}",
+            device
+                .name()
+                .map_err(|e| map_cpal_device_name_error("output_device_name", e))?
+        );
 
         let default_device_config = device
             .default_output_config()
-            .expect("InvalidStateError - error while querying device output config");
+            .map_err(|e| map_cpal_default_config_error("default_output_config", e))?;
 
         // we grab the largest number of channels provided by the soundcard
         // clamped to MAX_CHANNELS, this value cannot be changed by the user
@@ -261,29 +341,28 @@ impl AudioBackendManager for CpalBackend {
                     Arc::clone(&output_latency),
                 );
 
-                spawned
-                    .expect("InvalidStateError - Unable to spawn output stream with default config")
+                spawned.map_err(|e| map_cpal_build_error("build_fallback_output_stream", e))?
             }
         };
 
         // Required because some hosts don't play the stream automatically
         stream
             .play()
-            .expect("InvalidStateError - Output stream refused to play");
+            .map_err(|e| map_cpal_play_error("play_output_stream", e))?;
 
-        CpalBackend {
+        Ok(CpalBackend {
             stream: ThreadSafeClosableStream::new(stream),
             output_latency,
             sample_rate,
             number_of_channels,
             sink_id: options.sink_id,
-        }
+        })
     }
 
     fn build_input(
         options: AudioContextOptions,
         number_of_channels: Option<u32>,
-    ) -> (Self, Receiver<AudioBuffer>)
+    ) -> BackendResult<(Self, Receiver<AudioBuffer>)>
     where
         Self: Sized,
     {
@@ -292,24 +371,40 @@ impl AudioBackendManager for CpalBackend {
         log::info!("Audio Input Host: cpal {:?}", host.id());
 
         let device = if options.sink_id.is_empty() {
-            host.default_input_device()
-                .expect("InvalidStateError - no input device available")
+            host.default_input_device().ok_or_else(|| {
+                AudioBackendError::new(
+                    AudioBackendErrorKind::DeviceUnavailable,
+                    "cpal",
+                    "default_input_device",
+                    "No input device available",
+                )
+            })?
         } else {
-            Self::enumerate_devices_sync()
+            Self::enumerate_devices_sync()?
                 .into_iter()
                 .find(|e| e.device_id() == options.sink_id)
-                .map(|e| *e.device().downcast::<cpal::Device>().unwrap())
-                .unwrap_or_else(|| {
-                    host.default_input_device()
-                        .expect("InvalidStateError - no input device available")
-                })
+                .and_then(|e| e.device().downcast::<cpal::Device>().ok().map(|e| *e))
+                .or_else(|| host.default_input_device())
+                .ok_or_else(|| {
+                    AudioBackendError::new(
+                        AudioBackendErrorKind::DeviceUnavailable,
+                        "cpal",
+                        "select_input_device",
+                        "No input device available",
+                    )
+                })?
         };
 
-        log::info!("Input device: {:?}", device.name());
+        log::info!(
+            "Input device: {:?}",
+            device
+                .name()
+                .map_err(|e| map_cpal_device_name_error("input_device_name", e))?
+        );
 
         let supported = device
             .default_input_config()
-            .expect("InvalidStateError - error while querying device input config");
+            .map_err(|e| map_cpal_default_config_error("default_input_config", e))?;
 
         // clone the config, we may need to fall back on it later
         let mut preferred: StreamConfig = supported.clone().into();
@@ -382,15 +477,14 @@ impl AudioBackendManager for CpalBackend {
                     &supported_config,
                     renderer,
                 );
-                spawned
-                    .expect("InvalidStateError - Unable to spawn input stream with default config")
+                spawned.map_err(|e| map_cpal_build_error("build_fallback_input_stream", e))?
             }
         };
 
         // Required because some hosts don't play the stream automatically
         stream
             .play()
-            .expect("InvalidStateError - Input stream refused to play");
+            .map_err(|e| map_cpal_play_error("play_input_stream", e))?;
 
         let backend = CpalBackend {
             stream: ThreadSafeClosableStream::new(stream),
@@ -400,19 +494,20 @@ impl AudioBackendManager for CpalBackend {
             sink_id: options.sink_id,
         };
 
-        (backend, receiver)
+        Ok((backend, receiver))
     }
 
-    fn resume(&self) -> bool {
+    fn resume(&self) -> BackendResult<bool> {
         self.stream.resume()
     }
 
-    fn suspend(&self) -> bool {
+    fn suspend(&self) -> BackendResult<bool> {
         self.stream.suspend()
     }
 
-    fn close(&self) {
-        self.stream.close()
+    fn close(&self) -> BackendResult<()> {
+        self.stream.close();
+        Ok(())
     }
 
     fn sample_rate(&self) -> f32 {
@@ -423,29 +518,35 @@ impl AudioBackendManager for CpalBackend {
         self.number_of_channels
     }
 
-    fn output_latency(&self) -> f64 {
-        self.output_latency.load(Ordering::Relaxed)
+    fn output_latency(&self) -> BackendResult<f64> {
+        Ok(self.output_latency.load(Ordering::Relaxed))
     }
 
     fn sink_id(&self) -> &str {
         self.sink_id.as_str()
     }
 
-    fn enumerate_devices_sync() -> Vec<MediaDeviceInfo>
+    fn enumerate_devices_sync() -> BackendResult<Vec<MediaDeviceInfo>>
     where
         Self: Sized,
     {
         let host = get_host();
 
-        let input_devices = host.input_devices().unwrap().map(|d| {
-            let num_channels = d.default_input_config().unwrap().channels();
-            (d, MediaDeviceInfoKind::AudioInput, num_channels)
-        });
+        let input_devices = host
+            .input_devices()
+            .map_err(|e| map_cpal_devices_error("enumerate_input_devices", e))?
+            .filter_map(|d| {
+                let num_channels = d.default_input_config().ok()?.channels();
+                Some((d, MediaDeviceInfoKind::AudioInput, num_channels))
+            });
 
-        let output_devices = host.output_devices().unwrap().map(|d| {
-            let num_channels = d.default_output_config().unwrap().channels();
-            (d, MediaDeviceInfoKind::AudioOutput, num_channels)
-        });
+        let output_devices = host
+            .output_devices()
+            .map_err(|e| map_cpal_devices_error("enumerate_output_devices", e))?
+            .filter_map(|d| {
+                let num_channels = d.default_output_config().ok()?.channels();
+                Some((d, MediaDeviceInfoKind::AudioOutput, num_channels))
+            });
 
         // cf. https://github.com/orottier/web-audio-api-rs/issues/356
         let mut list = Vec::<MediaDeviceInfo>::new();
@@ -457,7 +558,9 @@ impl AudioBackendManager for CpalBackend {
                 let device_id = crate::media_devices::DeviceId::as_string(
                     kind,
                     "cpal".to_string(),
-                    device.name().unwrap(),
+                    device
+                        .name()
+                        .map_err(|e| map_cpal_device_name_error("device_name", e))?,
                     num_channels,
                     index,
                 );
@@ -467,7 +570,9 @@ impl AudioBackendManager for CpalBackend {
                         device_id,
                         None,
                         kind,
-                        device.name().unwrap(),
+                        device
+                            .name()
+                            .map_err(|e| map_cpal_device_name_error("device_name", e))?,
                         Box::new(device),
                     );
 
@@ -479,7 +584,7 @@ impl AudioBackendManager for CpalBackend {
             }
         }
 
-        list
+        Ok(list)
     }
 }
 
@@ -600,7 +705,7 @@ fn spawn_output_stream(
             err_fn,
             None,
         ),
-        _ => panic!("Unknown cpal output sample format"),
+        _ => Err(BuildStreamError::StreamConfigNotSupported),
     }
 }
 
@@ -651,6 +756,6 @@ fn spawn_input_stream(
         SampleFormat::I64 => {
             device.build_input_stream(config, move |d: &[i64], _c| render.render(d), err_fn, None)
         }
-        _ => panic!("Unknown cpal input sample format"),
+        _ => Err(BuildStreamError::StreamConfigNotSupported),
     }
 }

--- a/src/io/cpal.rs
+++ b/src/io/cpal.rs
@@ -74,7 +74,7 @@ mod private {
 }
 use private::ThreadSafeClosableStream;
 
-fn get_host() -> cpal::Host {
+fn get_host() -> BackendResult<cpal::Host> {
     #[cfg(feature = "cpal-jack")]
     {
         // seems to be always Some when jack is installed,
@@ -83,13 +83,13 @@ fn get_host() -> cpal::Host {
             .into_iter()
             .find(|id| *id == cpal::HostId::Jack)
         {
-            let Ok(jack_host) = cpal::host_from_id(jack_id) else {
-                return cpal::default_host();
-            };
+            let jack_host = cpal::host_from_id(jack_id).map_err(|e| {
+                map_cpal_backend_error(AudioBackendErrorKind::BackendSpecific, "jack_host", e)
+            })?;
 
             // if jack is not running, the host can't access devices
             // fallback to default host
-            return match jack_host.devices() {
+            let host = match jack_host.devices() {
                 Ok(devices) => {
                     // no jack devices found, jack is not running
                     if devices.count() == 0 {
@@ -103,10 +103,11 @@ fn get_host() -> cpal::Host {
                 // but just in case, fallback to default host
                 Err(_) => cpal::default_host(),
             };
+            return Ok(host);
         }
     }
 
-    cpal::default_host()
+    Ok(cpal::default_host())
 }
 
 fn map_cpal_backend_error(
@@ -184,7 +185,7 @@ impl AudioBackendManager for CpalBackend {
     where
         Self: Sized,
     {
-        let host = get_host();
+        let host = get_host()?;
 
         log::info!("Audio Output Host: cpal {:?}", host.id());
 
@@ -366,7 +367,7 @@ impl AudioBackendManager for CpalBackend {
     where
         Self: Sized,
     {
-        let host = get_host();
+        let host = get_host()?;
 
         log::info!("Audio Input Host: cpal {:?}", host.id());
 
@@ -530,7 +531,7 @@ impl AudioBackendManager for CpalBackend {
     where
         Self: Sized,
     {
-        let host = get_host();
+        let host = get_host()?;
 
         let input_devices = host
             .input_devices()

--- a/src/io/cubeb.rs
+++ b/src/io/cubeb.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
-use super::{AudioBackendManager, RenderThreadInit};
+use super::{
+    AudioBackendError, AudioBackendErrorKind, AudioBackendManager, BackendResult, RenderThreadInit,
+};
 
 use crate::buffer::AudioBuffer;
 use crate::context::AudioContextOptions;
@@ -52,41 +54,42 @@ mod private {
         }
 
         pub fn close(&self) {
-            self.suspend();
+            let _ = self.suspend();
             self.0.lock().unwrap().take();
         }
 
-        pub fn resume(&self) -> bool {
+        pub fn resume(&self) -> BackendResult<bool> {
             if let Some(s) = self.0.lock().unwrap().as_ref() {
-                if let Err(e) = s.0.delegate_start() {
-                    panic!("Error resuming cubeb stream: {:?}", e);
-                }
-                return true;
+                s.0.delegate_start()
+                    .map(|_| true)
+                    .map_err(|e| map_cubeb_error("resume", e))?;
+                return Ok(true);
             }
 
-            false
+            Ok(false)
         }
 
-        pub fn suspend(&self) -> bool {
+        pub fn suspend(&self) -> BackendResult<bool> {
             if let Some(s) = self.0.lock().unwrap().as_ref() {
-                if let Err(e) = s.0.delegate_stop() {
-                    panic!("Error suspending cubeb stream: {:?}", e);
-                }
-                return true;
+                s.0.delegate_stop()
+                    .map(|_| true)
+                    .map_err(|e| map_cubeb_error("suspend", e))?;
+                return Ok(true);
             }
 
-            false
+            Ok(false)
         }
 
-        pub fn output_latency(&self, sample_rate: f32) -> f64 {
+        pub fn output_latency(&self, sample_rate: f32) -> BackendResult<f64> {
             if let Some(s) = self.0.lock().unwrap().as_ref() {
-                match s.0.delegate_latency() {
-                    Err(e) => panic!("Error getting cubeb latency: {:?}", e),
-                    Ok(frames) => return frames as f64 / sample_rate as f64,
-                }
+                return s
+                    .0
+                    .delegate_latency()
+                    .map(|frames| frames as f64 / sample_rate as f64)
+                    .map_err(|e| map_cubeb_error("output_latency", e));
             }
 
-            0.
+            Ok(0.)
         }
     }
 
@@ -98,13 +101,35 @@ mod private {
 }
 use private::ThreadSafeClosableStream;
 
+fn map_cubeb_error(operation: &'static str, err: cubeb::Error) -> AudioBackendError {
+    let kind = match err.code() {
+        cubeb::ErrorCode::DeviceUnavailable => AudioBackendErrorKind::DeviceUnavailable,
+        cubeb::ErrorCode::InvalidFormat | cubeb::ErrorCode::NotSupported => {
+            AudioBackendErrorKind::NotSupported
+        }
+        cubeb::ErrorCode::InvalidParameter => AudioBackendErrorKind::InvalidArgument,
+        cubeb::ErrorCode::Error => AudioBackendErrorKind::BackendSpecific,
+    };
+
+    AudioBackendError::new(kind, "cubeb", operation, err.to_string())
+}
+
+fn cubeb_backend_error(operation: &'static str, message: impl Into<String>) -> AudioBackendError {
+    AudioBackendError::new(
+        AudioBackendErrorKind::BackendSpecific,
+        "cubeb",
+        operation,
+        message,
+    )
+}
+
 fn init_output_backend<const N: usize>(
     ctx: &Context,
     params: StreamParams,
     buffer_size: u32,
     device: Option<DeviceId>,
     mut renderer: RenderThread,
-) -> ThreadSafeClosableStream {
+) -> BackendResult<ThreadSafeClosableStream> {
     let mut builder = cubeb::StreamBuilder::<[f32; N]>::new();
 
     match device {
@@ -134,8 +159,8 @@ fn init_output_backend<const N: usize>(
 
     let stream = builder
         .init(ctx)
-        .expect("InvalidStateError - Failed to create cubeb stream");
-    ThreadSafeClosableStream::new(stream)
+        .map_err(|e| map_cubeb_error("init_output_stream", e))?;
+    Ok(ThreadSafeClosableStream::new(stream))
 }
 
 /// Audio backend using the `cubeb` library
@@ -148,7 +173,10 @@ pub(crate) struct CubebBackend {
 }
 
 impl AudioBackendManager for CubebBackend {
-    fn build_output(options: AudioContextOptions, render_thread_init: RenderThreadInit) -> Self
+    fn build_output(
+        options: AudioContextOptions,
+        render_thread_init: RenderThreadInit,
+    ) -> BackendResult<Self>
     where
         Self: Sized,
     {
@@ -161,7 +189,7 @@ impl AudioBackendManager for CubebBackend {
         } = render_thread_init;
 
         // Set up cubeb context
-        let ctx = Context::init(None, None).unwrap();
+        let ctx = Context::init(None, None).map_err(|e| map_cubeb_error("init_context", e))?;
         log::info!("Audio Output Host: cubeb {:?}", ctx.backend_id());
 
         // Use user requested sample rate, or else the device preferred one
@@ -215,10 +243,10 @@ impl AudioBackendManager for CubebBackend {
         let device = if options.sink_id.is_empty() {
             None
         } else {
-            Self::enumerate_devices_sync()
+            Self::enumerate_devices_sync()?
                 .into_iter()
                 .find(|e| e.device_id() == options.sink_id)
-                .map(|e| *e.device().downcast::<DeviceId>().unwrap())
+                .and_then(|e| e.device().downcast::<DeviceId>().ok().map(|e| *e))
         };
 
         let stream = match number_of_channels {
@@ -255,25 +283,28 @@ impl AudioBackendManager for CubebBackend {
             30 => init_output_backend::<30>(&ctx, params, buffer_size, device, renderer),
             31 => init_output_backend::<31>(&ctx, params, buffer_size, device, renderer),
             32 => init_output_backend::<32>(&ctx, params, buffer_size, device, renderer),
-            _ => unreachable!(),
+            _ => Err(cubeb_backend_error(
+                "init_output_stream",
+                "Unexpected channel count",
+            )),
         };
 
         let backend = CubebBackend {
-            stream,
+            stream: stream?,
             number_of_channels,
             sample_rate,
             sink_id: options.sink_id,
         };
 
-        backend.resume();
+        backend.resume()?;
 
-        backend
+        Ok(backend)
     }
 
     fn build_input(
         options: AudioContextOptions,
         _number_of_channels: Option<u32>,
-    ) -> (Self, Receiver<AudioBuffer>)
+    ) -> BackendResult<(Self, Receiver<AudioBuffer>)>
     where
         Self: Sized,
     {
@@ -285,7 +316,7 @@ impl AudioBackendManager for CubebBackend {
          */
 
         // Set up cubeb context
-        let ctx = Context::init(None, None).unwrap();
+        let ctx = Context::init(None, None).map_err(|e| map_cubeb_error("init_context", e))?;
         log::info!("Audio Input Host: cubeb {:?}", ctx.backend_id());
 
         // Use user requested sample rate, or else the device preferred one
@@ -316,10 +347,10 @@ impl AudioBackendManager for CubebBackend {
         let device = if options.sink_id.is_empty() {
             None
         } else {
-            Self::enumerate_devices_sync()
+            Self::enumerate_devices_sync()?
                 .into_iter()
                 .find(|e| e.device_id() == options.sink_id)
-                .map(|e| *e.device().downcast::<DeviceId>().unwrap())
+                .and_then(|e| e.device().downcast::<DeviceId>().ok().map(|e| *e))
         };
 
         let smoothing = 3; // todo, use buffering to smooth frame drops
@@ -354,9 +385,11 @@ impl AudioBackendManager for CubebBackend {
 
         let stream = builder
             .init(&ctx)
-            .expect("InvalidStateError - Failed to create cubeb stream");
+            .map_err(|e| map_cubeb_error("init_input_stream", e))?;
 
-        stream.start().unwrap();
+        stream
+            .start()
+            .map_err(|e| map_cubeb_error("start_input_stream", e))?;
 
         let backend = CubebBackend {
             stream: ThreadSafeClosableStream::new(stream),
@@ -365,19 +398,20 @@ impl AudioBackendManager for CubebBackend {
             sink_id: options.sink_id,
         };
 
-        (backend, receiver)
+        Ok((backend, receiver))
     }
 
-    fn resume(&self) -> bool {
+    fn resume(&self) -> BackendResult<bool> {
         self.stream.resume()
     }
 
-    fn suspend(&self) -> bool {
+    fn suspend(&self) -> BackendResult<bool> {
         self.stream.suspend()
     }
 
-    fn close(&self) {
-        self.stream.close()
+    fn close(&self) -> BackendResult<()> {
+        self.stream.close();
+        Ok(())
     }
 
     fn sample_rate(&self) -> f32 {
@@ -388,7 +422,7 @@ impl AudioBackendManager for CubebBackend {
         self.number_of_channels
     }
 
-    fn output_latency(&self) -> f64 {
+    fn output_latency(&self) -> BackendResult<f64> {
         self.stream.output_latency(self.sample_rate)
     }
 
@@ -396,16 +430,20 @@ impl AudioBackendManager for CubebBackend {
         self.sink_id.as_str()
     }
 
-    fn enumerate_devices_sync() -> Vec<MediaDeviceInfo>
+    fn enumerate_devices_sync() -> BackendResult<Vec<MediaDeviceInfo>>
     where
         Self: Sized,
     {
-        let context = Context::init(None, None).unwrap();
+        let context = Context::init(None, None).map_err(|e| map_cubeb_error("init_context", e))?;
 
-        let inputs = context.enumerate_devices(DeviceType::INPUT).unwrap();
+        let inputs = context
+            .enumerate_devices(DeviceType::INPUT)
+            .map_err(|e| map_cubeb_error("enumerate_input_devices", e))?;
         let input_devices = inputs.iter().map(|d| (d, MediaDeviceInfoKind::AudioInput));
 
-        let outputs = context.enumerate_devices(DeviceType::OUTPUT).unwrap();
+        let outputs = context
+            .enumerate_devices(DeviceType::OUTPUT)
+            .map_err(|e| map_cubeb_error("enumerate_output_devices", e))?;
         let output_devices = outputs
             .iter()
             .map(|d| (d, MediaDeviceInfoKind::AudioOutput));
@@ -419,8 +457,21 @@ impl AudioBackendManager for CubebBackend {
                 let device_id = crate::media_devices::DeviceId::as_string(
                     kind,
                     "cubeb".to_string(),
-                    device.friendly_name().unwrap().into(),
-                    device.max_channels().try_into().unwrap(),
+                    device
+                        .friendly_name()
+                        .ok_or_else(|| {
+                            cubeb_backend_error(
+                                "device_friendly_name",
+                                "Device has no friendly name",
+                            )
+                        })?
+                        .into(),
+                    device.max_channels().try_into().map_err(|_| {
+                        cubeb_backend_error(
+                            "device_max_channels",
+                            "Device channel count overflows u16",
+                        )
+                    })?,
                     index,
                 );
 
@@ -429,7 +480,15 @@ impl AudioBackendManager for CubebBackend {
                         device_id,
                         device.group_id().map(str::to_string),
                         kind,
-                        device.friendly_name().unwrap().into(),
+                        device
+                            .friendly_name()
+                            .ok_or_else(|| {
+                                cubeb_backend_error(
+                                    "device_friendly_name",
+                                    "Device has no friendly name",
+                                )
+                            })?
+                            .into(),
                         Box::new(device.devid()),
                     );
 
@@ -441,6 +500,6 @@ impl AudioBackendManager for CubebBackend {
             }
         }
 
-        list
+        Ok(list)
     }
 }

--- a/src/io/microphone.rs
+++ b/src/io/microphone.rs
@@ -30,7 +30,7 @@ impl MicrophoneStream {
 impl Drop for MicrophoneStream {
     fn drop(&mut self) {
         log::debug!("Microphone stream has been dropped");
-        self.stream.close()
+        let _ = self.stream.close();
     }
 }
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,5 +1,7 @@
 //! Audio input/output interfaces
 
+use std::error::Error;
+use std::fmt;
 use std::sync::atomic::{AtomicU64, AtomicU8};
 use std::sync::Arc;
 
@@ -24,6 +26,63 @@ mod cubeb;
 
 #[cfg(any(feature = "cubeb", feature = "cpal"))]
 mod microphone;
+
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum AudioBackendErrorKind {
+    DeviceUnavailable,
+    NotSupported,
+    InvalidArgument,
+    BackendSpecific,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct AudioBackendError {
+    pub(crate) kind: AudioBackendErrorKind,
+    pub(crate) backend: &'static str,
+    pub(crate) operation: &'static str,
+    pub(crate) message: String,
+}
+
+pub(crate) type BackendResult<T> = Result<T, AudioBackendError>;
+
+impl AudioBackendError {
+    pub(crate) fn new(
+        kind: AudioBackendErrorKind,
+        backend: &'static str,
+        operation: &'static str,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            kind,
+            backend,
+            operation,
+            message: message.into(),
+        }
+    }
+
+    #[cfg(all(not(feature = "cubeb"), not(feature = "cpal")))]
+    pub(crate) fn no_backend(operation: &'static str) -> Self {
+        Self::new(
+            AudioBackendErrorKind::NotSupported,
+            "none",
+            operation,
+            "No audio backend available, enable the 'cpal' or 'cubeb' feature",
+        )
+    }
+}
+
+impl fmt::Display for AudioBackendError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} backend error during {}: {:?}: {}",
+            self.backend, self.operation, self.kind, self.message
+        )
+    }
+}
+
+impl Error for AudioBackendError {}
 
 #[derive(Debug)]
 pub(crate) struct ControlThreadInit {
@@ -90,25 +149,25 @@ pub(crate) fn thread_init() -> (ControlThreadInit, RenderThreadInit) {
 pub(crate) fn build_output(
     options: AudioContextOptions,
     render_thread_init: RenderThreadInit,
-) -> Box<dyn AudioBackendManager> {
+) -> BackendResult<Box<dyn AudioBackendManager>> {
     if options.sink_id == "none" {
-        let backend = NoneBackend::build_output(options, render_thread_init);
-        return Box::new(backend);
+        let backend = NoneBackend::build_output(options, render_thread_init)?;
+        return Ok(Box::new(backend));
     }
 
     #[cfg(feature = "cubeb")]
     {
-        let backend = cubeb::CubebBackend::build_output(options, render_thread_init);
-        Box::new(backend)
+        let backend = cubeb::CubebBackend::build_output(options, render_thread_init)?;
+        Ok(Box::new(backend))
     }
     #[cfg(all(not(feature = "cubeb"), feature = "cpal"))]
     {
-        let backend = cpal::CpalBackend::build_output(options, render_thread_init);
-        Box::new(backend)
+        let backend = cpal::CpalBackend::build_output(options, render_thread_init)?;
+        Ok(Box::new(backend))
     }
     #[cfg(all(not(feature = "cubeb"), not(feature = "cpal")))]
     {
-        panic!("No audio backend available, enable the 'cpal' or 'cubeb' feature")
+        Err(AudioBackendError::no_backend("build_output"))
     }
 }
 
@@ -116,10 +175,10 @@ pub(crate) fn build_output(
 pub(crate) fn build_input(
     options: AudioContextOptions,
     number_of_channels: Option<u32>,
-) -> MediaStream {
+) -> BackendResult<MediaStream> {
     #[cfg(all(not(feature = "cubeb"), not(feature = "cpal")))]
     {
-        panic!("No audio backend available, enable the 'cpal' or 'cubeb' feature")
+        Err(AudioBackendError::no_backend("build_input"))
     }
 
     #[cfg(any(feature = "cubeb", feature = "cpal"))]
@@ -127,18 +186,18 @@ pub(crate) fn build_input(
         let (backend, receiver) = {
             #[cfg(feature = "cubeb")]
             {
-                cubeb::CubebBackend::build_input(options, number_of_channels)
+                cubeb::CubebBackend::build_input(options, number_of_channels)?
             }
 
             #[cfg(all(not(feature = "cubeb"), feature = "cpal"))]
             {
-                cpal::CpalBackend::build_input(options, number_of_channels)
+                cpal::CpalBackend::build_input(options, number_of_channels)?
             }
         };
 
         let media_iter = microphone::MicrophoneStream::new(receiver, Box::new(backend));
         let track = MediaStreamTrack::from_iter(media_iter);
-        MediaStream::from_tracks(vec![track])
+        Ok(MediaStream::from_tracks(vec![track]))
     }
 }
 
@@ -150,7 +209,10 @@ pub(crate) trait AudioBackendManager: Send + Sync + 'static {
     }
 
     /// Setup a new output stream (speakers)
-    fn build_output(options: AudioContextOptions, render_thread_init: RenderThreadInit) -> Self
+    fn build_output(
+        options: AudioContextOptions,
+        render_thread_init: RenderThreadInit,
+    ) -> BackendResult<Self>
     where
         Self: Sized;
 
@@ -158,18 +220,18 @@ pub(crate) trait AudioBackendManager: Send + Sync + 'static {
     fn build_input(
         options: AudioContextOptions,
         number_of_channels: Option<u32>,
-    ) -> (Self, Receiver<AudioBuffer>)
+    ) -> BackendResult<(Self, Receiver<AudioBuffer>)>
     where
         Self: Sized;
 
     /// Resume or start the stream
-    fn resume(&self) -> bool;
+    fn resume(&self) -> BackendResult<bool>;
 
     /// Suspend the stream
-    fn suspend(&self) -> bool;
+    fn suspend(&self) -> BackendResult<bool>;
 
     /// Close the stream, freeing all resources. It cannot be started again after closing.
-    fn close(&self);
+    fn close(&self) -> BackendResult<()>;
 
     /// Sample rate of the stream
     fn sample_rate(&self) -> f32;
@@ -181,12 +243,12 @@ pub(crate) trait AudioBackendManager: Send + Sync + 'static {
     ///
     /// This is the difference between the time the backend acquires the data in the callback and
     /// the listener can hear the sound.
-    fn output_latency(&self) -> f64;
+    fn output_latency(&self) -> BackendResult<f64>;
 
     /// The audio output device - `""` means the default device
     fn sink_id(&self) -> &str;
 
-    fn enumerate_devices_sync() -> Vec<MediaDeviceInfo>
+    fn enumerate_devices_sync() -> BackendResult<Vec<MediaDeviceInfo>>
     where
         Self: Sized;
 }
@@ -220,7 +282,7 @@ fn buffer_size_for_latency_category(
     }
 }
 
-pub(crate) fn enumerate_devices_sync() -> Vec<MediaDeviceInfo> {
+pub(crate) fn enumerate_devices_sync() -> BackendResult<Vec<MediaDeviceInfo>> {
     #[cfg(feature = "cubeb")]
     {
         cubeb::CubebBackend::enumerate_devices_sync()
@@ -232,5 +294,5 @@ pub(crate) fn enumerate_devices_sync() -> Vec<MediaDeviceInfo> {
     }
 
     #[cfg(all(not(feature = "cubeb"), not(feature = "cpal")))]
-    panic!("No audio backend available, enable the 'cpal' or 'cubeb' feature")
+    Err(AudioBackendError::no_backend("enumerate_devices_sync"))
 }

--- a/src/io/none.rs
+++ b/src/io/none.rs
@@ -1,7 +1,9 @@
 use std::thread;
 use std::time::{Duration, Instant};
 
-use super::{AudioBackendManager, RenderThreadInit};
+use super::{
+    AudioBackendError, AudioBackendErrorKind, AudioBackendManager, BackendResult, RenderThreadInit,
+};
 
 use crate::buffer::AudioBuffer;
 use crate::context::AudioContextOptions;
@@ -74,7 +76,10 @@ impl Callback {
 
 impl AudioBackendManager for NoneBackend {
     /// Setup a new output stream (speakers)
-    fn build_output(options: AudioContextOptions, render_thread_init: RenderThreadInit) -> Self
+    fn build_output(
+        options: AudioContextOptions,
+        render_thread_init: RenderThreadInit,
+    ) -> BackendResult<Self>
     where
         Self: Sized,
     {
@@ -114,38 +119,68 @@ impl AudioBackendManager for NoneBackend {
 
         thread::spawn(move || callback.run());
 
-        Self {
+        Ok(Self {
             sender,
             sample_rate,
-        }
+        })
     }
 
     /// Setup a new input stream (microphone capture)
     fn build_input(
         _options: AudioContextOptions,
         _number_of_channels: Option<u32>,
-    ) -> (Self, Receiver<AudioBuffer>)
+    ) -> BackendResult<(Self, Receiver<AudioBuffer>)>
     where
         Self: Sized,
     {
-        unimplemented!()
+        Err(AudioBackendError::new(
+            AudioBackendErrorKind::NotSupported,
+            "none",
+            "build_input",
+            "The none backend does not support audio input",
+        ))
     }
 
     /// Resume or start the stream
-    fn resume(&self) -> bool {
-        self.sender.send(NoneBackendMessage::Resume).unwrap();
-        true
+    fn resume(&self) -> BackendResult<bool> {
+        self.sender
+            .send(NoneBackendMessage::Resume)
+            .map(|_| true)
+            .map_err(|_| {
+                AudioBackendError::new(
+                    AudioBackendErrorKind::BackendSpecific,
+                    "none",
+                    "resume",
+                    "The render thread is no longer available",
+                )
+            })
     }
 
     /// Suspend the stream
-    fn suspend(&self) -> bool {
-        self.sender.send(NoneBackendMessage::Suspend).unwrap();
-        true
+    fn suspend(&self) -> BackendResult<bool> {
+        self.sender
+            .send(NoneBackendMessage::Suspend)
+            .map(|_| true)
+            .map_err(|_| {
+                AudioBackendError::new(
+                    AudioBackendErrorKind::BackendSpecific,
+                    "none",
+                    "suspend",
+                    "The render thread is no longer available",
+                )
+            })
     }
 
     /// Close the stream, freeing all resources. It cannot be started again after closing.
-    fn close(&self) {
-        self.sender.send(NoneBackendMessage::Close).unwrap()
+    fn close(&self) -> BackendResult<()> {
+        self.sender.send(NoneBackendMessage::Close).map_err(|_| {
+            AudioBackendError::new(
+                AudioBackendErrorKind::BackendSpecific,
+                "none",
+                "close",
+                "The render thread is no longer available",
+            )
+        })
     }
 
     /// Sample rate of the stream
@@ -162,8 +197,8 @@ impl AudioBackendManager for NoneBackend {
     ///
     /// This is the difference between the time the backend acquires the data in the callback and
     /// the listener can hear the sound.
-    fn output_latency(&self) -> f64 {
-        0.
+    fn output_latency(&self) -> BackendResult<f64> {
+        Ok(0.)
     }
 
     /// The audio output device
@@ -171,10 +206,10 @@ impl AudioBackendManager for NoneBackend {
         "none"
     }
 
-    fn enumerate_devices_sync() -> Vec<MediaDeviceInfo>
+    fn enumerate_devices_sync() -> BackendResult<Vec<MediaDeviceInfo>>
     where
         Self: Sized,
     {
-        unimplemented!()
+        Ok(vec![])
     }
 }

--- a/src/media_devices/mod.rs
+++ b/src/media_devices/mod.rs
@@ -227,7 +227,7 @@ fn is_valid_device_id(device_id: &str) -> bool {
 /// std::thread::sleep(std::time::Duration::from_secs(4));
 /// ```
 pub fn get_user_media_sync(constraints: MediaStreamConstraints) -> MediaStream {
-    try_get_user_media_sync(constraints).expect("InvalidStateError - Unable to open input stream")
+    try_get_user_media_sync(constraints).unwrap_or_else(|e| panic!("InvalidStateError - {e}"))
 }
 
 pub(crate) fn try_get_user_media_sync(

--- a/src/media_devices/mod.rs
+++ b/src/media_devices/mod.rs
@@ -205,6 +205,12 @@ fn is_valid_device_id(device_id: &str) -> bool {
 /// This function operates synchronously, which may be undesirable on the control thread. An async
 /// version is currently not implemented.
 ///
+/// # Panics
+///
+/// This function will panic when the selected audio backend cannot create or start the input
+/// stream. A public `try_get_user_media_sync` could be added in the future to handle these errors
+/// without panicking, similar to [`AudioContext::try_new`].
+///
 /// # Example
 ///
 /// ```no_run

--- a/src/media_devices/mod.rs
+++ b/src/media_devices/mod.rs
@@ -209,7 +209,7 @@ fn is_valid_device_id(device_id: &str) -> bool {
 ///
 /// This function will panic when the selected audio backend cannot create or start the input
 /// stream. A public `try_get_user_media_sync` could be added in the future to handle these errors
-/// without panicking, similar to [`AudioContext::try_new`].
+/// without panicking, similar to [`AudioContext::try_new`](crate::context::AudioContext::new).
 ///
 /// # Example
 ///

--- a/src/media_devices/mod.rs
+++ b/src/media_devices/mod.rs
@@ -8,6 +8,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
 use crate::context::{AudioContextLatencyCategory, AudioContextOptions};
+use crate::io::BackendResult;
 use crate::media_streams::MediaStream;
 
 /// List the available media output devices, such as speakers, headsets, loopbacks, etc
@@ -24,6 +25,13 @@ use crate::media_streams::MediaStream;
 /// assert_eq!(devices[0].label(), "Macbook Pro Builtin Speakers");
 /// ```
 pub fn enumerate_devices_sync() -> Vec<MediaDeviceInfo> {
+    try_enumerate_devices_sync().unwrap_or_else(|e| {
+        log::error!("Unable to enumerate media devices: {e}");
+        vec![]
+    })
+}
+
+pub(crate) fn try_enumerate_devices_sync() -> BackendResult<Vec<MediaDeviceInfo>> {
     crate::io::enumerate_devices_sync()
 }
 
@@ -219,6 +227,12 @@ fn is_valid_device_id(device_id: &str) -> bool {
 /// std::thread::sleep(std::time::Duration::from_secs(4));
 /// ```
 pub fn get_user_media_sync(constraints: MediaStreamConstraints) -> MediaStream {
+    try_get_user_media_sync(constraints).expect("InvalidStateError - Unable to open input stream")
+}
+
+pub(crate) fn try_get_user_media_sync(
+    constraints: MediaStreamConstraints,
+) -> BackendResult<MediaStream> {
     let (channel_count, mut options) = match constraints {
         MediaStreamConstraints::Audio => (None, AudioContextOptions::default()),
         MediaStreamConstraints::AudioWithConstraints(cs) => (cs.channel_count, cs.into()),


### PR DESCRIPTION
Only change to the public API is the addition of `AudioContext::try_new`
Other ones still panic (resume, suspend, latency), could make those public later.

Warning: AI assisted coding, but I reviewed thoroughly