### PR TITLE
Fix #579: AudioScheduledSource node multiple stop() behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Update cpal - raises the minimum Android API version to 26 (Android 8/Oreo).
 - Update MSRV to 1.86 (April 2025)
 - Changed: allow `[3000, 768000]` as supported sample rate range
+- Fix: Allow calling `stop()` multiple times on an AudioScheduledSourceNode
 - Fix: ScriptProcessorNode now accepts 0 for the buffer size - picking a decent default for you
 - Other dependency updates
 

--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -113,7 +113,7 @@ pub struct AudioBufferSourceNode {
     buffer_time: Arc<AtomicF64>,
     buffer: Option<AudioBuffer>,
     loop_state: LoopState,
-    start_stop_count: u8,
+    has_start: bool,
 }
 
 impl AudioNode for AudioBufferSourceNode {
@@ -151,12 +151,8 @@ impl AudioScheduledSourceNode for AudioBufferSourceNode {
 
     fn stop_at(&mut self, when: f64) {
         assert_valid_time_value(when);
-        assert_eq!(
-            self.start_stop_count, 1,
-            "InvalidStateError cannot stop before start"
-        );
+        assert!(self.has_start, "InvalidStateError cannot stop before start");
 
-        self.start_stop_count += 1;
         self.registration.post_message(ControlMessage::Stop(when));
     }
 }
@@ -226,7 +222,7 @@ impl AudioBufferSourceNode {
                 buffer_time: Arc::clone(&renderer.render_state.buffer_time),
                 buffer: None,
                 loop_state,
-                start_stop_count: 0,
+                has_start: false,
             };
 
             (node, Box::new(renderer))
@@ -258,12 +254,12 @@ impl AudioBufferSourceNode {
         assert_valid_time_value(start);
         assert_valid_time_value(offset);
         assert_valid_time_value(duration);
-        assert_eq!(
-            self.start_stop_count, 0,
+        assert!(
+            !self.has_start,
             "InvalidStateError - Cannot call `start` twice"
         );
 
-        self.start_stop_count += 1;
+        self.has_start = true;
         let control = ControlMessage::StartWithOffsetAndDuration(start, offset, duration);
         self.registration.post_message(control);
     }

--- a/src/node/constant_source.rs
+++ b/src/node/constant_source.rs
@@ -76,7 +76,7 @@ pub struct ConstantSourceNode {
     registration: AudioContextRegistration,
     channel_config: ChannelConfig,
     offset: AudioParam,
-    start_stop_count: u8,
+    has_start: bool,
 }
 
 impl AudioNode for ConstantSourceNode {
@@ -105,12 +105,12 @@ impl AudioScheduledSourceNode for ConstantSourceNode {
 
     fn start_at(&mut self, when: f64) {
         assert_valid_time_value(when);
-        assert_eq!(
-            self.start_stop_count, 0,
+        assert!(
+            !self.has_start,
             "InvalidStateError - Cannot call `start` twice"
         );
 
-        self.start_stop_count += 1;
+        self.has_start = true;
         self.registration.post_message(Schedule::Start(when));
     }
 
@@ -121,12 +121,8 @@ impl AudioScheduledSourceNode for ConstantSourceNode {
 
     fn stop_at(&mut self, when: f64) {
         assert_valid_time_value(when);
-        assert_eq!(
-            self.start_stop_count, 1,
-            "InvalidStateError cannot stop before start"
-        );
+        assert!(self.has_start, "InvalidStateError cannot stop before start");
 
-        self.start_stop_count += 1;
         self.registration.post_message(Schedule::Stop(when));
     }
 }
@@ -157,7 +153,7 @@ impl ConstantSourceNode {
                 registration,
                 channel_config: ChannelConfig::default(),
                 offset: param,
-                start_stop_count: 0,
+                has_start: false,
             };
 
             (node, Box::new(render))

--- a/src/node/oscillator.rs
+++ b/src/node/oscillator.rs
@@ -135,8 +135,8 @@ pub struct OscillatorNode {
     detune: AudioParam,
     /// Waveform of an oscillator
     type_: OscillatorType,
-    /// Number of start/stop actions, node can only be started and stopped once
-    start_stop_count: u8,
+    /// Tracks whether `start` has been called already.
+    has_start: bool,
 }
 
 impl AudioNode for OscillatorNode {
@@ -167,12 +167,12 @@ impl AudioScheduledSourceNode for OscillatorNode {
 
     fn start_at(&mut self, when: f64) {
         assert_valid_time_value(when);
-        assert_eq!(
-            self.start_stop_count, 0,
+        assert!(
+            !self.has_start,
             "InvalidStateError - Cannot call `start` twice"
         );
 
-        self.start_stop_count += 1;
+        self.has_start = true;
         self.registration.post_message(Schedule::Start(when));
     }
 
@@ -183,12 +183,8 @@ impl AudioScheduledSourceNode for OscillatorNode {
 
     fn stop_at(&mut self, when: f64) {
         assert_valid_time_value(when);
-        assert_eq!(
-            self.start_stop_count, 1,
-            "InvalidStateError cannot stop before start"
-        );
+        assert!(self.has_start, "InvalidStateError cannot stop before start");
 
-        self.start_stop_count += 1;
         self.registration.post_message(Schedule::Stop(when));
     }
 }
@@ -255,7 +251,7 @@ impl OscillatorNode {
                 frequency: f_param,
                 detune: det_param,
                 type_,
-                start_stop_count: 0,
+                has_start: false,
             };
 
             (node, Box::new(renderer))
@@ -1155,6 +1151,23 @@ mod tests {
         }
 
         assert_float_eq!(result[..], expected[..], abs_all <= 1e-5);
+    }
+
+    #[test]
+    fn osc_stop_disarms_future_start() {
+        let sample_rate = 44_100;
+        let future_start = 2. / sample_rate as f64;
+
+        let mut context = OfflineAudioContext::new(1, 128, sample_rate as f32);
+        let mut osc = context.create_oscillator();
+        osc.connect(&context.destination());
+        osc.start_at(future_start);
+        osc.stop();
+
+        let output = context.start_rendering_sync();
+        let result = output.get_channel_data(0);
+
+        assert_float_eq!(result[..], vec![0.; 128][..], abs_all <= 0.);
     }
 
     #[test]

--- a/src/node/scheduled_source.rs
+++ b/src/node/scheduled_source.rs
@@ -22,14 +22,14 @@ pub trait AudioScheduledSourceNode: AudioNode {
     ///
     /// # Panics
     ///
-    /// Panics if the source was already stopped
+    /// Panics if the source was not started yet
     fn stop(&mut self);
 
     /// Schedule playback stop at given timestamp
     ///
     /// # Panics
     ///
-    /// Panics if the source was already stopped
+    /// Panics if the source was not started yet
     fn stop_at(&mut self, when: f64);
 
     /// Register callback to run when the source node has stopped playing
@@ -316,6 +316,7 @@ mod tests {
     }
 
     fn run_stop_twice(f: impl FnOnce(&OfflineAudioContext) -> ConcreteAudioScheduledSourceNode) {
+        // is allowed, see https://github.com/orottier/web-audio-api-rs/issues/579
         let context = OfflineAudioContext::new(2, 1, 44_100.);
         let mut src = f(&context);
         src.start();
@@ -324,18 +325,15 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    fn test_stop_twice_constant_source() {
+    fn test_stop_twice_allowed_constant_source() {
         run_stop_twice(|c| Constant(c.create_constant_source()));
     }
     #[test]
-    #[should_panic]
-    fn test_stop_twice_buffer_source() {
+    fn test_stop_twice_allowed_buffer_source() {
         run_stop_twice(|c| Buffer(c.create_buffer_source()));
     }
     #[test]
-    #[should_panic]
-    fn test_stop_twice_oscillator() {
+    fn test_stop_twice_allowed_oscillator() {
         run_stop_twice(|c| Oscillator(c.create_oscillator()));
     }
 }


### PR DESCRIPTION
Stop can be called multiple times, should not throw. It should only check if start() has been called once.

https://webaudio.github.io/web-audio-api/#dom-audioscheduledsourcenode-stop https://developer.mozilla.org/en-US/docs/Web/API/AudioScheduledSourceNode/stop

> Each time you call stop() on the same node, the specified time replaces any
> previously-scheduled stop time that hasn't occurred yet. If the node has
> already stopped, this method has no effect.