### PR TITLE
More OscillatorNode work

### DIFF
--- a/benches/my_benchmark.rs
+++ b/benches/my_benchmark.rs
@@ -74,6 +74,18 @@ pub fn bench_sine() {
     assert_eq!(ctx.start_rendering_sync().length(), SAMPLES);
 }
 
+pub fn bench_detuned_sine() {
+    let mut ctx = OfflineAudioContext::new(2, black_box(SAMPLES), SAMPLE_RATE);
+    let mut osc = ctx.create_oscillator();
+    osc.detune()
+        .linear_ramp_to_value_at_time(1000., DURATION as f64);
+
+    osc.connect(&ctx.destination());
+    osc.start();
+
+    assert_eq!(ctx.start_rendering_sync().length(), SAMPLES);
+}
+
 pub fn bench_sine_gain() {
     let mut ctx = OfflineAudioContext::new(2, black_box(SAMPLES), SAMPLE_RATE);
     let mut osc = ctx.create_oscillator();
@@ -319,6 +331,7 @@ iai_or_criterion!(
     bench_sine,
     bench_sine_gain,
     bench_sine_gain_delay,
+    bench_detuned_sine,
     bench_buffer_src,
     bench_buffer_src_delay,
     bench_buffer_src_iir,

--- a/src/node/oscillator.rs
+++ b/src/node/oscillator.rs
@@ -519,7 +519,11 @@ impl OscillatorRenderer {
             // we need to adjust the phase first
             if current_time > self.start_time {
                 let ratio = (current_time - self.start_time) / dt;
-                self.phase = Self::unroll_phase(phase_incr * ratio);
+                self.phase = if outside_nyquist {
+                    Self::unroll_phase_unbounded(phase_incr * ratio)
+                } else {
+                    Self::unroll_phase(phase_incr * ratio)
+                };
             }
 
             self.started = true;
@@ -540,7 +544,11 @@ impl OscillatorRenderer {
             }
         };
 
-        self.phase = Self::unroll_phase(self.phase + phase_incr);
+        self.phase = if outside_nyquist {
+            Self::unroll_phase_unbounded(self.phase + phase_incr)
+        } else {
+            Self::unroll_phase(self.phase + phase_incr)
+        };
 
         current_time + dt
     }
@@ -646,6 +654,11 @@ impl OscillatorRenderer {
         }
 
         phase
+    }
+
+    #[inline]
+    fn unroll_phase_unbounded(phase: f64) -> f64 {
+        phase.rem_euclid(1.)
     }
 }
 
@@ -1353,6 +1366,31 @@ mod tests {
         let result = output.get_channel_data(0);
 
         assert_float_eq!(result[..], [0.; 128], abs_all <= 1e-5);
+    }
+
+    #[test]
+    fn oscillator_can_reenter_audible_range_after_large_phase_increments() {
+        let sample_rate = 44_100;
+        let mut context = OfflineAudioContext::new(1, 256, sample_rate as f32);
+
+        let mut osc = context.create_oscillator();
+        osc.connect(&context.destination());
+        osc.frequency().set_value(20_000.);
+        osc.detune().set_value(2400.); // computed frequency is 80_000Hz
+        osc.detune()
+            .set_value_at_time(0., RENDER_QUANTUM_SIZE as f64 / sample_rate as f64);
+        osc.start_at(0.);
+
+        let output = context.start_rendering_sync();
+        let result = output.get_channel_data(0);
+
+        assert_float_eq!(
+            result[..RENDER_QUANTUM_SIZE],
+            [0.; RENDER_QUANTUM_SIZE],
+            abs_all <= 1e-5
+        );
+        assert!(result[RENDER_QUANTUM_SIZE..].iter().all(|v| v.is_finite()));
+        assert!(result[RENDER_QUANTUM_SIZE..].iter().any(|&v| v != 0.));
     }
 
     #[test]

--- a/src/node/oscillator.rs
+++ b/src/node/oscillator.rs
@@ -27,11 +27,11 @@ fn precomputed_sine_table() -> &'static [f32] {
     })
 }
 
-fn get_phase_incr(freq: f32, detune: f32, sample_rate: f64) -> f64 {
-    let computed_freq = freq as f64 * (detune as f64 / 1200.).exp2();
-    let clamped = computed_freq.clamp(-sample_rate / 2., sample_rate / 2.);
-    clamped / sample_rate
-}
+// fn get_phase_incr(freq: f32, detune: f32, sample_rate: f64) -> f64 {
+//     let computed_freq = freq as f64 * (detune as f64 / 1200.).exp2();
+//     let clamped = computed_freq.clamp(-sample_rate / 2., sample_rate / 2.);
+//     clamped / sample_rate
+// }
 
 /// Options for constructing an [`OscillatorNode`]
 // dictionary OscillatorOptions : AudioNodeOptions {
@@ -423,18 +423,20 @@ impl AudioProcessor for OscillatorRenderer {
         }
 
         if frequency_values.len() == 1 && detune_values.len() == 1 {
-            let phase_incr = get_phase_incr(frequency_values[0], detune_values[0], sample_rate);
+            // let phase_incr = get_phase_incr(frequency_values[0], detune_values[0], sample_rate);
+            let freq = frequency_values[0];
+            let detune = detune_values[0];
+
             channel_data
                 .iter_mut()
-                .for_each(|output| self.generate_sample(output, phase_incr, &mut current_time, dt));
+                .for_each(|output| self.generate_sample(output, freq, detune, sample_rate, &mut current_time, dt));
         } else {
             channel_data
                 .iter_mut()
                 .zip(frequency_values.iter().cycle())
                 .zip(detune_values.iter().cycle())
-                .for_each(|((output, &f), &d)| {
-                    let phase_incr = get_phase_incr(f, d, sample_rate);
-                    self.generate_sample(output, phase_incr, &mut current_time, dt)
+                .for_each(|((output, &freq), &detune)| {
+                    self.generate_sample(output, freq, detune, sample_rate, &mut current_time, dt)
                 });
         }
 
@@ -493,7 +495,9 @@ impl OscillatorRenderer {
     fn generate_sample(
         &mut self,
         output: &mut f32,
-        phase_incr: f64,
+        freq: f32,
+        detune: f32,
+        sample_rate: f64,
         current_time: &mut f64,
         dt: f64,
     ) {
@@ -503,6 +507,9 @@ impl OscillatorRenderer {
 
             return;
         }
+
+        let computed_freq = freq as f64 * (detune as f64 / 1200.).exp2();
+        let phase_incr = computed_freq / sample_rate;
 
         // first sample to render
         if !self.started {
@@ -516,17 +523,24 @@ impl OscillatorRenderer {
             self.started = true;
         }
 
-        // @note: per spec all default oscillators should be rendered from a
-        // wavetable, define if it worth the assle...
-        // e.g. for now `generate_sine` and `generate_custom` are almost the sames
-        // cf. https://webaudio.github.io/web-audio-api/#oscillator-coefficients
-        *output = match self.type_ {
-            OscillatorType::Sine => self.generate_sine(),
-            OscillatorType::Sawtooth => self.generate_sawtooth(phase_incr),
-            OscillatorType::Square => self.generate_square(phase_incr),
-            OscillatorType::Triangle => self.generate_triangle(),
-            OscillatorType::Custom => self.generate_custom(),
-        };
+        // output zero if computed_freq is above nyquist but continue to compute
+        // timing and phase information as if there was sound. Doesn't seems neither
+        // specified nor tested, but looks like the logical thing to do.
+        if computed_freq >= sample_rate / 2. {
+            *output = 0.;
+        } else {
+            // @note: per spec all default oscillators should be rendered from a
+            // wavetable, define if it worth the hassle...
+            // e.g. for now `generate_sine` and `generate_custom` are almost the sames
+            // cf. https://webaudio.github.io/web-audio-api/#oscillator-coefficients
+            *output = match self.type_ {
+                OscillatorType::Sine => self.generate_sine(),
+                OscillatorType::Sawtooth => self.generate_sawtooth(phase_incr),
+                OscillatorType::Square => self.generate_square(phase_incr),
+                OscillatorType::Triangle => self.generate_triangle(),
+                OscillatorType::Custom => self.generate_custom(),
+            };
+        }
 
         *current_time += dt;
 

--- a/src/node/oscillator.rs
+++ b/src/node/oscillator.rs
@@ -425,7 +425,14 @@ impl AudioProcessor for OscillatorRenderer {
             let phase_incr = computed_freq / sample_rate;
 
             channel_data.iter_mut().for_each(|output| {
-                self.generate_sample(output, computed_freq, phase_incr, nyquist, &mut current_time, dt)
+                current_time = self.generate_sample(
+                    output,
+                    computed_freq,
+                    phase_incr,
+                    nyquist,
+                    current_time,
+                    dt,
+                );
             });
         } else {
             channel_data
@@ -435,7 +442,14 @@ impl AudioProcessor for OscillatorRenderer {
                 .for_each(|((output, &freq), &detune)| {
                     let computed_freq = freq as f64 * (detune as f64 / 1200.).exp2();
                     let phase_incr = computed_freq / sample_rate;
-                    self.generate_sample(output, computed_freq, phase_incr, nyquist, &mut current_time, dt)
+                    current_time = self.generate_sample(
+                        output,
+                        computed_freq,
+                        phase_incr,
+                        nyquist,
+                        current_time,
+                        dt,
+                    )
                 });
         }
 
@@ -497,22 +511,20 @@ impl OscillatorRenderer {
         computed_freq: f64,
         phase_incr: f64,
         nyquist: f64,
-        current_time: &mut f64,
+        current_time: f64,
         dt: f64,
-    ) {
-        if *current_time < self.start_time || *current_time >= self.stop_time {
+    ) -> f64 {
+        if current_time < self.start_time || current_time >= self.stop_time {
             *output = 0.;
-            *current_time += dt;
-
-            return;
+            return current_time + dt;
         }
 
         // first sample to render
         if !self.started {
             // if start time was between last frame and current frame
             // we need to adjust the phase first
-            if *current_time > self.start_time {
-                let ratio = (*current_time - self.start_time) / dt;
+            if current_time > self.start_time {
+                let ratio = (current_time - self.start_time) / dt;
                 self.phase = Self::unroll_phase(phase_incr * ratio);
             }
 
@@ -535,9 +547,9 @@ impl OscillatorRenderer {
             }
         }
 
-        *current_time += dt;
-
         self.phase = Self::unroll_phase(self.phase + phase_incr);
+
+        current_time + dt
     }
 
     #[inline]

--- a/src/node/oscillator.rs
+++ b/src/node/oscillator.rs
@@ -429,11 +429,21 @@ impl AudioProcessor for OscillatorRenderer {
             let computed_freq = get_computed_freq(freq, detune);
             let phase_incr = computed_freq / sample_rate;
             let outside_nyquist = computed_freq.abs() >= nyquist;
+            let fully_active = self.started
+                && self.start_time <= scope.current_time
+                && self.stop_time >= next_block_time;
 
-            channel_data.iter_mut().for_each(|output| {
-                current_time =
-                    self.generate_sample(output, outside_nyquist, phase_incr, current_time, dt);
-            });
+            if fully_active && !outside_nyquist {
+                channel_data.iter_mut().for_each(|output| {
+                    *output = self.generate_waveform_sample(phase_incr);
+                    self.phase = Self::unroll_phase(self.phase + phase_incr);
+                });
+            } else {
+                channel_data.iter_mut().for_each(|output| {
+                    current_time =
+                        self.generate_sample(output, outside_nyquist, phase_incr, current_time, dt);
+                });
+            }
         } else {
             channel_data
                 .iter_mut()
@@ -535,13 +545,7 @@ impl OscillatorRenderer {
             // automation can re-enter the audible range without resetting phase.
             0.
         } else {
-            match self.type_ {
-                OscillatorType::Sine => self.generate_sine(),
-                OscillatorType::Sawtooth => self.generate_sawtooth(phase_incr),
-                OscillatorType::Square => self.generate_square(phase_incr),
-                OscillatorType::Triangle => self.generate_triangle(),
-                OscillatorType::Custom => self.generate_custom(),
-            }
+            self.generate_waveform_sample(phase_incr)
         };
 
         self.phase = if outside_nyquist {
@@ -551,6 +555,17 @@ impl OscillatorRenderer {
         };
 
         current_time + dt
+    }
+
+    #[inline]
+    fn generate_waveform_sample(&mut self, phase_incr: f64) -> f32 {
+        match self.type_ {
+            OscillatorType::Sine => self.generate_sine(),
+            OscillatorType::Sawtooth => self.generate_sawtooth(phase_incr),
+            OscillatorType::Square => self.generate_square(phase_incr),
+            OscillatorType::Triangle => self.generate_triangle(),
+            OscillatorType::Custom => self.generate_custom(),
+        }
     }
 
     #[inline]
@@ -1388,6 +1403,27 @@ mod tests {
             abs_all <= 1e-5
         );
         assert!(result[RENDER_QUANTUM_SIZE..].iter().all(|v| v.is_finite()));
+        assert!(result[RENDER_QUANTUM_SIZE..].iter().any(|&v| v != 0.));
+    }
+
+    #[test]
+    fn oscillator_delayed_start_renders_first_fully_active_block() {
+        let sample_rate = 44_100;
+        let start_time = RENDER_QUANTUM_SIZE as f64 / sample_rate as f64;
+        let mut context = OfflineAudioContext::new(1, RENDER_QUANTUM_SIZE * 2, sample_rate as f32);
+
+        let mut osc = context.create_oscillator();
+        osc.connect(&context.destination());
+        osc.start_at(start_time);
+
+        let output = context.start_rendering_sync();
+        let result = output.get_channel_data(0);
+
+        assert_float_eq!(
+            result[..RENDER_QUANTUM_SIZE],
+            [0.; RENDER_QUANTUM_SIZE],
+            abs_all <= 1e-5
+        );
         assert!(result[RENDER_QUANTUM_SIZE..].iter().any(|&v| v != 0.));
     }
 

--- a/src/node/oscillator.rs
+++ b/src/node/oscillator.rs
@@ -525,16 +525,19 @@ impl OscillatorRenderer {
             self.started = true;
         }
 
-        // Output silence when the computed oscillator frequency is outside the
-        // nominal [-nyquist, nyquist] range. Timing and phase still advance so
-        // automation can re-enter the audible range without resetting phase.
-        *output = match (outside_nyquist, self.type_) {
-            (true, _) => 0.,
-            (false, OscillatorType::Sine) => self.generate_sine(),
-            (false, OscillatorType::Sawtooth) => self.generate_sawtooth(phase_incr),
-            (false, OscillatorType::Square) => self.generate_square(phase_incr),
-            (false, OscillatorType::Triangle) => self.generate_triangle(),
-            (false, OscillatorType::Custom) => self.generate_custom(),
+        *output = if outside_nyquist {
+            // Output silence when the computed oscillator frequency is outside the
+            // nominal [-nyquist, nyquist] range. Timing and phase still advance so
+            // automation can re-enter the audible range without resetting phase.
+            0.
+        } else {
+            match self.type_ {
+                OscillatorType::Sine => self.generate_sine(),
+                OscillatorType::Sawtooth => self.generate_sawtooth(phase_incr),
+                OscillatorType::Square => self.generate_square(phase_incr),
+                OscillatorType::Triangle => self.generate_triangle(),
+                OscillatorType::Custom => self.generate_custom(),
+            }
         };
 
         self.phase = Self::unroll_phase(self.phase + phase_incr);

--- a/src/node/oscillator.rs
+++ b/src/node/oscillator.rs
@@ -27,12 +27,6 @@ fn precomputed_sine_table() -> &'static [f32] {
     })
 }
 
-// fn get_phase_incr(freq: f32, detune: f32, sample_rate: f64) -> f64 {
-//     let computed_freq = freq as f64 * (detune as f64 / 1200.).exp2();
-//     let clamped = computed_freq.clamp(-sample_rate / 2., sample_rate / 2.);
-//     clamped / sample_rate
-// }
-
 /// Options for constructing an [`OscillatorNode`]
 // dictionary OscillatorOptions : AudioNodeOptions {
 //   OscillatorType type = "sine";

--- a/src/node/oscillator.rs
+++ b/src/node/oscillator.rs
@@ -535,10 +535,10 @@ impl OscillatorRenderer {
             self.started = true;
         }
 
-        // output zero if computed_freq is above nyquist but continue to compute
+        // output zero if computed_freq is beyond nyquist but continue to compute
         // timing and phase information as normal. Doesn't seems neither specified
         // nor tested, but looks like a sensible thing to do.
-        *output = match (computed_freq >= nyquist, self.type_) {
+        *output = match (computed_freq.abs() >= nyquist, self.type_) {
             (true, _) => 0.,
             (false, OscillatorType::Sine) => self.generate_sine(),
             (false, OscillatorType::Sawtooth) => self.generate_sawtooth(phase_incr),
@@ -1325,7 +1325,27 @@ mod tests {
     #[test]
     fn compute_freq_above_nyquist_outputs_zero() {
         let freq = 20000.;
-        let detune = 1200.; // one octava upper, then computer feq is 40000Hz
+        let detune = 1200.; // one octave upper, then computed feq is 40000Hz
+        let sample_rate = 44_100;
+
+        let mut context = OfflineAudioContext::new(1, 128, sample_rate as f32);
+
+        let mut osc = context.create_oscillator();
+        osc.connect(&context.destination());
+        osc.frequency().set_value(freq);
+        osc.detune().set_value(detune);
+        osc.start_at(0.);
+
+        let output = context.start_rendering_sync();
+        let result = output.get_channel_data(0);
+
+        assert_float_eq!(result[..], [0.; 128], abs_all <= 1e-5);
+    }
+
+    #[test]
+    fn compute_freq_below_negative_nyquist_outputs_zero() {
+        let freq = -20000.;
+        let detune = 1200.; // one octave lower, then computed feq is -40000Hz
         let sample_rate = 44_100;
 
         let mut context = OfflineAudioContext::new(1, 128, sample_rate as f32);

--- a/src/node/oscillator.rs
+++ b/src/node/oscillator.rs
@@ -423,20 +423,23 @@ impl AudioProcessor for OscillatorRenderer {
         }
 
         if frequency_values.len() == 1 && detune_values.len() == 1 {
-            // let phase_incr = get_phase_incr(frequency_values[0], detune_values[0], sample_rate);
             let freq = frequency_values[0];
             let detune = detune_values[0];
+            let computed_freq = freq as f64 * (detune as f64 / 1200.).exp2();
 
             channel_data
                 .iter_mut()
-                .for_each(|output| self.generate_sample(output, freq, detune, sample_rate, &mut current_time, dt));
+                .for_each(|output| {
+                    self.generate_sample(output, computed_freq, sample_rate, &mut current_time, dt)
+                });
         } else {
             channel_data
                 .iter_mut()
                 .zip(frequency_values.iter().cycle())
                 .zip(detune_values.iter().cycle())
                 .for_each(|((output, &freq), &detune)| {
-                    self.generate_sample(output, freq, detune, sample_rate, &mut current_time, dt)
+                    let computed_freq = freq as f64 * (detune as f64 / 1200.).exp2();
+                    self.generate_sample(output, computed_freq, sample_rate, &mut current_time, dt)
                 });
         }
 
@@ -495,8 +498,7 @@ impl OscillatorRenderer {
     fn generate_sample(
         &mut self,
         output: &mut f32,
-        freq: f32,
-        detune: f32,
+        computed_freq: f64,
         sample_rate: f64,
         current_time: &mut f64,
         dt: f64,
@@ -508,7 +510,6 @@ impl OscillatorRenderer {
             return;
         }
 
-        let computed_freq = freq as f64 * (detune as f64 / 1200.).exp2();
         let phase_incr = computed_freq / sample_rate;
 
         // first sample to render
@@ -524,22 +525,19 @@ impl OscillatorRenderer {
         }
 
         // output zero if computed_freq is above nyquist but continue to compute
-        // timing and phase information as if there was sound. Doesn't seems neither
-        // specified nor tested, but looks like the logical thing to do.
-        if computed_freq >= sample_rate / 2. {
-            *output = 0.;
-        } else {
-            // @note: per spec all default oscillators should be rendered from a
-            // wavetable, define if it worth the hassle...
-            // e.g. for now `generate_sine` and `generate_custom` are almost the sames
-            // cf. https://webaudio.github.io/web-audio-api/#oscillator-coefficients
-            *output = match self.type_ {
-                OscillatorType::Sine => self.generate_sine(),
-                OscillatorType::Sawtooth => self.generate_sawtooth(phase_incr),
-                OscillatorType::Square => self.generate_square(phase_incr),
-                OscillatorType::Triangle => self.generate_triangle(),
-                OscillatorType::Custom => self.generate_custom(),
-            };
+        // timing and phase information as normal. Doesn't seems neither specified
+        // nor tested, but looks like a sensible thing to do.
+        match computed_freq >= sample_rate / 2. {
+            true => *output = 0.,
+            false => {
+                *output = match self.type_ {
+                    OscillatorType::Sine => self.generate_sine(),
+                    OscillatorType::Sawtooth => self.generate_sawtooth(phase_incr),
+                    OscillatorType::Square => self.generate_square(phase_incr),
+                    OscillatorType::Triangle => self.generate_triangle(),
+                    OscillatorType::Custom => self.generate_custom(),
+                };
+            }
         }
 
         *current_time += dt;
@@ -641,6 +639,10 @@ impl OscillatorRenderer {
     fn unroll_phase(mut phase: f64) -> f64 {
         if phase >= 1. {
             phase -= 1.
+        }
+
+        if phase < 0. {
+            phase += 1.
         }
 
         phase
@@ -1308,6 +1310,34 @@ mod tests {
                 expected.push(sample as f32);
                 phase += phase_incr;
             }
+        }
+
+        assert_float_eq!(result[..], expected[..], abs_all <= 1e-5);
+    }
+
+    #[test]
+    fn sine_negative_frequency() {
+        let freq = -100.;
+        let sample_rate = 44_100;
+        let length = sample_rate as usize;
+
+
+        let mut context = OfflineAudioContext::new(1, length, sample_rate as f32);
+
+        let mut osc = context.create_oscillator();
+        osc.connect(&context.destination());
+        osc.frequency().set_value(freq);
+        osc.start_at(0.);
+
+        let output = context.start_rendering_sync();
+        let result = output.get_channel_data(0);
+        let mut expected = Vec::<f32>::with_capacity(length);
+
+        for i in 0..length {
+            let phase = freq as f64 * i as f64 / sample_rate as f64;
+            let sample = (phase * 2. * PI).sin();
+            // phase += phase_incr;
+            expected.push(sample as f32);
         }
 
         assert_float_eq!(result[..], expected[..], abs_all <= 1e-5);

--- a/src/node/oscillator.rs
+++ b/src/node/oscillator.rs
@@ -422,21 +422,17 @@ impl AudioProcessor for OscillatorRenderer {
 
         let nyquist = sample_rate / 2.;
 
+        // fast path for scalar AudioParam values
         if frequency_values.len() == 1 && detune_values.len() == 1 {
             let freq = frequency_values[0];
             let detune = detune_values[0];
             let computed_freq = get_computed_freq(freq, detune);
             let phase_incr = computed_freq / sample_rate;
+            let outside_nyquist = computed_freq.abs() >= nyquist;
 
             channel_data.iter_mut().for_each(|output| {
-                current_time = self.generate_sample(
-                    output,
-                    computed_freq,
-                    phase_incr,
-                    nyquist,
-                    current_time,
-                    dt,
-                );
+                current_time =
+                    self.generate_sample(output, outside_nyquist, phase_incr, current_time, dt);
             });
         } else {
             channel_data
@@ -446,14 +442,9 @@ impl AudioProcessor for OscillatorRenderer {
                 .for_each(|((output, &freq), &detune)| {
                     let computed_freq = get_computed_freq(freq, detune);
                     let phase_incr = computed_freq / sample_rate;
-                    current_time = self.generate_sample(
-                        output,
-                        computed_freq,
-                        phase_incr,
-                        nyquist,
-                        current_time,
-                        dt,
-                    )
+                    let outside_nyquist = computed_freq.abs() >= nyquist;
+                    current_time =
+                        self.generate_sample(output, outside_nyquist, phase_incr, current_time, dt)
                 });
         }
 
@@ -512,9 +503,8 @@ impl OscillatorRenderer {
     fn generate_sample(
         &mut self,
         output: &mut f32,
-        computed_freq: f64,
+        outside_nyquist: bool,
         phase_incr: f64,
-        nyquist: f64,
         current_time: f64,
         dt: f64,
     ) -> f64 {
@@ -535,10 +525,10 @@ impl OscillatorRenderer {
             self.started = true;
         }
 
-        // output zero if computed_freq is beyond nyquist but continue to compute
-        // timing and phase information as normal. Doesn't seems neither specified
-        // nor tested, but looks like a sensible thing to do.
-        *output = match (computed_freq.abs() >= nyquist, self.type_) {
+        // Output silence when the computed oscillator frequency is outside the
+        // nominal [-nyquist, nyquist] range. Timing and phase still advance so
+        // automation can re-enter the audible range without resetting phase.
+        *output = match (outside_nyquist, self.type_) {
             (true, _) => 0.,
             (false, OscillatorType::Sine) => self.generate_sine(),
             (false, OscillatorType::Sawtooth) => self.generate_sawtooth(phase_incr),

--- a/src/node/oscillator.rs
+++ b/src/node/oscillator.rs
@@ -644,16 +644,14 @@ impl OscillatorRenderer {
     }
 
     #[inline]
-    fn unroll_phase(mut phase: f64) -> f64 {
+    fn unroll_phase(phase: f64) -> f64 {
         if phase >= 1. {
-            phase -= 1.
+            phase - 1.
+        } else if phase < 0. {
+            phase + 1.
+        } else {
+            phase
         }
-
-        if phase < 0. {
-            phase += 1.
-        }
-
-        phase
     }
 
     #[inline]

--- a/src/node/oscillator.rs
+++ b/src/node/oscillator.rs
@@ -534,18 +534,26 @@ impl OscillatorRenderer {
         // output zero if computed_freq is above nyquist but continue to compute
         // timing and phase information as normal. Doesn't seems neither specified
         // nor tested, but looks like a sensible thing to do.
-        match computed_freq >= nyquist {
-            true => *output = 0.,
-            false => {
-                *output = match self.type_ {
-                    OscillatorType::Sine => self.generate_sine(),
-                    OscillatorType::Sawtooth => self.generate_sawtooth(phase_incr),
-                    OscillatorType::Square => self.generate_square(phase_incr),
-                    OscillatorType::Triangle => self.generate_triangle(),
-                    OscillatorType::Custom => self.generate_custom(),
-                };
-            }
-        }
+        *output = match (computed_freq >= nyquist, self.type_) {
+            (true, _) => 0.,
+            (false, OscillatorType::Sine) => self.generate_sine(),
+            (false, OscillatorType::Sawtooth) => self.generate_sawtooth(phase_incr),
+            (false, OscillatorType::Square) => self.generate_square(phase_incr),
+            (false, OscillatorType::Triangle) => self.generate_triangle(),
+            (false, OscillatorType::Custom) => self.generate_custom(),
+        };
+        // match computed_freq >= nyquist {
+        //     true => *output = 0.,
+        //     false => {
+        //         *output = match self.type_ {
+        //             OscillatorType::Sine => self.generate_sine(),
+        //             OscillatorType::Sawtooth => self.generate_sawtooth(phase_incr),
+        //             OscillatorType::Square => self.generate_square(phase_incr),
+        //             OscillatorType::Triangle => self.generate_triangle(),
+        //             OscillatorType::Custom => self.generate_custom(),
+        //         };
+        //     }
+        // }
 
         self.phase = Self::unroll_phase(self.phase + phase_incr);
 

--- a/src/node/oscillator.rs
+++ b/src/node/oscillator.rs
@@ -427,11 +427,9 @@ impl AudioProcessor for OscillatorRenderer {
             let detune = detune_values[0];
             let computed_freq = freq as f64 * (detune as f64 / 1200.).exp2();
 
-            channel_data
-                .iter_mut()
-                .for_each(|output| {
-                    self.generate_sample(output, computed_freq, sample_rate, &mut current_time, dt)
-                });
+            channel_data.iter_mut().for_each(|output| {
+                self.generate_sample(output, computed_freq, sample_rate, &mut current_time, dt)
+            });
         } else {
             channel_data
                 .iter_mut()
@@ -1316,11 +1314,30 @@ mod tests {
     }
 
     #[test]
+    fn compute_freq_above_nyquist_outputs_zero() {
+        let freq = 20000.;
+        let detune = 1200.; // one octava upper, then computer feq is 40000Hz
+        let sample_rate = 44_100;
+
+        let mut context = OfflineAudioContext::new(1, 128, sample_rate as f32);
+
+        let mut osc = context.create_oscillator();
+        osc.connect(&context.destination());
+        osc.frequency().set_value(freq);
+        osc.detune().set_value(detune);
+        osc.start_at(0.);
+
+        let output = context.start_rendering_sync();
+        let result = output.get_channel_data(0);
+
+        assert_float_eq!(result[..], [0.; 128], abs_all <= 1e-5);
+    }
+
+    #[test]
     fn sine_negative_frequency() {
         let freq = -100.;
         let sample_rate = 44_100;
         let length = sample_rate as usize;
-
 
         let mut context = OfflineAudioContext::new(1, length, sample_rate as f32);
 

--- a/src/node/oscillator.rs
+++ b/src/node/oscillator.rs
@@ -27,6 +27,10 @@ fn precomputed_sine_table() -> &'static [f32] {
     })
 }
 
+fn get_computed_freq(freq: f32, detune: f32) -> f64 {
+    freq as f64 * (detune as f64 / 1200.).exp2()
+}
+
 /// Options for constructing an [`OscillatorNode`]
 // dictionary OscillatorOptions : AudioNodeOptions {
 //   OscillatorType type = "sine";
@@ -421,7 +425,7 @@ impl AudioProcessor for OscillatorRenderer {
         if frequency_values.len() == 1 && detune_values.len() == 1 {
             let freq = frequency_values[0];
             let detune = detune_values[0];
-            let computed_freq = freq as f64 * (detune as f64 / 1200.).exp2();
+            let computed_freq = get_computed_freq(freq, detune);
             let phase_incr = computed_freq / sample_rate;
 
             channel_data.iter_mut().for_each(|output| {
@@ -440,7 +444,7 @@ impl AudioProcessor for OscillatorRenderer {
                 .zip(frequency_values.iter().cycle())
                 .zip(detune_values.iter().cycle())
                 .for_each(|((output, &freq), &detune)| {
-                    let computed_freq = freq as f64 * (detune as f64 / 1200.).exp2();
+                    let computed_freq = get_computed_freq(freq, detune);
                     let phase_incr = computed_freq / sample_rate;
                     current_time = self.generate_sample(
                         output,
@@ -542,18 +546,6 @@ impl OscillatorRenderer {
             (false, OscillatorType::Triangle) => self.generate_triangle(),
             (false, OscillatorType::Custom) => self.generate_custom(),
         };
-        // match computed_freq >= nyquist {
-        //     true => *output = 0.,
-        //     false => {
-        //         *output = match self.type_ {
-        //             OscillatorType::Sine => self.generate_sine(),
-        //             OscillatorType::Sawtooth => self.generate_sawtooth(phase_incr),
-        //             OscillatorType::Square => self.generate_square(phase_incr),
-        //             OscillatorType::Triangle => self.generate_triangle(),
-        //             OscillatorType::Custom => self.generate_custom(),
-        //         };
-        //     }
-        // }
 
         self.phase = Self::unroll_phase(self.phase + phase_incr);
 

--- a/src/node/oscillator.rs
+++ b/src/node/oscillator.rs
@@ -416,13 +416,16 @@ impl AudioProcessor for OscillatorRenderer {
             self.start_time = current_time;
         }
 
+        let nyquist = sample_rate / 2.;
+
         if frequency_values.len() == 1 && detune_values.len() == 1 {
             let freq = frequency_values[0];
             let detune = detune_values[0];
             let computed_freq = freq as f64 * (detune as f64 / 1200.).exp2();
+            let phase_incr = computed_freq / sample_rate;
 
             channel_data.iter_mut().for_each(|output| {
-                self.generate_sample(output, computed_freq, sample_rate, &mut current_time, dt)
+                self.generate_sample(output, computed_freq, phase_incr, nyquist, &mut current_time, dt)
             });
         } else {
             channel_data
@@ -431,7 +434,8 @@ impl AudioProcessor for OscillatorRenderer {
                 .zip(detune_values.iter().cycle())
                 .for_each(|((output, &freq), &detune)| {
                     let computed_freq = freq as f64 * (detune as f64 / 1200.).exp2();
-                    self.generate_sample(output, computed_freq, sample_rate, &mut current_time, dt)
+                    let phase_incr = computed_freq / sample_rate;
+                    self.generate_sample(output, computed_freq, phase_incr, nyquist, &mut current_time, dt)
                 });
         }
 
@@ -491,7 +495,8 @@ impl OscillatorRenderer {
         &mut self,
         output: &mut f32,
         computed_freq: f64,
-        sample_rate: f64,
+        phase_incr: f64,
+        nyquist: f64,
         current_time: &mut f64,
         dt: f64,
     ) {
@@ -501,8 +506,6 @@ impl OscillatorRenderer {
 
             return;
         }
-
-        let phase_incr = computed_freq / sample_rate;
 
         // first sample to render
         if !self.started {
@@ -519,7 +522,7 @@ impl OscillatorRenderer {
         // output zero if computed_freq is above nyquist but continue to compute
         // timing and phase information as normal. Doesn't seems neither specified
         // nor tested, but looks like a sensible thing to do.
-        match computed_freq >= sample_rate / 2. {
+        match computed_freq >= nyquist {
             true => *output = 0.,
             false => {
                 *output = match self.type_ {


### PR DESCRIPTION
Sorry I went a bit wild. Built further upon your work
- handle -nyquist values
- fix as possible panic path with large phase incr value
- add a fast path for not-automation frequence/detune
- added an even faster path for 'fully active' (oscillator is ringing during the whole render block)
- float value calculation optimization
- some tests and a benchmark for the slow path