### PR TITLE
Reduce oscillator sine table from 8192 to 2048 samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Decoders are enabled always - the legacy cargo features mp3/ogg/flac/wav/.. are now no-op
 - Added .aiff decoder support
 - Fix: mp3 decoding would sometimes insert leading silent frames
+- Improved sine oscillator performance
 
 ## Version 1.4.0 (2026-05-18)
 

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1,8 +1,5 @@
 //! The AudioNode interface and concrete types
 
-use std::f32::consts::PI;
-use std::sync::OnceLock;
-
 use crate::render::{
     AudioParamValues, AudioProcessor, AudioRenderQuantum, AudioWorkletGlobalScope,
 };
@@ -57,20 +54,6 @@ mod stereo_panner;
 pub use stereo_panner::*;
 mod waveshaper;
 pub use waveshaper::*;
-
-pub(crate) const TABLE_LENGTH_USIZE: usize = 8192;
-pub(crate) const TABLE_LENGTH_F32: f32 = TABLE_LENGTH_USIZE as f32;
-
-/// Precomputed sine table
-pub(crate) fn precomputed_sine_table() -> &'static [f32] {
-    static INSTANCE: OnceLock<Vec<f32>> = OnceLock::new();
-    INSTANCE.get_or_init(|| {
-        // Compute one period sine wavetable of size TABLE_LENGTH
-        (0..TABLE_LENGTH_USIZE)
-            .map(|x| ((x as f32) * 2.0 * PI * (1. / (TABLE_LENGTH_F32))).sin())
-            .collect()
-    })
-}
 
 // `MediaStreamRenderer` is internally used by `MediaElementAudioSourceNode` and
 // `MediaStreamAudioSourceNode`.

--- a/src/node/oscillator.rs
+++ b/src/node/oscillator.rs
@@ -1,5 +1,7 @@
 use std::any::Any;
+use std::f32::consts::PI;
 use std::fmt::Debug;
+use std::sync::OnceLock;
 
 use crate::context::{AudioContextRegistration, AudioParamId, BaseAudioContext};
 use crate::param::{AudioParam, AudioParamDescriptor, AutomationRate};
@@ -9,10 +11,21 @@ use crate::render::{
 use crate::PeriodicWave;
 use crate::{assert_valid_time_value, RENDER_QUANTUM_SIZE};
 
-use super::{
-    precomputed_sine_table, AudioNode, AudioNodeOptions, AudioScheduledSourceNode, ChannelConfig,
-    TABLE_LENGTH_USIZE,
-};
+use super::{AudioNode, AudioNodeOptions, AudioScheduledSourceNode, ChannelConfig};
+
+const SINE_TABLE_LENGTH_USIZE: usize = 2048;
+const SINE_TABLE_LENGTH_F32: f32 = SINE_TABLE_LENGTH_USIZE as f32;
+
+/// Precomputed sine table
+fn precomputed_sine_table() -> &'static [f32] {
+    static INSTANCE: OnceLock<Vec<f32>> = OnceLock::new();
+    INSTANCE.get_or_init(|| {
+        // Compute one period sine wavetable of size SINE_TABLE_LENGTH.
+        (0..SINE_TABLE_LENGTH_USIZE)
+            .map(|x| ((x as f32) * 2.0 * PI * (1. / (SINE_TABLE_LENGTH_F32))).sin())
+            .collect()
+    })
+}
 
 fn get_phase_incr(freq: f32, detune: f32, sample_rate: f64) -> f64 {
     let computed_freq = freq as f64 * (detune as f64 / 1200.).exp2();
@@ -522,12 +535,12 @@ impl OscillatorRenderer {
 
     #[inline]
     fn generate_sine(&mut self) -> f32 {
-        let position = self.phase * TABLE_LENGTH_USIZE as f64;
+        let position = self.phase * SINE_TABLE_LENGTH_USIZE as f64;
         let floored = position.floor();
 
         let prev_index = floored as usize;
         let mut next_index = prev_index + 1;
-        if next_index == TABLE_LENGTH_USIZE {
+        if next_index == SINE_TABLE_LENGTH_USIZE {
             next_index = 0;
         }
 
@@ -573,12 +586,13 @@ impl OscillatorRenderer {
     #[inline]
     fn generate_custom(&mut self) -> f32 {
         let periodic_wave = self.periodic_wave.as_ref().unwrap().as_slice();
-        let position = self.phase * TABLE_LENGTH_USIZE as f64;
+        let table_length = periodic_wave.len();
+        let position = self.phase * table_length as f64;
         let floored = position.floor();
 
         let prev_index = floored as usize;
         let mut next_index = prev_index + 1;
-        if next_index == TABLE_LENGTH_USIZE {
+        if next_index == table_length {
             next_index = 0;
         }
 

--- a/src/periodic_wave.rs
+++ b/src/periodic_wave.rs
@@ -5,8 +5,6 @@ use std::sync::Arc;
 
 use crate::context::BaseAudioContext;
 
-use crate::node::TABLE_LENGTH_USIZE;
-
 /// Options for constructing a [`PeriodicWave`]
 #[derive(Debug, Default, Clone)]
 pub struct PeriodicWaveOptions {
@@ -74,6 +72,8 @@ pub struct PeriodicWaveOptions {
 pub struct PeriodicWave {
     wavetable: Arc<Vec<f32>>,
 }
+
+const PERIODIC_WAVE_TABLE_LENGTH: usize = 8192;
 
 impl PeriodicWave {
     /// Returns a `PeriodicWave`
@@ -148,7 +148,8 @@ impl PeriodicWave {
 
         let normalize = !disable_normalization;
         // [spec] A conforming implementation MUST support PeriodicWave up to at least 8192 elements.
-        let wavetable = Self::generate_wavetable(&real, &imag, normalize, TABLE_LENGTH_USIZE);
+        let wavetable =
+            Self::generate_wavetable(&real, &imag, normalize, PERIODIC_WAVE_TABLE_LENGTH);
 
         Self {
             wavetable: Arc::new(wavetable),
@@ -213,10 +214,8 @@ mod tests {
     use float_eq::assert_float_eq;
     use std::f32::consts::PI;
 
+    use super::{PeriodicWave, PeriodicWaveOptions, PERIODIC_WAVE_TABLE_LENGTH};
     use crate::context::AudioContext;
-    use crate::node::{TABLE_LENGTH_F32, TABLE_LENGTH_USIZE};
-
-    use super::{PeriodicWave, PeriodicWaveOptions};
 
     #[test]
     #[should_panic]
@@ -279,11 +278,12 @@ mod tests {
         let reals = [0., 0.];
         let imags = [0., 1.];
 
-        let result = PeriodicWave::generate_wavetable(&reals, &imags, true, TABLE_LENGTH_USIZE);
+        let result =
+            PeriodicWave::generate_wavetable(&reals, &imags, true, PERIODIC_WAVE_TABLE_LENGTH);
         let mut expected = Vec::new();
 
-        for i in 0..TABLE_LENGTH_USIZE {
-            let sample = (i as f32 / TABLE_LENGTH_F32 * 2. * PI).sin();
+        for i in 0..PERIODIC_WAVE_TABLE_LENGTH {
+            let sample = (i as f32 / PERIODIC_WAVE_TABLE_LENGTH as f32 * 2. * PI).sin();
             expected.push(sample);
         }
 
@@ -295,15 +295,16 @@ mod tests {
         let reals = [0., 0., 0.];
         let imags = [0., 0.5, 0.5];
 
-        let result = PeriodicWave::generate_wavetable(&reals, &imags, false, TABLE_LENGTH_USIZE);
+        let result =
+            PeriodicWave::generate_wavetable(&reals, &imags, false, PERIODIC_WAVE_TABLE_LENGTH);
         let mut expected = Vec::new();
 
-        for i in 0..TABLE_LENGTH_USIZE {
+        for i in 0..PERIODIC_WAVE_TABLE_LENGTH {
             let mut sample = 0.;
             // fundamental frequency
-            sample += 0.5 * (1. * i as f32 / TABLE_LENGTH_F32 * 2. * PI).sin();
+            sample += 0.5 * (1. * i as f32 / PERIODIC_WAVE_TABLE_LENGTH as f32 * 2. * PI).sin();
             // 1rst partial
-            sample += 0.5 * (2. * i as f32 / TABLE_LENGTH_F32 * 2. * PI).sin();
+            sample += 0.5 * (2. * i as f32 / PERIODIC_WAVE_TABLE_LENGTH as f32 * 2. * PI).sin();
 
             expected.push(sample);
         }
@@ -335,15 +336,16 @@ mod tests {
         let reals = [0., 0., 0.];
         let imags = [0., 0.5, 0.5];
 
-        let result = PeriodicWave::generate_wavetable(&reals, &imags, true, TABLE_LENGTH_USIZE);
+        let result =
+            PeriodicWave::generate_wavetable(&reals, &imags, true, PERIODIC_WAVE_TABLE_LENGTH);
         let mut expected = Vec::new();
 
-        for i in 0..TABLE_LENGTH_USIZE {
+        for i in 0..PERIODIC_WAVE_TABLE_LENGTH {
             let mut sample = 0.;
             // fundamental frequency
-            sample += 0.5 * (1. * i as f32 / TABLE_LENGTH_F32 * 2. * PI).sin();
+            sample += 0.5 * (1. * i as f32 / PERIODIC_WAVE_TABLE_LENGTH as f32 * 2. * PI).sin();
             // 1rst partial
-            sample += 0.5 * (2. * i as f32 / TABLE_LENGTH_F32 * 2. * PI).sin();
+            sample += 0.5 * (2. * i as f32 / PERIODIC_WAVE_TABLE_LENGTH as f32 * 2. * PI).sin();
 
             expected.push(sample);
         }


### PR DESCRIPTION
Fixes #309

2048 samples and linear interpolation are good enough to reach WPT precision requirements. The smaller table size will reduce the cache pressure.

Keep the 8192-sample table length for PeriodicWave rendering (per the spec). Removed the consts and methods from src/node/mod.rs

Benchmarking showed that using the full 2 pi phase in the lookup table is fastest - so we do not use cleverness around the sine function symmetry