### PR TITLE
Fix - IIRFilterNode with feedback and feedforward coefs of different lengths

### DIFF
--- a/src/node/iir_filter.rs
+++ b/src/node/iir_filter.rs
@@ -386,7 +386,11 @@ impl AudioProcessor for IirFilterRenderer {
                 let input = f64::from(i);
                 let b0 = self.norm_coeffs[0].0;
                 let last_state = channel_state[0];
-                let mut output = b0.mul_add(input, last_state);
+                let mut output = b0.mul_add(input, last_state);// do not propagate denormals into graph and state
+
+                if !output.is_normal() {
+                    output = 0.;
+                }
 
                 // update states for next call
                 for (i, (b, a)) in self.norm_coeffs.iter().skip(1).enumerate() {

--- a/src/node/iir_filter.rs
+++ b/src/node/iir_filter.rs
@@ -386,8 +386,8 @@ impl AudioProcessor for IirFilterRenderer {
                 let input = f64::from(i);
                 let b0 = self.norm_coeffs[0].0;
                 let last_state = channel_state[0];
-                let mut output = b0.mul_add(input, last_state);// do not propagate denormals into graph and state
-
+                let mut output = b0.mul_add(input, last_state);
+                // do not propagate denormals into graph and state
                 if !output.is_normal() {
                     output = 0.;
                 }
@@ -543,11 +543,7 @@ mod tests {
         expected[0] = 0.5;
         expected[1] = 0.5;
 
-        assert_float_eq!(
-            result[..],
-            expected,
-            abs_all <= 0.
-        );
+        assert_float_eq!(result[..], expected, abs_all <= 0.);
     }
 
     #[test]

--- a/src/node/iir_filter.rs
+++ b/src/node/iir_filter.rs
@@ -268,7 +268,7 @@ impl IIRFilterNode {
 /// Renderer associated with the `IirFilterNode`
 struct IirFilterRenderer {
     /// Normalized filter's coeffs -- `(b[n], a[n])`
-    norm_coeffs: Vec<(f64, f64)>,
+    norm_coeffs: ArrayVec<(f64, f64), MAX_IIR_COEFFS_LEN>,
     /// Per-channel filter state. Only the first `norm_coeffs.len()` entries are active.
     states: ArrayVec<[f64; MAX_IIR_COEFFS_LEN], MAX_CHANNELS>,
 }
@@ -300,7 +300,8 @@ impl IirFilterRenderer {
         };
 
         let a0 = feedback[0];
-        let mut norm_coeffs: Vec<(f64, f64)> = feedforward.into_iter().zip(feedback).collect();
+        let mut norm_coeffs: ArrayVec<(f64, f64), MAX_IIR_COEFFS_LEN> =
+            feedforward.into_iter().zip(feedback).collect();
 
         norm_coeffs.iter_mut().for_each(|(b, a)| {
             *b /= a0;

--- a/src/node/iir_filter.rs
+++ b/src/node/iir_filter.rs
@@ -269,8 +269,8 @@ impl IIRFilterNode {
 struct IirFilterRenderer {
     /// Normalized filter's coeffs -- `(b[n], a[n])`
     norm_coeffs: Vec<(f64, f64)>,
-    /// filter's states
-    states: ArrayVec<Vec<f64>, MAX_CHANNELS>,
+    /// Per-channel filter state. Only the first `norm_coeffs.len()` entries are active.
+    states: ArrayVec<[f64; MAX_IIR_COEFFS_LEN], MAX_CHANNELS>,
 }
 
 impl IirFilterRenderer {
@@ -307,12 +307,10 @@ impl IirFilterRenderer {
             *a /= a0;
         });
 
-        let coeffs_len = norm_coeffs.len();
-
         // eagerly assume stereo input, will adjust during rendering if needed
         let mut states = ArrayVec::new();
-        states.push(vec![0.; coeffs_len]);
-        states.push(vec![0.; coeffs_len]);
+        states.push([0.; MAX_IIR_COEFFS_LEN]);
+        states.push([0.; MAX_IIR_COEFFS_LEN]);
 
         Self {
             norm_coeffs,
@@ -339,7 +337,10 @@ impl AudioProcessor for IirFilterRenderer {
 
             // if all values in states are 0., we have nothing left to process
             self.states.iter().all(|state| {
-                if state.iter().any(|&v| v.is_normal()) {
+                if state[..self.norm_coeffs.len()]
+                    .iter()
+                    .any(|&v| v.is_normal())
+                {
                     ended = false;
                 }
                 // if ended is false, `iter().all` will stop early
@@ -363,7 +364,7 @@ impl AudioProcessor for IirFilterRenderer {
             if num_channels != self.states.len() {
                 self.states.truncate(num_channels);
                 for _ in self.states.len()..num_channels {
-                    self.states.push(vec![0.; self.norm_coeffs.len()]);
+                    self.states.push([0.; MAX_IIR_COEFFS_LEN]);
                 }
             }
 

--- a/src/node/iir_filter.rs
+++ b/src/node/iir_filter.rs
@@ -282,14 +282,14 @@ impl IirFilterRenderer {
     fn new(mut feedforward: Vec<f64>, mut feedback: Vec<f64>) -> Self {
         // make sure feedback and feedforward have same length, fill with 0. to match
         match (feedforward.len(), feedback.len()) {
-            (feedforward_len, feedback_len) if feedforward_len > feedback_len => {
+            (feedforward_len, feedback_len) if feedforward_len < feedback_len => {
                 feedforward = feedforward
                     .into_iter()
                     .chain(std::iter::repeat(0.))
                     .take(feedback_len)
                     .collect();
             }
-            (feedforward_len, feedback_len) if feedforward_len < feedback_len => {
+            (feedforward_len, feedback_len) if feedforward_len > feedback_len => {
                 feedback = feedback
                     .into_iter()
                     .chain(std::iter::repeat(0.))
@@ -386,7 +386,7 @@ impl AudioProcessor for IirFilterRenderer {
                 let input = f64::from(i);
                 let b0 = self.norm_coeffs[0].0;
                 let last_state = channel_state[0];
-                let output = b0.mul_add(input, last_state);
+                let mut output = b0.mul_add(input, last_state);
 
                 // update states for next call
                 for (i, (b, a)) in self.norm_coeffs.iter().skip(1).enumerate() {
@@ -518,6 +518,32 @@ mod tests {
         let mut phase_response = [0., 1.0];
 
         iir.get_frequency_response(&frequency_hz, &mut mag_response, &mut phase_response);
+    }
+
+    #[test]
+    fn test_one_zero_with_feedback_feedforward_different_length() {
+        // cf. the-audio-api/the-iirfilternode-interface/iirfilter.html
+        let sample_rate = 24000.;
+        let mut context = OfflineAudioContext::new(1, 8000, sample_rate);
+        let buffer = AudioBuffer::from(vec![vec![1.]], sample_rate);
+        let mut source = context.create_buffer_source();
+        source.set_buffer(buffer);
+
+        let iir = context.create_iir_filter(vec![0.5, 0.5], vec![1.]);
+        source.connect(&iir).connect(&context.destination());
+        source.start();
+
+        let output = context.start_rendering_sync();
+        let result = output.get_channel_data(0);
+        let mut expected = [0.; 8000];
+        expected[0] = 0.5;
+        expected[1] = 0.5;
+
+        assert_float_eq!(
+            result[..],
+            expected,
+            abs_all <= 0.
+        );
     }
 
     #[test]


### PR DESCRIPTION
(+ prevent propagation of denormals into the graph)

Now fully WPT compliant!

```
RESULTS:
- # pass: 128
- # fail: 0
- # type error issues: 0
 ```



