### PR TITLE
Fix: force graph reordering when a node is added (without connections)

### DIFF
--- a/src/render/graph.rs
+++ b/src/render/graph.rs
@@ -197,6 +197,9 @@ impl Graph {
                 cycle_breaker: false,
             }),
         );
+
+        // void current ordering, some nodes should be processed even if not connected
+        self.ordered.clear();
     }
 
     pub fn add_edge(&mut self, source: (AudioNodeId, usize), dest: (AudioNodeId, usize)) {

--- a/src/render/graph.rs
+++ b/src/render/graph.rs
@@ -198,8 +198,9 @@ impl Graph {
             }),
         );
 
-        // void current ordering, some nodes should be processed even if not connected
-        self.ordered.clear();
+        // add to ordered list (some nodes should be processed even if not connected)
+        // if the node is connected later the ordered list will be recomputed
+        self.ordered.push(index);
     }
 
     pub fn add_edge(&mut self, source: (AudioNodeId, usize), dest: (AudioNodeId, usize)) {


### PR DESCRIPTION
This clears the ordered list when a node is added to the graph, then it is added to the ordered list even if it is not connected. This is somehow inline with the comment below:

```rs
// We cannot just start from the AudioDestinationNode and visit all nodes connecting to it,
// since the audio graph could contain legs detached from the destination and those should
// still be rendered.
```

This pattern happens quite often in the WPT, then this removes some of the timeouts that were occurring because some `process` method were never called (I had some hard time tracking down the problem :)

### Before

```
  RESULTS:
  - # pass: 5054
  - # fail: 413
  - # type error issues: 0
> wpt duration: 3:57.582 (m:ss.mmm)
```

### After

```
  RESULTS:
  - # pass: 5075
  - # fail: 407
  - # type error issues: 0
> wpt duration: 3:16.341 (m:ss.mmm)
```