### PR TITLE
Fix 558: cpal::Stream::suspend() stops the render callback causing control messages to stall

### DIFF
--- a/src/context/concrete_base.rs
+++ b/src/context/concrete_base.rs
@@ -289,7 +289,7 @@ impl ConcreteBaseAudioContext {
     }
 
     pub(crate) fn suspend_control_msgs(&self, msg: ControlMessage) {
-        let sender = self.inner.render_channel.write().unwrap();
+        let sender = self.inner.render_channel.read().unwrap();
         *self.inner.suspended_messages.lock().unwrap() = Some(Vec::new());
         if sender.send(msg).is_err() {
             log::warn!("Discarding control message - render thread is closed");
@@ -297,7 +297,7 @@ impl ConcreteBaseAudioContext {
     }
 
     pub(crate) fn resume_control_msgs(&self, msg: ControlMessage) {
-        let sender = self.inner.render_channel.write().unwrap();
+        let sender = self.inner.render_channel.read().unwrap();
         let messages = self
             .inner
             .suspended_messages

--- a/src/context/concrete_base.rs
+++ b/src/context/concrete_base.rs
@@ -94,6 +94,8 @@ struct ConcreteBaseAudioContextInner {
     destination_channel_config: ChannelConfig,
     /// message channel from control to render thread
     render_channel: RwLock<Sender<ControlMessage>>,
+    /// control messages staged while the render thread is suspended
+    suspended_messages: Mutex<Option<Vec<ControlMessage>>>,
     /// control messages that cannot be sent immediately
     queued_messages: Mutex<Vec<ControlMessage>>,
     /// number of frames played
@@ -140,6 +142,7 @@ impl ConcreteBaseAudioContext {
             sample_rate,
             max_channel_count,
             render_channel: RwLock::new(render_channel),
+            suspended_messages: Mutex::new(None),
             queued_messages: Mutex::new(Vec::new()),
             audio_node_id_provider,
             destination_channel_config: AudioNodeOptions::default().into(),
@@ -272,10 +275,46 @@ impl ConcreteBaseAudioContext {
     /// emitted.
     pub(crate) fn send_control_msg(&self, msg: ControlMessage) {
         if self.state() != AudioContextState::Closed {
-            let result = self.inner.render_channel.read().unwrap().send(msg);
+            let sender = self.inner.render_channel.read().unwrap();
+            if let Some(queued) = self.inner.suspended_messages.lock().unwrap().as_mut() {
+                queued.push(msg);
+                return;
+            }
+
+            let result = sender.send(msg);
             if result.is_err() {
                 log::warn!("Discarding control message - render thread is closed");
             }
+        }
+    }
+
+    pub(crate) fn suspend_control_msgs(&self, msg: ControlMessage) {
+        let sender = self.inner.render_channel.write().unwrap();
+        *self.inner.suspended_messages.lock().unwrap() = Some(Vec::new());
+        if sender.send(msg).is_err() {
+            log::warn!("Discarding control message - render thread is closed");
+        }
+    }
+
+    pub(crate) fn resume_control_msgs(&self, msg: ControlMessage) {
+        let sender = self.inner.render_channel.write().unwrap();
+        let messages = self
+            .inner
+            .suspended_messages
+            .lock()
+            .unwrap()
+            .take()
+            .unwrap_or_default();
+
+        for msg in messages {
+            if sender.send(msg).is_err() {
+                log::warn!("Discarding control message - render thread is closed");
+                return;
+            }
+        }
+
+        if sender.send(msg).is_err() {
+            log::warn!("Discarding control message - render thread is closed");
         }
     }
 

--- a/src/context/concrete_base.rs
+++ b/src/context/concrete_base.rs
@@ -276,6 +276,7 @@ impl ConcreteBaseAudioContext {
     pub(crate) fn send_control_msg(&self, msg: ControlMessage) {
         if self.state() != AudioContextState::Closed {
             let sender = self.inner.render_channel.read().unwrap();
+            // if the context is suspended, buffer the message and don't send it
             if let Some(queued) = self.inner.suspended_messages.lock().unwrap().as_mut() {
                 queued.push(msg);
                 return;

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -496,7 +496,7 @@ impl AudioContext {
         let (sender, receiver) = oneshot::channel();
         let notify = OneshotNotify::Async(sender);
         self.base
-            .send_control_msg(ControlMessage::Suspend { notify });
+            .suspend_control_msgs(ControlMessage::Suspend { notify });
 
         // Wait for the render thread to have processed the suspend message.
         // The AudioContextState will be updated by the render thread.
@@ -545,7 +545,7 @@ impl AudioContext {
             log::debug!("Resumed audio stream, waking audio graph");
             let notify = OneshotNotify::Async(sender);
             self.base
-                .send_control_msg(ControlMessage::Resume { notify });
+                .resume_control_msgs(ControlMessage::Resume { notify });
 
             // Drop the Mutex guard so we won't hold it across an await point
         }
@@ -630,7 +630,7 @@ impl AudioContext {
         let (sender, receiver) = crossbeam_channel::bounded(0);
         let notify = OneshotNotify::Sync(sender);
         self.base
-            .send_control_msg(ControlMessage::Suspend { notify });
+            .suspend_control_msgs(ControlMessage::Suspend { notify });
 
         // Wait for the render thread to have processed the suspend message.
         // The AudioContextState will be updated by the render thread.
@@ -678,7 +678,7 @@ impl AudioContext {
         let (sender, receiver) = crossbeam_channel::bounded(0);
         let notify = OneshotNotify::Sync(sender);
         self.base
-            .send_control_msg(ControlMessage::Resume { notify });
+            .resume_control_msgs(ControlMessage::Resume { notify });
 
         // Wait for the render thread to have processed the resume message
         // The AudioContextState will be updated by the render thread.

--- a/tests/online.rs
+++ b/tests/online.rs
@@ -9,6 +9,7 @@ use web_audio_api::context::{
 use web_audio_api::node::AudioNode;
 
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::thread;
 use std::time::Duration;
 use web_audio_api::MAX_CHANNELS;
 
@@ -294,4 +295,37 @@ fn test_suspend_then_close() {
     assert_eq!(context.state(), AudioContextState::Suspended);
     context.close_sync();
     assert_eq!(context.state(), AudioContextState::Closed);
+}
+
+#[test]
+fn test_control_messages_do_not_block_while_suspended() {
+    let (suspended_tx, suspended_rx) = std::sync::mpsc::channel();
+    let (done_tx, done_rx) = std::sync::mpsc::channel();
+
+    thread::spawn(move || {
+        let options = AudioContextOptions {
+            sink_id: "none".into(),
+            ..AudioContextOptions::default()
+        };
+        let context = AudioContext::new(options);
+
+        context.suspend_sync();
+        assert_eq!(context.state(), AudioContextState::Suspended);
+        suspended_tx.send(()).unwrap();
+
+        // The control channel currently has a capacity of 256. Sending more messages while the
+        // backend callback is suspended must not block the control thread.
+        for i in 0..300 {
+            context.destination().set_channel_count(1 + i % 2);
+        }
+
+        done_tx.send(()).unwrap();
+    });
+
+    suspended_rx.recv().unwrap();
+
+    assert!(
+        done_rx.recv_timeout(Duration::from_millis(500)).is_ok(),
+        "control messages blocked while the render callback was suspended"
+    );
 }


### PR DESCRIPTION
This would be the most easy fix. I need to think about it a bit more. Probably refactor that giant ConcreteBaseAudioContextInner a bit..

Fixes #558 