### PR TITLE
Fix StereoPannerNode: accurate computation of right and left gains

### DIFF
--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -59,10 +59,7 @@ mod waveshaper;
 pub use waveshaper::*;
 
 pub(crate) const TABLE_LENGTH_USIZE: usize = 8192;
-pub(crate) const TABLE_LENGTH_BY_4_USIZE: usize = TABLE_LENGTH_USIZE / 4;
-
 pub(crate) const TABLE_LENGTH_F32: f32 = TABLE_LENGTH_USIZE as f32;
-pub(crate) const TABLE_LENGTH_BY_4_F32: f32 = TABLE_LENGTH_BY_4_USIZE as f32;
 
 /// Precomputed sine table
 pub(crate) fn precomputed_sine_table() -> &'static [f32] {

--- a/src/node/stereo_panner.rs
+++ b/src/node/stereo_panner.rs
@@ -1,14 +1,13 @@
 //! The stereo panner control and renderer parts
+use std::f32::consts::PI;
+
 use crate::context::{AudioContextRegistration, AudioParamId, BaseAudioContext};
 use crate::param::{AudioParam, AudioParamDescriptor};
 use crate::render::{
     AudioParamValues, AudioProcessor, AudioRenderQuantum, AudioWorkletGlobalScope,
 };
 
-use super::{
-    precomputed_sine_table, AudioNode, AudioNodeOptions, ChannelConfig, ChannelCountMode,
-    ChannelInterpretation, TABLE_LENGTH_BY_4_F32, TABLE_LENGTH_BY_4_USIZE,
-};
+use super::{AudioNode, AudioNodeOptions, ChannelConfig, ChannelCountMode, ChannelInterpretation};
 
 /// Options for constructing a [`StereoPannerOptions`]
 // dictionary StereoPannerOptions : AudioNodeOptions {
@@ -68,17 +67,13 @@ fn assert_valid_channel_count_mode(mode: ChannelCountMode) {
     );
 }
 
-/// Generates the stereo gains for a specific x ∈ [0, 1] derived from pan.
-/// Basically the following by a table lookup:
-///
+/// Generates the stereo gains for a specific x ∈ [0, 1] derived from pan:
 /// - `gain_left = (x * PI / 2.).cos()`
 /// - `gain_right = (x * PI / 2.).sin()`
 #[inline(always)]
-fn get_stereo_gains(sine_table: &[f32], x: f32) -> [f32; 2] {
-    let idx = (x * TABLE_LENGTH_BY_4_F32) as usize;
-
-    let gain_left = sine_table[idx + TABLE_LENGTH_BY_4_USIZE];
-    let gain_right = sine_table[idx];
+fn get_stereo_gains(x: f32) -> [f32; 2] {
+    let gain_left = ((1. - x) * PI / 2.).sin(); // more accurate than cos()
+    let gain_right = (x * PI / 2.).sin();
 
     [gain_left, gain_right]
 }
@@ -212,15 +207,11 @@ struct StereoPannerRenderer {
     /// Position of the input in the output’s stereo image.
     /// -1 represents full left, +1 represents full right.
     pan: AudioParamId,
-    sine_table: &'static [f32],
 }
 
 impl StereoPannerRenderer {
     fn new(pan: AudioParamId) -> Self {
-        Self {
-            pan,
-            sine_table: precomputed_sine_table(),
-        }
+        Self { pan }
     }
 }
 
@@ -254,7 +245,7 @@ impl AudioProcessor for StereoPannerRenderer {
                 if pan_values.len() == 1 {
                     let pan = pan_values[0];
                     let x = (pan + 1.) * 0.5;
-                    let [gain_left, gain_right] = get_stereo_gains(self.sine_table, x);
+                    let [gain_left, gain_right] = get_stereo_gains(x);
 
                     left.iter_mut()
                         .zip(right.iter_mut())
@@ -270,7 +261,7 @@ impl AudioProcessor for StereoPannerRenderer {
                         .zip(input.channel_data(0).iter())
                         .for_each(|(((l, r), pan), input)| {
                             let x = (pan + 1.) * 0.5;
-                            let [gain_left, gain_right] = get_stereo_gains(self.sine_table, x);
+                            let [gain_left, gain_right] = get_stereo_gains(x);
 
                             *l = input * gain_left;
                             *r = input * gain_right;
@@ -281,7 +272,7 @@ impl AudioProcessor for StereoPannerRenderer {
                 if pan_values.len() == 1 {
                     let pan = pan_values[0];
                     let x = if pan <= 0. { pan + 1. } else { pan };
-                    let [gain_left, gain_right] = get_stereo_gains(self.sine_table, x);
+                    let [gain_left, gain_right] = get_stereo_gains(x);
 
                     left.iter_mut()
                         .zip(right.iter_mut())
@@ -305,13 +296,13 @@ impl AudioProcessor for StereoPannerRenderer {
                         .for_each(|((((l, r), &pan), &input_left), &input_right)| {
                             if pan <= 0. {
                                 let x = pan + 1.;
-                                let [gain_left, gain_right] = get_stereo_gains(self.sine_table, x);
+                                let [gain_left, gain_right] = get_stereo_gains(x);
 
                                 *l = input_right.mul_add(gain_left, input_left);
                                 *r = input_right * gain_right;
                             } else {
                                 let x = pan;
-                                let [gain_left, gain_right] = get_stereo_gains(self.sine_table, x);
+                                let [gain_left, gain_right] = get_stereo_gains(x);
 
                                 *l = input_left * gain_left;
                                 *r = input_left.mul_add(gain_right, input_right);
@@ -329,7 +320,6 @@ impl AudioProcessor for StereoPannerRenderer {
 #[cfg(test)]
 mod tests {
     use float_eq::assert_float_eq;
-    use std::f32::consts::PI;
 
     use crate::context::{BaseAudioContext, OfflineAudioContext};
     use crate::node::AudioScheduledSourceNode;
@@ -374,31 +364,6 @@ mod tests {
             ChannelCountMode::Explicit
         );
         assert_eq!(panner.channel_count_mode(), ChannelCountMode::Explicit);
-    }
-
-    #[test]
-    fn test_get_stereo_gains() {
-        let sine_table = precomputed_sine_table();
-
-        // check correctness of wavetable lookup
-        for i in 0..1001 {
-            let x = i as f32 / 1000.;
-
-            let [gain_left, gain_right] = get_stereo_gains(sine_table, x);
-
-            assert_float_eq!(
-                gain_left,
-                (x * PI / 2.).cos(),
-                abs <= 1e-3,
-                "gain_l panicked"
-            );
-            assert_float_eq!(
-                gain_right,
-                (x * PI / 2.).sin(),
-                abs <= 1e-3,
-                "gain_r panicked"
-            );
-        }
     }
 
     #[test]
@@ -499,7 +464,7 @@ mod tests {
                     *p = l * l + r * r;
                 });
 
-            assert_float_eq!(power, [1.; 128], abs_all <= 1e-7);
+            assert_float_eq!(power, [1.; 128], abs_all <= 1.2e-7);
         }
     }
 


### PR DESCRIPTION
This removes the table lookup that was both wrong and inaccurate enough

The WPT tests that are passing now:
- the-stereopanner-interface/no-dezippering.html
- the-stereopanner-interface/stereopannernode-panning.html

Which means the `StereoPannerNode` is fully compliant:

```
  RESULTS:
  - # pass: 121
  - # fail: 0
  - # type error issues: 0
```