### PR TITLE
WIP - experimenting with  `device disconnect`

### DIFF
--- a/examples/sink_id.rs
+++ b/examples/sink_id.rs
@@ -57,10 +57,16 @@ fn main() {
     osc.start();
 
     loop {
-	println!();
-        loop {
-		println!("Current time is now {:<3}\r", context.current_time());
-                std::thread::sleep(std::time::Duration::from_millis(100));
+        let sink_id = ask_sink_id();
+        let result = context.set_sink_id_sync(sink_id);
+
+        if let Err(err) = result {
+            println!("Error setting sink id {}", err);
         }
+
+        println!("Playing beep for sink {:?}", context.sink_id());
+
+        // with this info we can ensure the progression of time with any backend
+        println!("Current time is now {:<3}", context.current_time());
     }
 }

--- a/examples/sink_id.rs
+++ b/examples/sink_id.rs
@@ -57,16 +57,10 @@ fn main() {
     osc.start();
 
     loop {
-        let sink_id = ask_sink_id();
-        let result = context.set_sink_id_sync(sink_id);
-
-        if let Err(err) = result {
-            println!("Error setting sink id {}", err);
+	println!();
+        loop {
+		println!("Current time is now {:<3}\r", context.current_time());
+                std::thread::sleep(std::time::Duration::from_millis(100));
         }
-
-        println!("Playing beep for sink {:?}", context.sink_id());
-
-        // with this info we can ensure the progression of time with any backend
-        println!("Current time is now {:<3}", context.current_time());
     }
 }

--- a/src/context/concrete_base.rs
+++ b/src/context/concrete_base.rs
@@ -13,7 +13,7 @@ use crate::spatial::AudioListenerParams;
 
 use crate::AudioListener;
 
-use crossbeam_channel::{SendError, Sender};
+use crossbeam_channel::Sender;
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use std::sync::{Arc, Mutex, RwLock, RwLockWriteGuard};
@@ -60,6 +60,9 @@ impl AudioNodeIdProvider {
 pub struct ConcreteBaseAudioContext {
     inner: Arc<ConcreteBaseAudioContextInner>,
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct EventSendError;
 
 impl PartialEq for ConcreteBaseAudioContext {
     fn eq(&self, other: &Self) -> bool {
@@ -319,8 +322,8 @@ impl ConcreteBaseAudioContext {
         }
     }
 
-    pub(crate) fn send_event(&self, msg: EventDispatch) -> Result<(), SendError<EventDispatch>> {
-        self.inner.event_send.send(msg)
+    pub(crate) fn send_event(&self, msg: EventDispatch) -> Result<(), EventSendError> {
+        self.inner.event_send.send(msg).map_err(|_| EventSendError)
     }
 
     pub(crate) fn lock_control_msg_sender(&self) -> RwLockWriteGuard<'_, Sender<ControlMessage>> {

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -135,7 +135,7 @@ pub struct AudioContext {
     /// represents the underlying `BaseAudioContext`
     base: ConcreteBaseAudioContext,
     /// audio backend (play/pause functionality)
-    backend_manager: Mutex<Box<dyn AudioBackendManager>>,
+    backend_manager: Arc<Mutex<Box<dyn AudioBackendManager>>>,
     /// Provider for rendering performance metrics
     render_capacity: AudioRenderCapacity,
     /// Provider for playback statistics
@@ -162,7 +162,7 @@ impl Drop for AudioContext {
         // Continue playing the stream if the AudioContext goes out of scope
         if self.state() == AudioContextState::Running {
             let tombstone = Box::new(NoneBackend::void());
-            let original = std::mem::replace(self.backend_manager.get_mut().unwrap(), tombstone);
+            let original = std::mem::replace(&mut *self.backend_manager.lock().unwrap(), tombstone);
             Box::leak(original);
         }
     }
@@ -304,7 +304,7 @@ impl AudioContext {
 
         Ok(Self {
             base,
-            backend_manager: Mutex::new(backend),
+            backend_manager: Arc::new(Mutex::new(backend)),
             render_capacity,
             playback_stats,
             startup_pending,

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -33,6 +33,41 @@ fn is_valid_sink_id(sink_id: &str) -> bool {
     }
 }
 
+fn spawn_default_output_watcher(
+    base: ConcreteBaseAudioContext,
+    backend_manager: Arc<Mutex<Box<dyn AudioBackendManager>>>,
+) {
+    std::thread::spawn(move || loop {
+        std::thread::sleep(std::time::Duration::from_millis(500));
+
+        match base.state() {
+            AudioContextState::Closed => return,
+            AudioContextState::Running => {}
+            AudioContextState::Suspended => continue,
+        }
+
+        let backend = backend_manager.lock().unwrap();
+        if !backend.sink_id().is_empty() {
+            continue;
+        }
+
+        match backend.default_output_changed() {
+            Ok(true) => {
+                log::info!("Closing backend after default output device changed");
+                if let Err(error) = backend.close() {
+                    log::error!(
+                        "Unable to close backend after default output device changed: {error}"
+                    );
+                }
+            }
+            Ok(false) => {}
+            Err(error) => {
+                log::warn!("Unable to check default output device: {error}");
+            }
+        }
+    });
+}
+
 #[derive(Debug)]
 enum AudioContextError {
     SinkNotFound { sink_id: String },
@@ -248,6 +283,7 @@ impl AudioContext {
         // Set up the audio output thread
         let (control_thread_init, render_thread_init) = io::thread_init();
         let startup_pending = Arc::clone(&render_thread_init.startup_pending);
+        let watch_default_output = options.sink_id.is_empty();
         let backend = io::build_output(options, render_thread_init.clone())?;
 
         let ControlThreadInit {
@@ -356,6 +392,10 @@ impl AudioContext {
                 }
             })),
         );
+
+        if watch_default_output {
+            spawn_default_output_watcher(base.clone(), Arc::clone(&backend_manager));
+        }
 
         // As the final step, spawn a thread for the event loop. If we do this earlier we may miss
         // event handling of the initial events that are emitted right after render thread

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -282,7 +282,10 @@ impl AudioContext {
         let render_capacity = AudioRenderCapacity::new(base.clone(), stats.clone());
         let playback_stats = AudioPlaybackStats::new(base.clone(), stats);
 
+        let backend_manager = Arc::new(Mutex::new(backend));
         let recovery_base = base.clone();
+        let recovery_backend_manager = Arc::clone(&backend_manager);
+        let recovery_render_thread_init = render_thread_init.clone();
         base.set_event_handler(
             EventType::InternalGraphRecovery,
             EventHandler::Multiple(Box::new(move |payload| {
@@ -294,6 +297,23 @@ impl AudioContext {
                     return;
                 }
                 log::info!("Recovered audio graph from dropped render thread: {graph:?}");
+
+                let options = AudioContextOptions {
+                    sample_rate: Some(recovery_base.sample_rate()),
+                    sink_id: String::new(),
+                    ..AudioContextOptions::default()
+                };
+
+                match io::build_output(options, recovery_render_thread_init.clone()) {
+                    Ok(backend) => {
+                        *recovery_backend_manager.lock().unwrap() = backend;
+                        recovery_base.send_control_msg(ControlMessage::Startup { graph });
+                        log::info!("Rebooted audio graph on default output device");
+                    }
+                    Err(error) => {
+                        log::error!("Unable to reboot audio graph on default output device: {error}");
+                    }
+                }
             })),
         );
 
@@ -304,7 +324,7 @@ impl AudioContext {
 
         Ok(Self {
             base,
-            backend_manager: Arc::new(Mutex::new(backend)),
+            backend_manager,
             render_capacity,
             playback_stats,
             startup_pending,

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -286,6 +286,24 @@ impl AudioContext {
         let recovery_base = base.clone();
         let recovery_backend_manager = Arc::clone(&backend_manager);
         let recovery_render_thread_init = render_thread_init.clone();
+        let error_base = base.clone();
+        let error_backend_manager = Arc::clone(&backend_manager);
+        base.set_event_handler(
+            EventType::InternalBackendStreamError,
+            EventHandler::Multiple(Box::new(move |payload| {
+                let EventPayload::InternalBackendStreamError = payload else {
+                    unreachable!();
+                };
+                if error_base.state() == AudioContextState::Closed {
+                    log::info!("Ignoring backend stream error from closed context");
+                    return;
+                }
+                log::info!("Closing backend after runtime stream error");
+                if let Err(error) = error_backend_manager.lock().unwrap().close() {
+                    log::error!("Unable to close backend after runtime stream error: {error}");
+                }
+            })),
+        );
         base.set_event_handler(
             EventType::InternalGraphRecovery,
             EventHandler::Multiple(Box::new(move |payload| {

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -5,7 +5,10 @@ use std::sync::{Arc, Mutex};
 
 use crate::context::{AudioContextState, BaseAudioContext, ConcreteBaseAudioContext};
 use crate::events::{EventDispatch, EventHandler, EventLoop, EventPayload, EventType};
-use crate::io::{self, AudioBackendManager, ControlThreadInit, NoneBackend, RenderThreadInit};
+use crate::io::{
+    self, AudioBackendManager, AudioBackendStreamEvent, ControlThreadInit, NoneBackend,
+    RenderThreadInit,
+};
 use crate::media_devices::{enumerate_devices_sync, MediaDeviceInfoKind};
 use crate::media_streams::{MediaStream, MediaStreamTrack};
 use crate::message::{ControlMessage, OneshotNotify};
@@ -289,18 +292,33 @@ impl AudioContext {
         let error_base = base.clone();
         let error_backend_manager = Arc::clone(&backend_manager);
         base.set_event_handler(
-            EventType::InternalBackendStreamError,
+            EventType::InternalBackendStreamEvent,
             EventHandler::Multiple(Box::new(move |payload| {
-                let EventPayload::InternalBackendStreamError = payload else {
+                let EventPayload::InternalBackendStreamEvent(error) = payload else {
                     unreachable!();
                 };
                 if error_base.state() == AudioContextState::Closed {
-                    log::info!("Ignoring backend stream error from closed context");
+                    log::info!("Ignoring backend stream event from closed context");
                     return;
                 }
-                log::info!("Closing backend after runtime stream error");
+
+                match error {
+                    AudioBackendStreamEvent::DeviceNotAvailable
+                    | AudioBackendStreamEvent::StreamInvalidated => {
+                        log::info!("Closing backend after recoverable runtime stream event: {error:?}");
+                    }
+                    AudioBackendStreamEvent::BufferUnderrun => {
+                        log::debug!("Ignoring backend stream buffer underrun event");
+                        return;
+                    }
+                    AudioBackendStreamEvent::BackendSpecific { message } => {
+                        log::warn!("Ignoring backend-specific stream event: {message}");
+                        return;
+                    }
+                }
+
                 if let Err(error) = error_backend_manager.lock().unwrap().close() {
-                    log::error!("Unable to close backend after runtime stream error: {error}");
+                    log::error!("Unable to close backend after runtime stream event: {error}");
                 }
             })),
         );

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -282,6 +282,21 @@ impl AudioContext {
         let render_capacity = AudioRenderCapacity::new(base.clone(), stats.clone());
         let playback_stats = AudioPlaybackStats::new(base.clone(), stats);
 
+        let recovery_base = base.clone();
+        base.set_event_handler(
+            EventType::InternalGraphRecovery,
+            EventHandler::Multiple(Box::new(move |payload| {
+                let EventPayload::InternalGraphRecovery(graph) = payload else {
+                    unreachable!();
+                };
+                if recovery_base.state() == AudioContextState::Closed {
+                    log::info!("Ignoring recovered audio graph from closed context");
+                    return;
+                }
+                log::info!("Recovered audio graph from dropped render thread: {graph:?}");
+            })),
+        );
+
         // As the final step, spawn a thread for the event loop. If we do this earlier we may miss
         // event handling of the initial events that are emitted right after render thread
         // construction.

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -305,7 +305,9 @@ impl AudioContext {
                 match error {
                     AudioBackendStreamEvent::DeviceNotAvailable
                     | AudioBackendStreamEvent::StreamInvalidated => {
-                        log::info!("Closing backend after recoverable runtime stream event: {error:?}");
+                        log::info!(
+                            "Closing backend after recoverable runtime stream event: {error:?}"
+                        );
                     }
                     AudioBackendStreamEvent::BufferUnderrun => {
                         log::debug!("Ignoring backend stream buffer underrun event");
@@ -347,7 +349,9 @@ impl AudioContext {
                         log::info!("Rebooted audio graph on default output device");
                     }
                     Err(error) => {
-                        log::error!("Unable to reboot audio graph on default output device: {error}");
+                        log::error!(
+                            "Unable to reboot audio graph on default output device: {error}"
+                        );
                     }
                 }
             })),

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,5 +1,6 @@
 use crate::context::ConcreteBaseAudioContext;
 use crate::context::{AudioContextState, AudioNodeId};
+use crate::io::AudioBackendStreamEvent;
 use crate::render::graph::Graph;
 use crate::{AudioBuffer, AudioRenderCapacityEvent};
 
@@ -30,7 +31,7 @@ pub(crate) enum EventType {
     Complete,
     AudioProcessing(AudioNodeId),
     InternalGraphRecovery,
-    InternalBackendStreamError,
+    InternalBackendStreamEvent,
 }
 
 /// The Error Event interface
@@ -92,7 +93,7 @@ pub(crate) enum EventPayload {
     Complete(AudioBuffer),
     AudioProcessing(AudioProcessingEvent),
     InternalGraphRecovery(Graph),
-    InternalBackendStreamError,
+    InternalBackendStreamEvent(AudioBackendStreamEvent),
 }
 
 #[derive(Debug)]
@@ -172,10 +173,10 @@ impl EventDispatch {
         }
     }
 
-    pub(crate) fn internal_backend_stream_error() -> Self {
+    pub(crate) fn internal_backend_stream_event(error: AudioBackendStreamEvent) -> Self {
         EventDispatch {
-            type_: EventType::InternalBackendStreamError,
-            payload: EventPayload::InternalBackendStreamError,
+            type_: EventType::InternalBackendStreamEvent,
+            payload: EventPayload::InternalBackendStreamEvent(error),
         }
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -30,6 +30,7 @@ pub(crate) enum EventType {
     Complete,
     AudioProcessing(AudioNodeId),
     InternalGraphRecovery,
+    InternalBackendStreamError,
 }
 
 /// The Error Event interface
@@ -91,6 +92,7 @@ pub(crate) enum EventPayload {
     Complete(AudioBuffer),
     AudioProcessing(AudioProcessingEvent),
     InternalGraphRecovery(Graph),
+    InternalBackendStreamError,
 }
 
 #[derive(Debug)]
@@ -167,6 +169,13 @@ impl EventDispatch {
         EventDispatch {
             type_: EventType::InternalGraphRecovery,
             payload: EventPayload::InternalGraphRecovery(graph),
+        }
+    }
+
+    pub(crate) fn internal_backend_stream_error() -> Self {
+        EventDispatch {
+            type_: EventType::InternalBackendStreamError,
+            payload: EventPayload::InternalBackendStreamError,
         }
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,5 +1,6 @@
 use crate::context::ConcreteBaseAudioContext;
 use crate::context::{AudioContextState, AudioNodeId};
+use crate::render::graph::Graph;
 use crate::{AudioBuffer, AudioRenderCapacityEvent};
 
 use std::any::Any;
@@ -28,6 +29,7 @@ pub(crate) enum EventType {
     Message(AudioNodeId),
     Complete,
     AudioProcessing(AudioNodeId),
+    InternalGraphRecovery,
 }
 
 /// The Error Event interface
@@ -88,6 +90,7 @@ pub(crate) enum EventPayload {
     AudioContextState(AudioContextState),
     Complete(AudioBuffer),
     AudioProcessing(AudioProcessingEvent),
+    InternalGraphRecovery(Graph),
 }
 
 #[derive(Debug)]
@@ -157,6 +160,13 @@ impl EventDispatch {
         EventDispatch {
             type_: EventType::AudioProcessing(id),
             payload: EventPayload::AudioProcessing(value),
+        }
+    }
+
+    pub(crate) fn internal_graph_recovery(graph: Graph) -> Self {
+        EventDispatch {
+            type_: EventType::InternalGraphRecovery,
+            payload: EventPayload::InternalGraphRecovery(graph),
         }
     }
 }

--- a/src/io/cpal.rs
+++ b/src/io/cpal.rs
@@ -12,7 +12,8 @@ use cpal::{
 use crossbeam_channel::Receiver;
 
 use super::{
-    AudioBackendError, AudioBackendErrorKind, AudioBackendManager, BackendResult, RenderThreadInit,
+    AudioBackendError, AudioBackendErrorKind, AudioBackendManager, AudioBackendStreamEvent,
+    BackendResult, RenderThreadInit,
 };
 
 use crate::buffer::AudioBuffer;
@@ -107,6 +108,17 @@ fn map_cpal_pause_error(operation: &'static str, err: PauseStreamError) -> Audio
         PauseStreamError::BackendSpecific { .. } => AudioBackendErrorKind::BackendSpecific,
     };
     map_cpal_backend_error(kind, operation, err)
+}
+
+fn map_cpal_stream_event(err: cpal::StreamError) -> AudioBackendStreamEvent {
+    match err {
+        cpal::StreamError::DeviceNotAvailable => AudioBackendStreamEvent::DeviceNotAvailable,
+        cpal::StreamError::StreamInvalidated => AudioBackendStreamEvent::StreamInvalidated,
+        cpal::StreamError::BufferUnderrun => AudioBackendStreamEvent::BufferUnderrun,
+        cpal::StreamError::BackendSpecific { err } => AudioBackendStreamEvent::BackendSpecific {
+            message: err.to_string(),
+        },
+    }
 }
 
 fn map_cpal_devices_error(operation: &'static str, err: DevicesError) -> AudioBackendError {
@@ -665,11 +677,12 @@ fn spawn_output_stream(
 ) -> Result<Stream, BuildStreamError> {
     let err_fn = move |err| {
         log::error!("an error occurred on the output audio stream: {}", err);
+        let err = map_cpal_stream_event(err);
         if event_send
-            .try_send(EventDispatch::internal_backend_stream_error())
+            .try_send(EventDispatch::internal_backend_stream_event(err))
             .is_err()
         {
-            log::warn!("Unable to queue backend stream error event");
+            log::warn!("Unable to queue backend stream event");
         }
     };
 

--- a/src/io/cpal.rs
+++ b/src/io/cpal.rs
@@ -169,6 +169,10 @@ fn cpal_device_channels(device: &Device, kind: MediaDeviceInfoKind) -> Option<u1
     })
 }
 
+fn cpal_device_id(device: &Device) -> Option<String> {
+    device.id().ok().map(|id| id.to_string())
+}
+
 fn cpal_stable_device_id(
     device: &Device,
     kind: MediaDeviceInfoKind,
@@ -217,6 +221,8 @@ pub(crate) struct CpalBackend {
     sample_rate: f32,
     number_of_channels: usize,
     sink_id: String,
+    device_id: Option<String>,
+    default_output_sample_rate: Option<u32>,
 }
 
 impl AudioBackendManager for CpalBackend {
@@ -273,6 +279,7 @@ impl AudioBackendManager for CpalBackend {
         let default_device_config = device
             .default_output_config()
             .map_err(|e| map_cpal_default_config_error("default_output_config", e))?;
+        let default_output_sample_rate = default_device_config.sample_rate();
 
         // we grab the largest number of channels provided by the soundcard
         // clamped to MAX_CHANNELS, this value cannot be changed by the user
@@ -404,6 +411,8 @@ impl AudioBackendManager for CpalBackend {
             sample_rate,
             number_of_channels,
             sink_id: options.sink_id,
+            device_id: cpal_device_id(&device),
+            default_output_sample_rate: Some(default_output_sample_rate),
         })
     }
 
@@ -538,6 +547,8 @@ impl AudioBackendManager for CpalBackend {
             sample_rate,
             number_of_channels,
             sink_id: options.sink_id,
+            device_id: cpal_device_id(&device),
+            default_output_sample_rate: None,
         };
 
         Ok((backend, receiver))
@@ -584,6 +595,34 @@ impl AudioBackendManager for CpalBackend {
 
     fn sink_id(&self) -> &str {
         self.sink_id.as_str()
+    }
+
+    fn default_output_changed(&self) -> BackendResult<bool> {
+        if !self.sink_id.is_empty() || self.stream.lock().unwrap().is_none() {
+            return Ok(false);
+        }
+
+        let Some(device_id) = self.device_id.as_ref() else {
+            return Ok(false);
+        };
+
+        let host = get_host()?;
+        let Some(default_device) = host.default_output_device() else {
+            return Ok(false);
+        };
+        let Some(default_device_id) = cpal_device_id(&default_device) else {
+            return Ok(false);
+        };
+
+        let default_sample_rate = default_device
+            .default_output_config()
+            .map_err(|e| map_cpal_default_config_error("default_output_config", e))?
+            .sample_rate();
+
+        Ok(default_device_id != *device_id
+            || self
+                .default_output_sample_rate
+                .is_some_and(|sample_rate| sample_rate != default_sample_rate))
     }
 
     fn enumerate_devices_sync() -> BackendResult<Vec<MediaDeviceInfo>>

--- a/src/io/cpal.rs
+++ b/src/io/cpal.rs
@@ -18,6 +18,7 @@ use super::{
 use crate::buffer::AudioBuffer;
 use crate::context::AudioContextLatencyCategory;
 use crate::context::AudioContextOptions;
+use crate::events::EventDispatch;
 use crate::io::microphone::MicrophoneRender;
 use crate::media_devices::{MediaDeviceInfo, MediaDeviceInfoKind};
 use crate::render::RenderThread;
@@ -332,6 +333,7 @@ impl AudioBackendManager for CpalBackend {
             renderer,
             Arc::clone(&output_latency),
             stats.clone(),
+            event_send.clone(),
         );
 
         let stream = match spawned {
@@ -360,7 +362,7 @@ impl AudioBackendManager for CpalBackend {
                     state,
                     frames_played,
                     stats.clone(),
-                    event_send,
+                    event_send.clone(),
                 );
                 renderer.set_startup_pending(startup_pending);
                 renderer.spawn_garbage_collector_thread();
@@ -372,6 +374,7 @@ impl AudioBackendManager for CpalBackend {
                     renderer,
                     Arc::clone(&output_latency),
                     stats.clone(),
+                    event_send,
                 );
 
                 spawned.map_err(|e| map_cpal_build_error("build_fallback_output_stream", e))?
@@ -658,8 +661,17 @@ fn spawn_output_stream(
     mut render: RenderThread,
     output_latency: Arc<AtomicF64>,
     stats: AudioStats,
+    event_send: crossbeam_channel::Sender<EventDispatch>,
 ) -> Result<Stream, BuildStreamError> {
-    let err_fn = |err| log::error!("an error occurred on the output audio stream: {}", err);
+    let err_fn = move |err| {
+        log::error!("an error occurred on the output audio stream: {}", err);
+        if event_send
+            .try_send(EventDispatch::internal_backend_stream_error())
+            .is_err()
+        {
+            log::warn!("Unable to queue backend stream error event");
+        }
+    };
 
     match sample_format {
         SampleFormat::F32 => device.build_output_stream(

--- a/src/io/cubeb.rs
+++ b/src/io/cubeb.rs
@@ -1,11 +1,13 @@
 use std::thread;
 
 use super::{
-    AudioBackendError, AudioBackendErrorKind, AudioBackendManager, BackendResult, RenderThreadInit,
+    AudioBackendError, AudioBackendErrorKind, AudioBackendManager, AudioBackendStreamEvent,
+    BackendResult, RenderThreadInit,
 };
 
 use crate::buffer::AudioBuffer;
 use crate::context::AudioContextOptions;
+use crate::events::EventDispatch;
 use crate::io::microphone::MicrophoneRender;
 use crate::media_devices::{MediaDeviceInfo, MediaDeviceInfoKind};
 use crate::render::RenderThread;
@@ -226,6 +228,15 @@ fn cubeb_backend_error(operation: &'static str, message: impl Into<String>) -> A
     )
 }
 
+fn queue_cubeb_stream_event(event_send: &Sender<EventDispatch>, event: AudioBackendStreamEvent) {
+    if event_send
+        .try_send(EventDispatch::internal_backend_stream_event(event))
+        .is_err()
+    {
+        log::warn!("Unable to queue backend stream event");
+    }
+}
+
 fn cubeb_device_for_id(
     context: &Context,
     device_type: DeviceType,
@@ -254,6 +265,7 @@ fn init_output_backend<const N: usize>(
     buffer_size: u32,
     device: Option<DeviceId>,
     mut renderer: RenderThread,
+    event_send: Sender<EventDispatch>,
 ) -> BackendResult<BoxedStream> {
     let mut builder = cubeb::StreamBuilder::<[f32; N]>::new();
 
@@ -278,8 +290,16 @@ fn init_output_backend<const N: usize>(
 
             output.len() as isize
         })
-        .state_callback(|state| {
-            log::debug!("stream state changed: {state:?}");
+        .state_callback(move |state| {
+            log::debug!("output stream state changed: {state:?}");
+
+            if state == cubeb::State::Error {
+                log::error!("cubeb output stream entered error state");
+                queue_cubeb_stream_event(
+                    &event_send,
+                    AudioBackendStreamEvent::StreamInvalidated,
+                );
+            }
         });
 
     let stream = builder
@@ -340,6 +360,7 @@ impl AudioBackendManager for CubebBackend {
                 _ => cubeb::ChannelLayout::UNDEFINED, // TODO, does this work?
             };
 
+            let stream_event_send = event_send.clone();
             let mut renderer = RenderThread::new(
                 sample_rate,
                 number_of_channels,
@@ -379,40 +400,53 @@ impl AudioBackendManager for CubebBackend {
                 )?
             };
 
+            macro_rules! init_output {
+                ($channels:literal) => {
+                    init_output_backend::<$channels>(
+                        &ctx,
+                        params,
+                        buffer_size,
+                        device,
+                        renderer,
+                        stream_event_send,
+                    )
+                };
+            }
+
             let stream = match number_of_channels {
                 // so sorry, but I need to constify the non-const `number_of_channels`
-                1 => init_output_backend::<1>(&ctx, params, buffer_size, device, renderer),
-                2 => init_output_backend::<2>(&ctx, params, buffer_size, device, renderer),
-                3 => init_output_backend::<3>(&ctx, params, buffer_size, device, renderer),
-                4 => init_output_backend::<4>(&ctx, params, buffer_size, device, renderer),
-                5 => init_output_backend::<5>(&ctx, params, buffer_size, device, renderer),
-                6 => init_output_backend::<6>(&ctx, params, buffer_size, device, renderer),
-                7 => init_output_backend::<7>(&ctx, params, buffer_size, device, renderer),
-                8 => init_output_backend::<8>(&ctx, params, buffer_size, device, renderer),
-                9 => init_output_backend::<9>(&ctx, params, buffer_size, device, renderer),
-                10 => init_output_backend::<10>(&ctx, params, buffer_size, device, renderer),
-                11 => init_output_backend::<11>(&ctx, params, buffer_size, device, renderer),
-                12 => init_output_backend::<12>(&ctx, params, buffer_size, device, renderer),
-                13 => init_output_backend::<13>(&ctx, params, buffer_size, device, renderer),
-                14 => init_output_backend::<14>(&ctx, params, buffer_size, device, renderer),
-                15 => init_output_backend::<15>(&ctx, params, buffer_size, device, renderer),
-                16 => init_output_backend::<16>(&ctx, params, buffer_size, device, renderer),
-                17 => init_output_backend::<17>(&ctx, params, buffer_size, device, renderer),
-                18 => init_output_backend::<18>(&ctx, params, buffer_size, device, renderer),
-                19 => init_output_backend::<19>(&ctx, params, buffer_size, device, renderer),
-                20 => init_output_backend::<20>(&ctx, params, buffer_size, device, renderer),
-                21 => init_output_backend::<21>(&ctx, params, buffer_size, device, renderer),
-                22 => init_output_backend::<22>(&ctx, params, buffer_size, device, renderer),
-                23 => init_output_backend::<23>(&ctx, params, buffer_size, device, renderer),
-                24 => init_output_backend::<24>(&ctx, params, buffer_size, device, renderer),
-                25 => init_output_backend::<25>(&ctx, params, buffer_size, device, renderer),
-                26 => init_output_backend::<26>(&ctx, params, buffer_size, device, renderer),
-                27 => init_output_backend::<27>(&ctx, params, buffer_size, device, renderer),
-                28 => init_output_backend::<28>(&ctx, params, buffer_size, device, renderer),
-                29 => init_output_backend::<29>(&ctx, params, buffer_size, device, renderer),
-                30 => init_output_backend::<30>(&ctx, params, buffer_size, device, renderer),
-                31 => init_output_backend::<31>(&ctx, params, buffer_size, device, renderer),
-                32 => init_output_backend::<32>(&ctx, params, buffer_size, device, renderer),
+                1 => init_output!(1),
+                2 => init_output!(2),
+                3 => init_output!(3),
+                4 => init_output!(4),
+                5 => init_output!(5),
+                6 => init_output!(6),
+                7 => init_output!(7),
+                8 => init_output!(8),
+                9 => init_output!(9),
+                10 => init_output!(10),
+                11 => init_output!(11),
+                12 => init_output!(12),
+                13 => init_output!(13),
+                14 => init_output!(14),
+                15 => init_output!(15),
+                16 => init_output!(16),
+                17 => init_output!(17),
+                18 => init_output!(18),
+                19 => init_output!(19),
+                20 => init_output!(20),
+                21 => init_output!(21),
+                22 => init_output!(22),
+                23 => init_output!(23),
+                24 => init_output!(24),
+                25 => init_output!(25),
+                26 => init_output!(26),
+                27 => init_output!(27),
+                28 => init_output!(28),
+                29 => init_output!(29),
+                30 => init_output!(30),
+                31 => init_output!(31),
+                32 => init_output!(32),
                 _ => Err(cubeb_backend_error(
                     "init_output_stream",
                     "Unexpected channel count",

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -258,6 +258,12 @@ pub(crate) trait AudioBackendManager: Send + Sync + 'static {
     /// The audio output device - `""` means the default device
     fn sink_id(&self) -> &str;
 
+    /// Whether the current system default output no longer matches this stream.
+    #[allow(dead_code)]
+    fn default_output_changed(&self) -> BackendResult<bool> {
+        Ok(false)
+    }
+
     fn enumerate_devices_sync() -> BackendResult<Vec<MediaDeviceInfo>>
     where
         Self: Sized;

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -47,6 +47,14 @@ pub(crate) struct AudioBackendError {
 
 pub(crate) type BackendResult<T> = Result<T, AudioBackendError>;
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum AudioBackendStreamEvent {
+    DeviceNotAvailable,
+    StreamInvalidated,
+    BufferUnderrun,
+    BackendSpecific { message: String },
+}
+
 impl AudioBackendError {
     pub(crate) fn new(
         kind: AudioBackendErrorKind,

--- a/src/render/thread.rs
+++ b/src/render/thread.rs
@@ -526,6 +526,7 @@ impl RenderThread {
 impl Drop for RenderThread {
     fn drop(&mut self) {
         if let Some(graph) = self.graph.take() {
+	    log::info!("Recover graph");
             if self
                 .event_sender
                 .try_send(EventDispatch::internal_graph_recovery(graph))

--- a/src/render/thread.rs
+++ b/src/render/thread.rs
@@ -525,6 +525,16 @@ impl RenderThread {
 
 impl Drop for RenderThread {
     fn drop(&mut self) {
+        if let Some(graph) = self.graph.take() {
+            if self
+                .event_sender
+                .try_send(EventDispatch::internal_graph_recovery(graph))
+                .is_err()
+            {
+                log::warn!("Unable to queue graph recovery event");
+            }
+        }
+
         if let Some(gc) = self.garbage_collector.as_mut() {
             gc.push(llq::Node::new(Box::new(TerminateGarbageCollectorThread)))
         }

--- a/src/render/thread.rs
+++ b/src/render/thread.rs
@@ -526,7 +526,7 @@ impl RenderThread {
 impl Drop for RenderThread {
     fn drop(&mut self) {
         if let Some(graph) = self.graph.take() {
-	    log::info!("Recover graph");
+            log::info!("Recover graph");
             if self
                 .event_sender
                 .try_send(EventDispatch::internal_graph_recovery(graph))

--- a/src/render/thread.rs
+++ b/src/render/thread.rs
@@ -39,6 +39,7 @@ pub(crate) struct RenderThread {
     startup_pending: Option<Arc<AtomicBool>>,
     frames_played: Arc<AtomicU64>,
     receiver: Option<Receiver<ControlMessage>>,
+    pending_startup_messages: Vec<ControlMessage>,
     buffer_offset: Option<(usize, AudioRenderQuantum)>,
     stats: AudioStats,
     event_sender: Sender<EventDispatch>,
@@ -87,6 +88,7 @@ impl RenderThread {
             startup_pending: None,
             frames_played,
             receiver: Some(receiver),
+            pending_startup_messages: Vec::new(),
             buffer_offset: None,
             stats,
             event_sender,
@@ -122,6 +124,12 @@ impl RenderThread {
 
     fn handle_control_message(&mut self, msg: ControlMessage) -> ControlFlow<()> {
         use ControlMessage::*;
+
+        if self.graph.is_none() && !matches!(msg, Startup { .. }) {
+            // TODO: not realtime safe
+            self.pending_startup_messages.push(msg);
+            return ControlFlow::Continue(());
+        }
 
         match msg {
             RegisterNode {
@@ -182,6 +190,12 @@ impl RenderThread {
                     startup_pending.store(false, Ordering::Release);
                 }
                 self.set_state(AudioContextState::Running);
+                let pending_startup_messages = std::mem::take(&mut self.pending_startup_messages);
+                for msg in pending_startup_messages {
+                    if self.handle_control_message(msg).is_break() {
+                        return ControlFlow::Break(());
+                    }
+                }
             }
             NodeMessage { id, mut msg } => {
                 self.graph.as_mut().unwrap().route_message(id, msg.as_mut());


### PR DESCRIPTION
Create a loopback virtual device
Run `RUST_LOG=debug cargo run --example sink_id`
Choose virtual device
While running, remove the device in loopback
Observe output


Bluetooth disconnect does not trigger cpal err_fn
Changing output device from OSX settings does not trigger either

Perhaps interesting read
https://github.com/RustAudio/cpal/issues/373


Needs more polishing!