### PR TITLE
Fix `ConvolverNode` active processing

### DIFF
--- a/src/node/convolver.rs
+++ b/src/node/convolver.rs
@@ -354,15 +354,15 @@ impl AudioProcessor for ConvolverRenderer {
 
         // handle tail time and active processing, return early if input is silent
         // and we reached the end of the convolution
-        let is_silent_input = input.is_silent();
-
-        if is_silent_input {
+        if input.is_silent() {
             if self.tail_count > self.impulse_length {
                 output.make_silent();
                 return false;
             }
 
             self.tail_count += RENDER_QUANTUM_SIZE;
+        } else {
+            self.tail_count = 0;
         }
 
         let convolvers = match &mut self.convolvers {
@@ -485,10 +485,6 @@ impl AudioProcessor for ConvolverRenderer {
                 output.set_number_of_channels(2);
             }
             _ => unreachable!(),
-        }
-
-        if !is_silent_input {
-            self.tail_count = 0;
         }
 
         true

--- a/src/node/convolver.rs
+++ b/src/node/convolver.rs
@@ -352,8 +352,8 @@ impl AudioProcessor for ConvolverRenderer {
         let input = &inputs[0];
         let output = &mut outputs[0];
 
-        // handle tail time and active processing, return early if input is silent
-        // and we reached the end of the convolution
+        // handle tail time and active processing
+        // return early if input is silent and we reached the end of the convolution
         if input.is_silent() {
             if self.tail_count > self.impulse_length {
                 output.make_silent();
@@ -375,7 +375,6 @@ impl AudioProcessor for ConvolverRenderer {
         };
 
         // https://webaudio.github.io/web-audio-api/#Convolution-channel-configurations
-        // @todo - handle tailtime per channel if input number of channel changes
         match (input.number_of_channels(), self.impulse_number_of_channels) {
             (1, 1) => {
                 output.set_number_of_channels(1);

--- a/src/node/convolver.rs
+++ b/src/node/convolver.rs
@@ -355,7 +355,7 @@ impl AudioProcessor for ConvolverRenderer {
         // handle tail time and active processing
         // return early if input is silent and we reached the end of the convolution
         if input.is_silent() {
-            if self.tail_count > self.impulse_length {
+            if self.tail_count >= self.impulse_length {
                 output.make_silent();
                 return false;
             }

--- a/src/node/convolver.rs
+++ b/src/node/convolver.rs
@@ -351,7 +351,19 @@ impl AudioProcessor for ConvolverRenderer {
         // single input/output node
         let input = &inputs[0];
         let output = &mut outputs[0];
-        output.force_mono();
+
+        // handle tail time and active processing, return early if input is silent
+        // and we reached the end of the convolution
+        let is_silent_input = input.is_silent();
+
+        if is_silent_input {
+            if self.tail_count > self.impulse_length {
+                output.make_silent();
+                return false;
+            }
+
+            self.tail_count += RENDER_QUANTUM_SIZE;
+        }
 
         let convolvers = match &mut self.convolvers {
             None => {
@@ -475,13 +487,9 @@ impl AudioProcessor for ConvolverRenderer {
             _ => unreachable!(),
         }
 
-        // handle tail time
-        if input.is_silent() {
-            self.tail_count += RENDER_QUANTUM_SIZE;
-            return self.tail_count < self.impulse_length;
+        if !is_silent_input {
+            self.tail_count = 0;
         }
-
-        self.tail_count = 0;
 
         true
     }


### PR DESCRIPTION
Just like the title indicates :) 

Mark the node as not actively processsing (i.e. `output.make_silent()`) if input is silent and we reached the end of the convolution.

Fix `wpt/webaudio/the-audio-api/the-convolvernode-interface/active-processing.https.html` (visible only given #600, as wpt relies on this to test active processing)