### PR TITLE
Fixes for v1.6.0: hang safety, AudioParam automation, and graph handling

### DIFF
--- a/src/context/concrete_base.rs
+++ b/src/context/concrete_base.rs
@@ -13,10 +13,11 @@ use crate::spatial::AudioListenerParams;
 
 use crate::AudioListener;
 
-use crossbeam_channel::{SendError, Sender};
+use crossbeam_channel::{Receiver, RecvTimeoutError, SendError, SendTimeoutError, Sender};
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use std::sync::{Arc, Mutex, RwLock, RwLockWriteGuard};
+use std::time::Duration;
 
 /// This struct assigns new [`AudioNodeId`]s for [`AudioNode`]s
 ///
@@ -282,9 +283,138 @@ impl ConcreteBaseAudioContext {
                 return;
             }
 
-            let result = sender.send(msg);
-            if result.is_err() {
-                log::warn!("Discarding control message - render thread is closed");
+            self.send_to_render_thread(&sender, msg);
+        }
+    }
+
+    /// Hands one control message to the render thread without ever blocking
+    /// the control thread indefinitely.
+    ///
+    /// Previously this was a bare `sender.send(msg)`. The control channel is
+    /// bounded(256) (the receiving end lives on the render thread; a bounded
+    /// channel is allocation-free and therefore realtime-safe). Once the render
+    /// thread stops draining - the device was unplugged or the driver died,
+    /// and cpal's err_fn only logs - the 257th message blocks the control
+    /// thread forever. Hosts running script on the control thread hang wholesale.
+    ///
+    /// The fix keeps the channel semantics and only changes *how long* to wait:
+    ///   - the channel stays bounded (render-side realtime safety untouched);
+    ///   - back-pressure stays blocking, so messages are neither dropped nor
+    ///     reordered (single FIFO channel, one-for-one with the old behavior);
+    ///   - the indefinite wait becomes a wait on render-thread *liveness*:
+    ///     while the channel is full, wake every `POLL` and check whether
+    ///     `frames_played` advanced (the render thread bumps it by 128 per
+    ///     rendered quantum).
+    ///       - progress: the render thread is alive, we are merely producing
+    ///         faster than it consumes - keep waiting (same as upstream);
+    ///       - zero progress across the whole `STALL_GRACE` window: the render
+    ///         side is gone - mark the context Closed and drop this message.
+    ///         The `state() != Closed` check at the top of send_control_msg
+    ///         then short-circuits every later message, so the control thread
+    ///         never touches this channel again.
+    ///
+    /// Liveness (frames_played) instead of a fixed send timeout: a fixed
+    /// timeout misfires on healthy-but-busy devices or during device startup.
+    /// One quantum is ~2.9 ms (128 frames at 44.1 kHz); zero progress across
+    /// the grace window means the render thread has skipped hundreds of quanta
+    /// - that is not busyness.
+    ///
+    /// Dropping is safe here: it only happens once the context is deemed
+    /// Closed, and a Closed context discards all control messages anyway (same
+    /// log line upstream) - with the device dead there is no render thread
+    /// left to execute the message regardless.
+    ///
+    /// Offline contexts are unaffected: their control channel is unbounded, so
+    /// send_timeout always succeeds immediately.
+    fn send_to_render_thread(&self, sender: &Sender<ControlMessage>, msg: ControlMessage) {
+        // Poll interval while the channel is full (much coarser than a quantum
+        // to keep wakeups cheap).
+        const POLL: Duration = Duration::from_millis(50);
+        // Zero playhead progress for this long means the render side stalled
+        // (~700 quanta; also comfortably covers device startup jitter).
+        const STALL_GRACE: Duration = Duration::from_secs(2);
+
+        let mut msg = msg;
+        let mut last_frames = self.inner.frames_played.load(Ordering::Relaxed);
+        let mut stalled = Duration::ZERO;
+
+        loop {
+            match sender.send_timeout(msg, POLL) {
+                Ok(()) => return,
+                Err(SendTimeoutError::Disconnected(_)) => {
+                    log::warn!("Discarding control message - render thread is closed");
+                    return;
+                }
+                Err(SendTimeoutError::Timeout(returned)) => {
+                    msg = returned; // send_timeout hands the message back - nothing is lost
+                    let frames = self.inner.frames_played.load(Ordering::Relaxed);
+                    if frames != last_frames {
+                        last_frames = frames;
+                        stalled = Duration::ZERO; // the render thread is progressing - plain back-pressure
+                        continue;
+                    }
+                    stalled += POLL;
+                    if stalled < STALL_GRACE {
+                        continue;
+                    }
+                    log::error!(
+                        "Render thread did not consume any control message for {:?} and did not \
+                         advance the playhead - assuming the audio device is gone, closing the \
+                         AudioContext",
+                        STALL_GRACE
+                    );
+                    self.set_state(AudioContextState::Closed);
+                    return;
+                }
+            }
+        }
+    }
+
+    /// Waits until the render thread acknowledges a *synchronous* control
+    /// message (the oneshot notify used by Suspend / Resume / Close).
+    ///
+    /// online.rs used a bare `receiver.recv().ok()` - the same hang surface as
+    /// the send side: with the render thread stalled the notify never arrives
+    /// and close_sync()/suspend_sync() block the control thread forever.
+    /// "Device unplugged, app calls ctx.close()" is precisely the most likely
+    /// call sequence in that situation. The wait uses the same frames_played
+    /// liveness rule: zero progress across `STALL_GRACE` deems the device dead,
+    /// marks the context Closed and returns `false` so the caller can skip
+    /// further operations against a device that no longer exists.
+    ///
+    /// On a healthy device the behavior is identical to upstream: the notify
+    /// arrives within one quantum (the render thread drains control messages on
+    /// every callback).
+    pub(crate) fn wait_for_render_thread(&self, receiver: &Receiver<()>) -> bool {
+        const POLL: Duration = Duration::from_millis(50);
+        const STALL_GRACE: Duration = Duration::from_secs(2);
+
+        let mut last_frames = self.inner.frames_played.load(Ordering::Relaxed);
+        let mut stalled = Duration::ZERO;
+
+        loop {
+            match receiver.recv_timeout(POLL) {
+                Ok(()) => return true,
+                Err(RecvTimeoutError::Disconnected) => return true, // render thread is gone - nothing to wait for
+                Err(RecvTimeoutError::Timeout) => {
+                    let frames = self.inner.frames_played.load(Ordering::Relaxed);
+                    if frames != last_frames {
+                        last_frames = frames;
+                        stalled = Duration::ZERO;
+                        continue;
+                    }
+                    stalled += POLL;
+                    if stalled < STALL_GRACE {
+                        continue;
+                    }
+                    log::error!(
+                        "Render thread did not respond within {:?} - assuming the audio device is \
+                         gone, closing the AudioContext",
+                        STALL_GRACE
+                    );
+                    self.set_state(AudioContextState::Closed);
+                    return false;
+                }
             }
         }
     }
@@ -292,9 +422,10 @@ impl ConcreteBaseAudioContext {
     pub(crate) fn suspend_control_msgs(&self, msg: ControlMessage) {
         let sender = self.inner.render_channel.read().unwrap();
         *self.inner.suspended_messages.lock().unwrap() = Some(Vec::new());
-        if sender.send(msg).is_err() {
-            log::warn!("Discarding control message - render thread is closed");
-        }
+        // Same as send_control_msg: this path must not hang either. Routing
+        // through the same function keeps a single FIFO, which preserves
+        // ordering with any messages already queued.
+        self.send_to_render_thread(&sender, msg);
     }
 
     pub(crate) fn resume_control_msgs(&self, msg: ControlMessage) {
@@ -308,15 +439,10 @@ impl ConcreteBaseAudioContext {
             .unwrap_or_default();
 
         for msg in messages {
-            if sender.send(msg).is_err() {
-                log::warn!("Discarding control message - render thread is closed");
-                return;
-            }
+            self.send_to_render_thread(&sender, msg);
         }
 
-        if sender.send(msg).is_err() {
-            log::warn!("Discarding control message - render thread is closed");
-        }
+        self.send_to_render_thread(&sender, msg);
     }
 
     pub(crate) fn send_event(&self, msg: EventDispatch) -> Result<(), SendError<EventDispatch>> {

--- a/src/context/concrete_base.rs
+++ b/src/context/concrete_base.rs
@@ -623,11 +623,25 @@ impl ConcreteBaseAudioContext {
 
     /// Connects the output of the `from` audio node to the input of the `to` audio node
     pub(crate) fn connect(&self, from: AudioNodeId, to: AudioNodeId, output: usize, input: usize) {
-        self.inner
+        // The connections set is the authoritative list of established
+        // connections, but the ConnectNode message used to be sent
+        // unconditionally. Graph::add_edge on the render thread is a plain
+        // Vec::push, so a repeated connect() with identical termini created a
+        // duplicate render edge and the destination summed the source twice
+        // (audibly louder, and N-fold after N calls). The spec requires the
+        // repeat call to be a no-op: "There can only be one connection between
+        // a given output of one specific node and a given input of another
+        // specific node. Multiple connections with the same termini are
+        // ignored."
+        let inserted = self
+            .inner
             .connections
             .lock()
             .unwrap()
             .insert((from, output, to, input));
+        if !inserted {
+            return;
+        }
         let message = ControlMessage::ConnectNode {
             from,
             to,

--- a/src/context/concrete_base.rs
+++ b/src/context/concrete_base.rs
@@ -419,6 +419,62 @@ impl ConcreteBaseAudioContext {
         }
     }
 
+    /// Same liveness rule as `wait_for_render_thread`, for protocol steps that
+    /// expect a payload back from the render thread - currently the audio
+    /// graph handed back during a sink change (`CloseAndRecycle`).
+    ///
+    /// `set_sink_id_sync` used a bare `graph_recv.recv().unwrap()`. With the
+    /// render thread stalled (device unplugged, driver dead - cpal only calls
+    /// err_fn and stops issuing callbacks) the graph never arrives and the
+    /// control thread blocks forever; "output device disappeared, application
+    /// switches to another sink" is precisely the sequence that hits this.
+    ///
+    /// Returns `None` when the render thread is deemed gone: zero playhead
+    /// progress across `STALL_GRACE`, or the reply channel disconnected
+    /// without a payload. The context is marked Closed in both cases - the
+    /// graph is unrecoverable at that point, so no later operation could
+    /// succeed anyway.
+    pub(crate) fn recv_from_render_thread<T>(&self, receiver: &Receiver<T>) -> Option<T> {
+        const POLL: Duration = Duration::from_millis(50);
+        const STALL_GRACE: Duration = Duration::from_secs(2);
+
+        let mut last_frames = self.inner.frames_played.load(Ordering::Relaxed);
+        let mut stalled = Duration::ZERO;
+
+        loop {
+            match receiver.recv_timeout(POLL) {
+                Ok(v) => return Some(v),
+                Err(RecvTimeoutError::Disconnected) => {
+                    log::error!(
+                        "Render thread dropped the reply channel without responding - closing \
+                         the AudioContext"
+                    );
+                    self.set_state(AudioContextState::Closed);
+                    return None;
+                }
+                Err(RecvTimeoutError::Timeout) => {
+                    let frames = self.inner.frames_played.load(Ordering::Relaxed);
+                    if frames != last_frames {
+                        last_frames = frames;
+                        stalled = Duration::ZERO;
+                        continue;
+                    }
+                    stalled += POLL;
+                    if stalled < STALL_GRACE {
+                        continue;
+                    }
+                    log::error!(
+                        "Render thread did not respond within {:?} - assuming the audio device \
+                         is gone, closing the AudioContext",
+                        STALL_GRACE
+                    );
+                    self.set_state(AudioContextState::Closed);
+                    return None;
+                }
+            }
+        }
+    }
+
     pub(crate) fn suspend_control_msgs(&self, msg: ControlMessage) {
         let sender = self.inner.render_channel.read().unwrap();
         *self.inner.suspended_messages.lock().unwrap() = Some(Vec::new());

--- a/src/context/offline.rs
+++ b/src/context/offline.rs
@@ -1,6 +1,6 @@
 //! The `OfflineAudioContext` type
 
-use std::sync::atomic::{AtomicU64, AtomicU8};
+use std::sync::atomic::{AtomicU64, AtomicU8, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use crate::buffer::AudioBuffer;
@@ -35,6 +35,33 @@ pub struct OfflineAudioContext {
     renderer: Mutex<Option<OfflineAudioContextRenderer>>,
     /// channel to notify resume actions on the rendering
     resume_sender: mpsc::Sender<()>,
+    /// Incremental rendering state (embedders' drive model; see
+    /// [`Self::render_upto_sync`])
+    incremental: Mutex<Option<IncrementalRender>>,
+    /// Finished incremental render, waiting to be taken by
+    /// [`Self::take_rendered_sync`]
+    rendered: Mutex<Option<AudioBuffer>>,
+    /// Number of frames rendered so far. This must be a lock-free atomic and
+    /// not derived from `incremental`: the early-return paths of
+    /// `render_upto_sync` report the frame count *while holding* the
+    /// `incremental` MutexGuard, and a std Mutex is not re-entrant, so reading
+    /// the count through the mutex from there would self-deadlock the calling
+    /// thread (both sequences are legal: render to the end, take the result,
+    /// call render_upto_sync again; or start_rendering_sync followed by
+    /// render_upto_sync). With an atomic, that deadlock path does not exist by
+    /// construction. It also fixes a semantic wart: after the result has been
+    /// taken, both `incremental` and `rendered` are None and the count would
+    /// otherwise read as 0 instead of `length`.
+    rendered_frames: AtomicUsize,
+}
+
+/// Cross-call state of an incremental offline render.
+struct IncrementalRender {
+    renderer: crate::render::RenderThread,
+    buffer: Vec<Vec<f32>>,
+    /// Number of render quanta produced so far
+    quantum: usize,
+    event_loop: crate::events::EventLoop,
 }
 
 impl std::fmt::Debug for OfflineAudioContext {
@@ -139,6 +166,9 @@ impl OfflineAudioContext {
             length,
             renderer: Mutex::new(Some(renderer)),
             resume_sender,
+            incremental: Mutex::new(None),
+            rendered: Mutex::new(None),
+            rendered_frames: AtomicUsize::new(0),
         }
     }
 
@@ -153,6 +183,130 @@ impl OfflineAudioContext {
     /// # Panics
     ///
     /// Panics if this method is called multiple times
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Incremental offline rendering (for embedders)
+    //
+    // start_rendering_sync renders the whole buffer in one call and consumes
+    // the renderer, and suspend points must all be registered before rendering
+    // starts (suspending after the renderer has been taken panics). Embedders
+    // hosting a JavaScript engine drive rendering incrementally instead:
+    // render up to a suspend point, hand control back to script (which mutates
+    // the graph inside the suspend promise callback), resume, render the next
+    // segment. The three methods below provide that capability; they are
+    // mutually exclusive with suspend/suspend_sync.
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// Renders up to `upto_frame` (exclusive; rounded up to whole render
+    /// quanta; >= length renders to the end). May be called repeatedly to
+    /// continue. Returns the total number of rendered frames. When the end is
+    /// reached the result is stored and can be taken once through
+    /// [`Self::take_rendered_sync`].
+    ///
+    /// Calling after the render has finished (result stored or already taken)
+    /// or after `start_rendering*` has claimed the renderer is a no-op that
+    /// returns the current frame count. Those early returns run while the
+    /// `incremental` lock is held, which is why the frame count lives in a
+    /// lock-free atomic (see the `rendered_frames` field comment).
+    pub fn render_upto_sync(&mut self, upto_frame: usize) -> usize {
+        let length = self.length;
+        let num_quanta = length.div_ceil(RENDER_QUANTUM_SIZE);
+
+        let mut inc_guard = self.incremental.lock().unwrap();
+        if inc_guard.is_none() {
+            // First call: claim the renderer (mutually exclusive with
+            // start_rendering_sync - both take() it).
+            let Some(r) = self.renderer.lock().unwrap().take() else {
+                // Already finished or claimed by start_rendering* - no-op.
+                // Note: inc_guard is still held here, so only the lock-free
+                // rendered_frames may be read.
+                return self.rendered_frames_sync();
+            };
+            let mut buffer = Vec::with_capacity(r.renderer.output_channels());
+            buffer.resize_with(buffer.capacity(), || Vec::with_capacity(length));
+            *inc_guard = Some(IncrementalRender {
+                renderer: r.renderer,
+                buffer,
+                quantum: 0,
+                event_loop: r.event_loop,
+            });
+        }
+
+        let Some(inc) = inc_guard.as_mut() else {
+            // As above: `incremental` must not be locked again from here.
+            return self.rendered_frames_sync();
+        };
+
+        // A segment is being rendered - Running (the previous segment may have
+        // parked the state at Suspended, see the end of this function).
+        self.base.set_state(AudioContextState::Running);
+
+        let target_q = if upto_frame >= length {
+            num_quanta
+        } else {
+            upto_frame.div_ceil(RENDER_QUANTUM_SIZE).min(num_quanta)
+        };
+        if target_q > inc.quantum {
+            let n = target_q - inc.quantum;
+            let ev = inc.event_loop.clone();
+            inc.renderer.render_offline_quanta(&mut inc.buffer, n, &ev);
+            inc.quantum = target_q;
+        }
+
+        let done = inc.quantum >= num_quanta;
+        let frames = (inc.quantum * RENDER_QUANTUM_SIZE).min(length);
+        self.rendered_frames.store(frames, Ordering::Release);
+
+        if done {
+            // Rendered to the end: finalize and store the result.
+            // finish_offline_render consumes the RenderThread (unload_graph
+            // takes self by value), so the whole IncrementalRender is taken out
+            // and destructured.
+            let owned = inc_guard.take().expect("just checked");
+            drop(inc_guard);
+            let IncrementalRender {
+                renderer,
+                mut buffer,
+                event_loop,
+                ..
+            } = owned;
+            renderer.finish_offline_render(&event_loop);
+            for ch in buffer.iter_mut() {
+                ch.truncate(length); // the last quantum may overshoot `length`
+            }
+            let result = AudioBuffer::from(buffer, self.base.sample_rate());
+            *self.rendered.lock().unwrap() = Some(result.clone());
+            self.base.set_state(AudioContextState::Closed);
+            let _ = self.base.send_event(EventDispatch::complete(result));
+            // Spin the event loop once more after finalizing: the
+            // complete/statechange events are only queued after
+            // finish_offline_render, past the last spin inside it. Without this
+            // extra spin the crate-side oncomplete/onstatechange handlers would
+            // never fire. Matches the tail of start_rendering_sync.
+            event_loop.handle_pending_events();
+        } else {
+            // Parked at a suspend point: per the spec, an OfflineAudioContext
+            // must report "suspended" while parked (leaving it at Running lets
+            // script observe "running" from inside the suspend callback).
+            self.base.set_state(AudioContextState::Suspended);
+        }
+        frames
+    }
+
+    /// Number of frames rendered so far (currentTime = frames / sampleRate).
+    /// Lock-free (see the `rendered_frames` field comment).
+    #[must_use]
+    pub fn rendered_frames_sync(&self) -> usize {
+        self.rendered_frames.load(Ordering::Acquire)
+    }
+
+    /// Takes the finished result after rendering reached the end (None if the
+    /// render is unfinished or the result was already taken).
+    #[must_use]
+    pub fn take_rendered_sync(&mut self) -> Option<AudioBuffer> {
+        self.rendered.lock().unwrap().take()
+    }
+
     #[must_use]
     pub fn start_rendering_sync(&mut self) -> AudioBuffer {
         let renderer = self
@@ -649,5 +803,65 @@ mod tests {
         require_send_sync(context.start_rendering());
         require_send_sync(context.suspend(1.));
         require_send_sync(context.resume());
+    }
+}
+
+#[cfg(test)]
+mod incremental_render_tests {
+    use float_eq::assert_float_eq;
+
+    use super::*;
+    use crate::node::{AudioNode, AudioScheduledSourceNode};
+
+    fn build_graph(context: &mut OfflineAudioContext) {
+        let mut osc = context.create_oscillator();
+        osc.frequency().set_value(440.);
+        osc.connect(&context.destination());
+        osc.start();
+    }
+
+    #[test]
+    fn test_chunked_render_equals_one_shot() {
+        // Rendering in arbitrary increments must produce the exact same samples
+        // as a single start_rendering_sync pass over an identical graph.
+        let length = 1000; // deliberately not a multiple of the quantum size
+
+        let mut reference = OfflineAudioContext::new(1, length, 48000.);
+        build_graph(&mut reference);
+        let expected = reference.start_rendering_sync();
+
+        let mut chunked = OfflineAudioContext::new(1, length, 48000.);
+        build_graph(&mut chunked);
+        assert_eq!(chunked.render_upto_sync(100), 128); // rounded up to quanta
+        assert_eq!(chunked.state(), AudioContextState::Suspended);
+        assert_eq!(chunked.render_upto_sync(600), 640);
+        let frames = chunked.render_upto_sync(usize::MAX);
+        assert_eq!(frames, length);
+        assert_eq!(chunked.state(), AudioContextState::Closed);
+
+        let result = chunked.take_rendered_sync().expect("render finished");
+        assert_float_eq!(
+            result.get_channel_data(0),
+            expected.get_channel_data(0),
+            abs_all <= 0.
+        );
+
+        // The result can only be taken once; afterwards the frame count keeps
+        // reporting the full length and further render calls are no-ops (this
+        // sequence used to self-deadlock when the frame count was derived from
+        // the incremental state under its own mutex).
+        assert!(chunked.take_rendered_sync().is_none());
+        assert_eq!(chunked.render_upto_sync(usize::MAX), length);
+        assert_eq!(chunked.rendered_frames_sync(), length);
+    }
+
+    #[test]
+    fn test_render_upto_after_start_rendering_is_noop() {
+        // start_rendering_sync claims the renderer; a later incremental call
+        // must not panic or deadlock, just report the current frame count.
+        let mut context = OfflineAudioContext::new(1, 256, 48000.);
+        build_graph(&mut context);
+        let _ = context.start_rendering_sync();
+        let _ = context.render_upto_sync(usize::MAX);
     }
 }

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -684,7 +684,15 @@ impl AudioContext {
         // Wait for the render thread to have processed the suspend message.
         // The AudioContextState will be updated by the render thread.
         log::debug!("Suspending audio graph, waiting for signal..");
-        receiver.recv().ok();
+        // Liveness wait (see ConcreteBaseAudioContext::wait_for_render_thread):
+        // with the render thread stalled the notify never arrives and a bare
+        // recv() would block the control thread forever.
+        if !self.base.wait_for_render_thread(&receiver) {
+            // The render side is dead and the context has been marked Closed;
+            // do not touch a device that no longer exists (backend.suspend()
+            // would fail).
+            return;
+        }
 
         // Then ask the audio host to suspend the stream
         log::debug!("Suspended audio graph. Suspending audio stream..");
@@ -731,7 +739,11 @@ impl AudioContext {
 
         // Wait for the render thread to have processed the resume message
         // The AudioContextState will be updated by the render thread.
-        receiver.recv().ok();
+        // Liveness wait - same reasoning as in suspend_sync (a stalled render
+        // thread never sends the notify and a bare recv() hangs).
+        if !self.base.wait_for_render_thread(&receiver) {
+            return; // render side is dead - the context is Closed now
+        }
         log::debug!("Resumed audio graph");
     }
 
@@ -768,7 +780,12 @@ impl AudioContext {
             // Wait for the render thread to have processed the suspend message.
             // The AudioContextState will be updated by the render thread.
             log::debug!("Suspending audio graph, waiting for signal..");
-            receiver.recv().ok();
+            // Liveness wait - the notify never arrives when the render thread
+            // is stalled, and close() is exactly the API an application calls
+            // right after a device disappears. On a stall the wait marks the
+            // context Closed; execution then continues below to shut down the
+            // audio stream and release device resources (no early return).
+            self.base.wait_for_render_thread(&receiver);
         } else {
             // if the context is not running, change the state manually
             self.base.set_state(AudioContextState::Closed);
@@ -1007,5 +1024,39 @@ mod tests {
             .any(|node| node.id == DESTINATION_NODE_ID.0
                 && node.inputs == node.input_channels.len()
                 && node.outputs == node.output_channels.len()));
+    }
+}
+
+#[cfg(test)]
+mod render_stall_tests {
+    use super::*;
+    use crate::node::AudioNode;
+
+    #[test]
+    fn test_stall_detector_does_not_misfire_on_suspended_context() {
+        // Guard against false positives of the liveness-based stall detection:
+        // a suspended context keeps draining its control channel even though
+        // the playhead does not advance, so flooding it with far more messages
+        // than the channel capacity (256) must neither block the control
+        // thread nor close the context. (The stall direction itself - a device
+        // that disappeared, taking the draining render callback with it -
+        // cannot be simulated deterministically without hardware; see the
+        // commit message for the manual reproduction.)
+        let options = AudioContextOptions {
+            sink_id: "none".into(),
+            ..AudioContextOptions::default()
+        };
+        let context = AudioContext::new(options);
+        context.suspend_sync();
+
+        let gain = context.create_gain();
+        for i in 0..2000 {
+            gain.gain().set_value(i as f32);
+        }
+
+        assert_eq!(context.state(), AudioContextState::Suspended);
+        context.resume_sync();
+        assert_eq!(context.state(), AudioContextState::Running);
+        let _ = context.close_sync();
     }
 }

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -411,7 +411,20 @@ impl AudioContext {
                 // No new audio will be produced because it will receive the shutdown command first.
                 backend_manager_guard.resume()?;
             }
-            graph_recv.recv().unwrap()
+            // Do not block indefinitely: with the render thread stalled (device
+            // unplugged / driver dead) the graph never comes back and a bare
+            // recv() hangs the control thread forever. The liveness wait marks
+            // the context Closed when the render side is deemed gone.
+            match self.base.recv_from_render_thread(&graph_recv) {
+                Some(graph) => graph,
+                None => {
+                    return Err(
+                        "InvalidStateError - the render thread is unresponsive, the AudioContext \
+                         has been closed"
+                            .into(),
+                    );
+                }
+            }
         };
 
         log::debug!("SinkChange: closing audio stream");

--- a/src/io/cpal.rs
+++ b/src/io/cpal.rs
@@ -1,5 +1,5 @@
 //! Audio IO management API
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -190,6 +190,12 @@ fn stable_device_id(
 #[allow(unused)]
 pub(crate) struct CpalBackend {
     stream: Arc<Mutex<Option<Stream>>>,
+    // ALSA's snd_pcm_pause is an optional hardware feature (dmix, the null
+    // device and many plug devices report errno 77). When the native pause
+    // fails, suspension falls back to this flag: the output callback emits
+    // silence and does not invoke the renderer, so the rendering clock stops -
+    // semantically equivalent to a paused stream. resume() clears the flag.
+    suspended: Arc<AtomicBool>,
     output_latency: Arc<AtomicF64>,
     sample_rate: f32,
     number_of_channels: usize,
@@ -315,6 +321,7 @@ impl AudioBackendManager for CpalBackend {
             &preferred_config
         );
 
+        let suspended = Arc::new(AtomicBool::new(false));
         let spawned = spawn_output_stream(
             &device,
             default_device_config.sample_format(),
@@ -322,6 +329,7 @@ impl AudioBackendManager for CpalBackend {
             renderer,
             Arc::clone(&output_latency),
             stats.clone(),
+            Arc::clone(&suspended),
         );
 
         let stream = match spawned {
@@ -362,6 +370,7 @@ impl AudioBackendManager for CpalBackend {
                     renderer,
                     Arc::clone(&output_latency),
                     stats.clone(),
+                    Arc::clone(&suspended),
                 );
 
                 spawned.map_err(|e| map_cpal_error("build_fallback_output_stream", e))?
@@ -379,6 +388,7 @@ impl AudioBackendManager for CpalBackend {
             sample_rate,
             number_of_channels,
             sink_id: options.sink_id,
+            suspended,
         })
     }
 
@@ -513,17 +523,30 @@ impl AudioBackendManager for CpalBackend {
             sample_rate,
             number_of_channels,
             sink_id: options.sink_id,
+            // Input streams do not use flag suspension.
+            suspended: Arc::new(AtomicBool::new(false)),
         };
 
         Ok((backend, receiver))
     }
 
     fn resume(&self) -> BackendResult<bool> {
+        // Clear the silence flag first (devices without native pause support
+        // are suspended through it), then try to play() for devices that were
+        // natively paused.
+        let was_flag = self.suspended.swap(false, Ordering::Relaxed);
         if let Some(s) = self.stream.lock().unwrap().as_ref() {
-            s.play()
-                .map(|_| true)
-                .map_err(|e| map_cpal_error("resume", e))?;
-            return Ok(true);
+            match s.play() {
+                Ok(()) => return Ok(true),
+                Err(e) => {
+                    if was_flag {
+                        // Flag-suspended device: the stream never stopped, a
+                        // play() failure is inconsequential.
+                        return Ok(true);
+                    }
+                    return Err(map_cpal_error("resume", e));
+                }
+            }
         }
 
         Ok(false)
@@ -531,10 +554,16 @@ impl AudioBackendManager for CpalBackend {
 
     fn suspend(&self) -> BackendResult<bool> {
         if let Some(s) = self.stream.lock().unwrap().as_ref() {
-            s.pause()
-                .map(|_| true)
-                .map_err(|e| map_cpal_error("suspend", e))?;
-            return Ok(true);
+            match s.pause() {
+                Ok(()) => return Ok(true),
+                Err(_) => {
+                    // Native pause unavailable (ALSA errno 77 and friends):
+                    // fall back to the silence flag, which stops the output
+                    // callback from advancing the rendering clock.
+                    self.suspended.store(true, Ordering::Relaxed);
+                    return Ok(true);
+                }
+            }
         }
 
         Ok(false)
@@ -645,6 +674,9 @@ fn spawn_output_stream(
     mut render: RenderThread,
     output_latency: Arc<AtomicF64>,
     stats: AudioStats,
+    // Silence-flag suspension for devices without native pause support (see
+    // CpalBackend::suspend).
+    suspended: Arc<AtomicBool>,
 ) -> Result<Stream, CpalError> {
     let err_fn = |err| log::error!("an error occurred on the output audio stream: {}", err);
 
@@ -652,6 +684,11 @@ fn spawn_output_stream(
         SampleFormat::F32 => device.build_output_stream(
             config,
             move |d: &mut [f32], i: &OutputCallbackInfo| {
+                if suspended.load(Ordering::Relaxed) {
+                    // Suspended: emit silence without advancing the renderer.
+                    d.fill(cpal::Sample::EQUILIBRIUM);
+                    return;
+                }
                 render.render(d);
                 let latency = latency_in_seconds(i);
                 output_latency.store(latency, Ordering::Relaxed);
@@ -663,6 +700,11 @@ fn spawn_output_stream(
         SampleFormat::F64 => device.build_output_stream(
             config,
             move |d: &mut [f64], i: &OutputCallbackInfo| {
+                if suspended.load(Ordering::Relaxed) {
+                    // Suspended: emit silence without advancing the renderer.
+                    d.fill(cpal::Sample::EQUILIBRIUM);
+                    return;
+                }
                 render.render(d);
                 let latency = latency_in_seconds(i);
                 output_latency.store(latency, Ordering::Relaxed);
@@ -674,6 +716,11 @@ fn spawn_output_stream(
         SampleFormat::U8 => device.build_output_stream(
             config,
             move |d: &mut [u8], i: &OutputCallbackInfo| {
+                if suspended.load(Ordering::Relaxed) {
+                    // Suspended: emit silence without advancing the renderer.
+                    d.fill(cpal::Sample::EQUILIBRIUM);
+                    return;
+                }
                 render.render(d);
                 let latency = latency_in_seconds(i);
                 output_latency.store(latency, Ordering::Relaxed);
@@ -685,6 +732,11 @@ fn spawn_output_stream(
         SampleFormat::U16 => device.build_output_stream(
             config,
             move |d: &mut [u16], i: &OutputCallbackInfo| {
+                if suspended.load(Ordering::Relaxed) {
+                    // Suspended: emit silence without advancing the renderer.
+                    d.fill(cpal::Sample::EQUILIBRIUM);
+                    return;
+                }
                 render.render(d);
                 let latency = latency_in_seconds(i);
                 output_latency.store(latency, Ordering::Relaxed);
@@ -696,6 +748,11 @@ fn spawn_output_stream(
         SampleFormat::U32 => device.build_output_stream(
             config,
             move |d: &mut [u32], i: &OutputCallbackInfo| {
+                if suspended.load(Ordering::Relaxed) {
+                    // Suspended: emit silence without advancing the renderer.
+                    d.fill(cpal::Sample::EQUILIBRIUM);
+                    return;
+                }
                 render.render(d);
                 let latency = latency_in_seconds(i);
                 output_latency.store(latency, Ordering::Relaxed);
@@ -707,6 +764,11 @@ fn spawn_output_stream(
         SampleFormat::U64 => device.build_output_stream(
             config,
             move |d: &mut [u64], i: &OutputCallbackInfo| {
+                if suspended.load(Ordering::Relaxed) {
+                    // Suspended: emit silence without advancing the renderer.
+                    d.fill(cpal::Sample::EQUILIBRIUM);
+                    return;
+                }
                 render.render(d);
                 let latency = latency_in_seconds(i);
                 output_latency.store(latency, Ordering::Relaxed);
@@ -718,6 +780,11 @@ fn spawn_output_stream(
         SampleFormat::I8 => device.build_output_stream(
             config,
             move |d: &mut [i8], i: &OutputCallbackInfo| {
+                if suspended.load(Ordering::Relaxed) {
+                    // Suspended: emit silence without advancing the renderer.
+                    d.fill(cpal::Sample::EQUILIBRIUM);
+                    return;
+                }
                 render.render(d);
                 let latency = latency_in_seconds(i);
                 output_latency.store(latency, Ordering::Relaxed);
@@ -729,6 +796,11 @@ fn spawn_output_stream(
         SampleFormat::I16 => device.build_output_stream(
             config,
             move |d: &mut [i16], i: &OutputCallbackInfo| {
+                if suspended.load(Ordering::Relaxed) {
+                    // Suspended: emit silence without advancing the renderer.
+                    d.fill(cpal::Sample::EQUILIBRIUM);
+                    return;
+                }
                 render.render(d);
                 let latency = latency_in_seconds(i);
                 output_latency.store(latency, Ordering::Relaxed);
@@ -740,6 +812,11 @@ fn spawn_output_stream(
         SampleFormat::I32 => device.build_output_stream(
             config,
             move |d: &mut [i32], i: &OutputCallbackInfo| {
+                if suspended.load(Ordering::Relaxed) {
+                    // Suspended: emit silence without advancing the renderer.
+                    d.fill(cpal::Sample::EQUILIBRIUM);
+                    return;
+                }
                 render.render(d);
                 let latency = latency_in_seconds(i);
                 output_latency.store(latency, Ordering::Relaxed);
@@ -751,6 +828,11 @@ fn spawn_output_stream(
         SampleFormat::I64 => device.build_output_stream(
             config,
             move |d: &mut [i64], i: &OutputCallbackInfo| {
+                if suspended.load(Ordering::Relaxed) {
+                    // Suspended: emit silence without advancing the renderer.
+                    d.fill(cpal::Sample::EQUILIBRIUM);
+                    return;
+                }
                 render.render(d);
                 let latency = latency_in_seconds(i);
                 output_latency.store(latency, Ordering::Relaxed);
@@ -811,5 +893,44 @@ fn spawn_input_stream(
             device.build_input_stream(config, move |d: &[i64], _c| render.render(d), err_fn, None)
         }
         _ => Err(CpalErrorKind::UnsupportedConfig.into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::context::{AudioContext, AudioContextOptions, BaseAudioContext};
+
+    #[test]
+    fn test_suspend_resume_on_real_device() {
+        // suspend()/resume() must work on the default output device even when
+        // it does not support native pausing (ALSA's snd_pcm_pause is an
+        // optional feature; dmix, the null device and many plug devices return
+        // errno 77). Before the silence-flag fallback this errored out, and -
+        // worse - the failure path inside set_sink_id_sync() poisoned the
+        // backend manager mutex, bricking the context.
+        //
+        // The test needs an actual output device; skip silently when none is
+        // available (e.g. headless CI).
+        let context = match AudioContext::try_new(AudioContextOptions::default()) {
+            Ok(context) => context,
+            Err(_) => return,
+        };
+
+        context.suspend_sync();
+        let t1 = context.current_time();
+        std::thread::sleep(std::time::Duration::from_millis(150));
+        let t2 = context.current_time();
+        // The rendering clock must stop while suspended.
+        assert!(
+            (t2 - t1).abs() < 1e-9,
+            "clock advanced while suspended: {t1} -> {t2}"
+        );
+
+        context.resume_sync();
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        let t3 = context.current_time();
+        assert!(t3 > t2, "clock did not resume: {t2} -> {t3}");
+
+        let _ = context.close_sync();
     }
 }

--- a/src/media_streams/mod.rs
+++ b/src/media_streams/mod.rs
@@ -249,3 +249,78 @@ mod tests {
         assert!(iter.next().is_none());
     }
 }
+
+#[cfg(test)]
+mod loopback_tests {
+    use crate::context::{AudioContext, AudioContextOptions, BaseAudioContext};
+    use crate::node::AudioNode;
+    use crate::node::AudioScheduledSourceNode;
+
+    #[test]
+    fn test_same_context_loopback_does_not_deadlock() {
+        // Loopback within one context: dest.stream -> create_media_stream_source.
+        // AudioDestinationNodeStream::next used a blocking recv(); in any
+        // quantum where the source node is ordered before the destination node
+        // the render thread waits for data that only it can produce, and
+        // rendering deadlocks (currentTime freezes). With try_recv plus
+        // underrun silence the iterator never blocks.
+        let options = AudioContextOptions {
+            sink_id: "none".into(),
+            ..AudioContextOptions::default()
+        };
+        let context = AudioContext::new(options);
+
+        let dest = context.create_media_stream_destination();
+        let mut osc = context.create_oscillator();
+        osc.connect(&dest);
+        osc.start();
+        let src = context.create_media_stream_source(dest.stream());
+        src.connect(&context.destination());
+
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        let t = context.current_time();
+        assert!(
+            t > 0.2,
+            "render thread deadlocked: currentTime = {t} after 500ms"
+        );
+    }
+
+    #[test]
+    fn test_cross_rate_stream_consumption_does_not_panic() {
+        // Consuming a MediaStream in a context running at a different sample
+        // rate sends the chunks through the Resampler, which stitches adjacent
+        // chunks with AudioBuffer::extend. extend() asserts equal channel
+        // counts, so underrun silence emitted with a channel count different
+        // from the real data panics the consumer's render thread (its clock
+        // then freezes while the producer keeps running).
+        let mk = |rate: f32| {
+            AudioContext::new(AudioContextOptions {
+                sink_id: "none".into(),
+                sample_rate: Some(rate),
+                ..AudioContextOptions::default()
+            })
+        };
+        let producer = mk(48000.);
+        let consumer = mk(44100.);
+
+        let dest = producer.create_media_stream_destination();
+        let mut osc = producer.create_oscillator();
+        osc.connect(&dest);
+        osc.start();
+
+        let src = consumer.create_media_stream_source(dest.stream());
+        src.connect(&consumer.destination());
+
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        assert!(
+            producer.current_time() > 0.2,
+            "producer stalled: {}",
+            producer.current_time()
+        );
+        assert!(
+            consumer.current_time() > 0.2,
+            "consumer render thread died (channel count mismatch panic): {}",
+            consumer.current_time()
+        );
+    }
+}

--- a/src/node/audio_buffer_source.rs
+++ b/src/node/audio_buffer_source.rs
@@ -151,7 +151,10 @@ impl AudioScheduledSourceNode for AudioBufferSourceNode {
 
     fn stop_at(&mut self, when: f64) {
         assert_valid_time_value(when);
-        assert!(self.has_start, "InvalidStateError cannot stop before start");
+        assert!(
+            self.has_start,
+            "InvalidStateError - cannot stop before start"
+        );
 
         self.registration.post_message(ControlMessage::Stop(when));
     }
@@ -2068,5 +2071,16 @@ mod tests {
 
         assert_float_eq!(channel[..], expected[..], abs_all <= 0.);
         assert!(onended_called.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    #[should_panic(expected = "InvalidStateError - cannot stop before start")]
+    fn stop_before_start_panics_with_parseable_message() {
+        // Embedders map panic messages of the form "<DOMException name> - <detail>"
+        // back to the corresponding DOMException. This message lacked the " - "
+        // separator and would be misclassified as a generic error.
+        let context = OfflineAudioContext::new(1, 128, 48000.);
+        let mut src = context.create_buffer_source();
+        src.stop();
     }
 }

--- a/src/node/constant_source.rs
+++ b/src/node/constant_source.rs
@@ -122,7 +122,10 @@ impl AudioScheduledSourceNode for ConstantSourceNode {
 
     fn stop_at(&mut self, when: f64) {
         assert_valid_time_value(when);
-        assert!(self.has_start, "InvalidStateError cannot stop before start");
+        assert!(
+            self.has_start,
+            "InvalidStateError - cannot stop before start"
+        );
 
         self.registration.post_message(Schedule::Stop(when));
     }
@@ -371,5 +374,16 @@ mod tests {
 
         assert_float_eq!(channel[0..258], vec![0.; 258][..], abs_all <= 0.);
         assert_float_eq!(channel[258..], vec![1.; 254][..], abs_all <= 0.);
+    }
+
+    #[test]
+    #[should_panic(expected = "InvalidStateError - cannot stop before start")]
+    fn stop_before_start_panics_with_parseable_message() {
+        // Embedders map panic messages of the form "<DOMException name> - <detail>"
+        // back to the corresponding DOMException. This message lacked the " - "
+        // separator and would be misclassified as a generic error.
+        let context = OfflineAudioContext::new(1, 128, 48000.);
+        let mut src = context.create_constant_source();
+        src.stop();
     }
 }

--- a/src/node/media_stream_destination.rs
+++ b/src/node/media_stream_destination.rs
@@ -83,11 +83,15 @@ impl AudioNode for MediaStreamAudioDestinationNode {
 impl MediaStreamAudioDestinationNode {
     /// Create a new MediaStreamAudioDestinationNode
     pub fn new<C: BaseAudioContext>(context: &C, options: AudioNodeOptions) -> Self {
+        let sample_rate = context.sample_rate();
+        let silence_channels = options.channel_count;
         context.base().register(move |registration| {
             let (send, recv) = crossbeam_channel::bounded(1);
 
             let iter = AudioDestinationNodeStream {
                 receiver: recv.clone(),
+                sample_rate,
+                channels: silence_channels,
             };
             let track = MediaStreamTrack::from_iter(iter);
             let stream = MediaStream::from_tracks(vec![track]);
@@ -145,14 +149,38 @@ impl AudioProcessor for DestinationRenderer {
 
 struct AudioDestinationNodeStream {
     receiver: Receiver<AudioBuffer>,
+    sample_rate: f32,
+    /// Channel count for underrun silence: starts at the node's channel_count
+    /// and then follows the most recent real buffer. Consumers (the Resampler
+    /// on cross-sample-rate paths) stitch buffers with AudioBuffer::extend,
+    /// whose assert requires adjacent chunks to have equal channel counts - a
+    /// drifting silence channel count panics the render thread.
+    channels: usize,
 }
 
 impl Iterator for AudioDestinationNodeStream {
     type Item = Result<AudioBuffer, Box<dyn Error + Send + Sync>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        match self.receiver.recv() {
-            Ok(buf) => Some(Ok(buf)),
+        // This iterator must never block. When the stream is consumed by a
+        // MediaStreamAudioSourceNode living in the *same* context (a loopback:
+        // dest.stream -> createMediaStreamSource), it is pulled from the render
+        // thread itself. A blocking recv() then deadlocks the render thread in
+        // any quantum where the source node is ordered before the destination
+        // node - the thread waits for data that only it can produce, and
+        // currentTime freezes. try_recv instead: on Empty emit one quantum of
+        // silence (initial block / underrun; a source ordered first simply sees
+        // one quantum of latency), on data pass it through, and a disconnected
+        // channel still reports the error so the source node stops.
+        match self.receiver.try_recv() {
+            Ok(buf) => {
+                self.channels = buf.number_of_channels();
+                Some(Ok(buf))
+            }
+            Err(crossbeam_channel::TryRecvError::Empty) => Some(Ok(AudioBuffer::from(
+                vec![vec![0.; crate::RENDER_QUANTUM_SIZE]; self.channels.max(1)],
+                self.sample_rate,
+            ))),
             Err(e) => Some(Err(Box::new(e))),
         }
     }

--- a/src/node/oscillator.rs
+++ b/src/node/oscillator.rs
@@ -194,7 +194,10 @@ impl AudioScheduledSourceNode for OscillatorNode {
 
     fn stop_at(&mut self, when: f64) {
         assert_valid_time_value(when);
-        assert!(self.has_start, "InvalidStateError cannot stop before start");
+        assert!(
+            self.has_start,
+            "InvalidStateError - cannot stop before start"
+        );
 
         self.registration.post_message(Schedule::Stop(when));
     }
@@ -1452,5 +1455,16 @@ mod tests {
         }
 
         assert_float_eq!(result[..], expected[..], abs_all <= 1e-5);
+    }
+
+    #[test]
+    #[should_panic(expected = "InvalidStateError - cannot stop before start")]
+    fn stop_before_start_panics_with_parseable_message() {
+        // Embedders map panic messages of the form "<DOMException name> - <detail>"
+        // back to the corresponding DOMException. This message lacked the " - "
+        // separator and would be misclassified as a generic error.
+        let context = OfflineAudioContext::new(1, 128, 48000.);
+        let mut src = context.create_oscillator();
+        src.stop();
     }
 }

--- a/src/node/panner.rs
+++ b/src/node/panner.rs
@@ -831,7 +831,13 @@ impl AudioProcessor for PannerRenderer {
             // EqualPower panning
 
             // Optimize for static Panner & Listener
-            let single_valued = listener_position_x.len() == 1
+            let single_valued = source_position_x.len() == 1
+                && source_position_y.len() == 1
+                && source_position_z.len() == 1
+                && source_orientation_x.len() == 1
+                && source_orientation_y.len() == 1
+                && source_orientation_z.len() == 1
+                && listener_position_x.len() == 1
                 && listener_position_y.len() == 1
                 && listener_position_z.len() == 1
                 && listener_forward_x.len() == 1
@@ -1266,5 +1272,50 @@ mod tests {
 
         let right = output.channel_data(1).as_slice();
         assert!(right[128..256].iter().any(|v| *v >= 1E-6));
+    }
+}
+
+#[cfg(test)]
+mod arate_position_tests {
+    use crate::context::{BaseAudioContext, OfflineAudioContext};
+    use crate::node::{AudioNode, AudioScheduledSourceNode};
+
+    #[test]
+    fn test_arate_position_automation_varies_within_quantum() {
+        // The EqualPower fast path decides whether spatialization parameters
+        // are constant over the render quantum ("single valued"). It only
+        // inspected the nine *listener* parameter buffers and ignored the
+        // panner's own position/orientation params. A static listener is the
+        // common case, so the check almost always passed and any automation on
+        // the panner's positionX/Y/Z (a-rate per spec) was silently evaluated
+        // once per quantum, i.e. degraded to k-rate: the output moves in
+        // 128-frame stair steps instead of per-sample.
+        let mut context = OfflineAudioContext::new(2, 256, 48000.);
+
+        let mut src = context.create_constant_source();
+        src.offset().set_value(1.);
+        src.start();
+
+        let panner = context.create_panner();
+        // Sweep the source across the listener within the very first quantum.
+        panner.position_x().set_value_at_time(-10., 0.);
+        panner
+            .position_x()
+            .linear_ramp_to_value_at_time(10., 128. / 48000.);
+
+        src.connect(&panner);
+        panner.connect(&context.destination());
+
+        let result = context.start_rendering_sync();
+        let left = result.get_channel_data(0);
+
+        // With per-sample (a-rate) evaluation the left-channel gain must vary
+        // inside the first quantum; the k-rate degradation renders the whole
+        // quantum with the frame-0 position and the samples are all equal.
+        let varies = left.windows(2).take(127).any(|w| w[0] != w[1]);
+        assert!(
+            varies,
+            "position automation was evaluated once per quantum (k-rate degradation)"
+        );
     }
 }

--- a/src/param.rs
+++ b/src/param.rs
@@ -61,7 +61,19 @@ fn assert_sequence_length(values: &[f32]) {
     );
 }
 
-// 𝑣(𝑡) = 𝑉0 + (𝑉1−𝑉0) * ((𝑡−𝑇0) / (𝑇1−𝑇0))
+// v(t) = V0 + (V1 - V0) * ((t - T0) / (T1 - T0))
+//
+// Deliberately NOT mul_add: an FMA rounds once, while the natural
+// multiply-then-add rounds twice. WPT's k-rate connection suites (e.g.
+// k-rate-dynamics-compressor-connections) assert *bit-equality* between a
+// param automated with ramp(min -> max) and a param whose intrinsic value is
+// min with an audio-rate input ramping 0 -> max - min. With FMA the automated
+// path computes fma(diff, phase, min) while the input path computes
+// min + round(diff * phase), which differ by 1 ulp whenever min != 0 (the
+// compressor's ratio has min = 1 and threshold has min = -100). Browsers
+// evaluate the plain expression, so both paths share one expression tree and
+// compare equal. Rust never re-fuses a spelled-out a * b + c, so writing it
+// out guarantees the two-rounding form.
 #[inline(always)]
 fn compute_linear_ramp_sample(
     start_time: f64,
@@ -71,7 +83,7 @@ fn compute_linear_ramp_sample(
     time: f64,
 ) -> f32 {
     let phase = (time - start_time) / duration;
-    diff.mul_add(phase as f32, start_value)
+    diff * (phase as f32) + start_value
 }
 
 // v(t) = v1 * (v2/v1)^((t-t1) / (t2-t1))
@@ -3898,6 +3910,49 @@ mod tests {
         expected[0] = 2.;
 
         assert_float_eq!(output.channel_data(0)[..], &expected[..], abs_all <= 0.);
+    }
+}
+
+#[cfg(test)]
+mod linear_ramp_rounding_tests {
+    use crate::context::{BaseAudioContext, OfflineAudioContext};
+
+    use super::*;
+
+    #[test]
+    fn test_linear_ramp_matches_offset_composition_bitwise() {
+        // A ramp from base to base+span must produce bit-identical samples to
+        // base + (a ramp from 0 to span). With mul_add in the sample formula
+        // the left side rounds once - fma(span, phase, base) - while any
+        // composed path rounds twice, and the two differ by 1 ulp for many
+        // phases whenever base != 0. WPT's k-rate connection suites assert
+        // exact equality between exactly such paths.
+        let context = OfflineAudioContext::new(1, 1, 48000.);
+
+        let make = |base: f32, span: f32| {
+            let opts = AudioParamDescriptor {
+                name: String::new(),
+                automation_rate: AutomationRate::A,
+                default_value: 0.,
+                min_value: -200.,
+                max_value: 200.,
+            };
+            let (param, mut render) = audio_param_pair(opts, context.mock_registration());
+            render.handle_incoming_event(param.set_value_at_time_raw(base, 0.));
+            render.handle_incoming_event(param.linear_ramp_to_value_at_time_raw(base + span, 1.));
+            let dt = 1. / 128.;
+            render.compute_intrinsic_values(0., dt, 128).to_vec()
+        };
+
+        let automated = make(-100., 119.); // e.g. a compressor threshold sweep
+        let composed = make(0., 119.);
+        for (i, (a, c)) in automated.iter().zip(composed.iter()).enumerate() {
+            let expected = -100. + c;
+            assert!(
+                a.to_bits() == expected.to_bits(),
+                "sample {i}: {a:?} != -100 + {c:?} (= {expected:?})"
+            );
+        }
     }
 }
 

--- a/src/param.rs
+++ b/src/param.rs
@@ -1639,7 +1639,7 @@ impl AudioParamProcessor {
     ///     a-rate machinery evaluates them at block_time into buffer[0]).
     /// last_event bookkeeping mirrors the corresponding main-loop branches
     /// (subsequent ramps depend on it for their start point).
-    fn krate_catch_up(&mut self, block_time: f64) {
+    fn catch_up_head_events(&mut self, block_time: f64) {
         loop {
             let Some(event) = self.event_timeline.peek() else {
                 return;
@@ -1747,6 +1747,19 @@ impl AudioParamProcessor {
         let is_a_rate = self.automation_rate.is_a_rate();
         let next_block_time = dt.mul_add(count as f64, block_time);
 
+        // Settle queued head events that take effect at or before the first
+        // frame of this block (SetValue/SetValueAtTime at the block boundary,
+        // ramps and curves that already ended). Running this before the
+        // constant-block check lets a block whose only event lands exactly on
+        // its first frame be classified as constant, so the single-valued
+        // optimization below applies and AudioWorkletProcessor.process()
+        // receives a length-1 parameter array as the spec describes (WPT
+        // audioworklet-audioparam-size). For k-rate params this is the same
+        // catch-up that used to run just before the timeline loop (first-frame
+        // semantics); consuming these events here is equivalent for a-rate:
+        // the timeline loop would have applied them on sample 0.
+        self.catch_up_head_events(block_time);
+
         // Check if we can safely return a buffer of length 1 even for a-rate params.
         // Several cases allow us to do so:
         // - The timeline is empty
@@ -1794,7 +1807,7 @@ impl AudioParamProcessor {
         // them onto sample 0.
         //
         // Two steps:
-        //   1. Catch-up (krate_catch_up): apply queued head events whose actual
+        //   1. Catch-up (catch_up_head_events, ran above): apply queued head events whose actual
         //      time is <= block_time to intrinsic_value (root fix for the
         //      first-block problem); strictly later events stay queued.
         //   2. Run the full a-rate machinery and keep only buffer[0] (the
@@ -1810,7 +1823,7 @@ impl AudioParamProcessor {
         let k_first_frame = if is_a_rate {
             0.0 // unused
         } else {
-            self.krate_catch_up(block_time);
+            // catch-up already ran above; intrinsic_value is the first-frame value
             self.intrinsic_value
         };
         let block_infos = BlockInfos {
@@ -2061,7 +2074,7 @@ mod tests {
             let vs = render.compute_intrinsic_values(0., 1., 10);
 
             assert_float_eq!(param.value(), 2., abs_all <= 0.);
-            assert_float_eq!(vs, &[2.; 10][..], abs_all <= 0.);
+            assert_float_eq!(vs, &[2.][..], abs_all <= 0.); // constant block: single-valued
         }
 
         // make sure param.value() is properly clamped
@@ -2085,7 +2098,7 @@ mod tests {
 
             // value should clamped while intrinsic value should not
             assert_float_eq!(param.value(), 1., abs_all <= 0.);
-            assert_float_eq!(vs, &[2.; 10][..], abs_all <= 0.);
+            assert_float_eq!(vs, &[2.][..], abs_all <= 0.); // constant block: single-valued
         }
     }
 
@@ -2297,9 +2310,10 @@ mod tests {
             abs_all <= 0.
         );
 
-        // ramp finishes on first value of this block, i.e. length is 10
+        // ramp finishes on the first value of this block: settled before any
+        // sample is produced, so the block is constant and single-valued
         let vs = render.compute_intrinsic_values(20., 1., 10);
-        assert_float_eq!(vs, &[10.; 10][..], abs_all <= 0.);
+        assert_float_eq!(vs, &[10.][..], abs_all <= 0.); // constant block: single-valued
     }
 
     #[test]
@@ -2339,7 +2353,7 @@ mod tests {
 
         // ramp finished t = 20..30
         let vs = render.compute_intrinsic_values(20., 1., 10);
-        assert_float_eq!(vs, &[20.0; 10][..], abs_all <= 0.);
+        assert_float_eq!(vs, &[20.0][..], abs_all <= 0.); // constant block: single-valued
         assert_float_eq!(param.value(), 20., abs <= 0.);
     }
 
@@ -2425,7 +2439,7 @@ mod tests {
         );
 
         let vs = render.compute_intrinsic_values(10., 1., 10);
-        assert_float_eq!(vs, &[-1.; 10][..], abs_all <= 0.);
+        assert_float_eq!(vs, &[-1.][..], abs_all <= 0.); // constant block: single-valued
 
         // start time should be end time of last event, i.e. 10.
         render.handle_incoming_event(param.linear_ramp_to_value_at_time_raw(1., 30.));
@@ -2471,7 +2485,7 @@ mod tests {
         assert_float_eq!(vs, &res[..], abs_all <= 0.);
 
         let vs = render.compute_intrinsic_values(10., 1., 10);
-        assert_float_eq!(vs, &[1.0; 10][..], abs_all <= 0.);
+        assert_float_eq!(vs, &[1.0][..], abs_all <= 0.); // constant block: single-valued
     }
 
     #[test]
@@ -2694,7 +2708,7 @@ mod tests {
         );
 
         let vs = render.compute_intrinsic_values(10., 1., 10);
-        assert_float_eq!(vs, &[1.; 10][..], abs_all <= 0.);
+        assert_float_eq!(vs, &[1.][..], abs_all <= 0.); // constant block: single-valued
 
         // start time should be end time of last event, i.e. 10.
         render.handle_incoming_event(param.exponential_ramp_to_value_at_time_raw(0.0001, 30.));
@@ -3003,7 +3017,7 @@ mod tests {
             assert_float_eq!(vs, &res[10..20], abs_all <= 1.0e-6);
             // ramp ended
             let vs = render.compute_intrinsic_values(20., 1., 10);
-            assert_float_eq!(vs, &[v1; 10][..], abs_all <= 0.);
+            assert_float_eq!(vs, &[v1][..], abs_all <= 0.); // constant block: single-valued
         }
     }
 
@@ -3080,9 +3094,9 @@ mod tests {
         let vs = render.compute_intrinsic_values(20., 1., 10);
         assert_float_eq!(vs, &res[20..30], abs_all <= 0.);
 
-        // then this block should be [0.; 10]
+        // then this block is constant at 0 (single-valued)
         let vs = render.compute_intrinsic_values(30., 1., 10);
-        assert_float_eq!(vs, &[0.; 10][..], abs_all <= 0.);
+        assert_float_eq!(vs, &[0.][..], abs_all <= 0.); // constant block: single-valued
     }
 
     #[test]
@@ -3189,7 +3203,7 @@ mod tests {
             render.handle_incoming_event(param.cancel_scheduled_values_raw(10.));
 
             let vs = render.compute_intrinsic_values(0., 1., 10);
-            assert_float_eq!(vs, &[0.; 10][..], abs_all <= 0.);
+            assert_float_eq!(vs, &[0.][..], abs_all <= 0.); // constant block: single-valued
         }
 
         // ramp already started, go back to previous value
@@ -3240,7 +3254,7 @@ mod tests {
             render.handle_incoming_event(param.cancel_scheduled_values_raw(10.)); // cancels the ramp
 
             let vs = render.compute_intrinsic_values(0., 1., 10);
-            assert_float_eq!(vs, &[0.; 10][..], abs_all <= 0.);
+            assert_float_eq!(vs, &[0.][..], abs_all <= 0.); // constant block: single-valued
         }
 
         {
@@ -3535,7 +3549,7 @@ mod tests {
         );
 
         let vs = render.compute_intrinsic_values(10., 1., 10);
-        assert_float_eq!(vs, &[0.; 10][..], abs_all <= 0.);
+        assert_float_eq!(vs, &[0.][..], abs_all <= 0.); // constant block: single-valued
     }
 
     #[test]
@@ -3570,7 +3584,7 @@ mod tests {
         );
 
         let vs = render.compute_intrinsic_values(20., 1., 10);
-        assert_float_eq!(vs, &[0.; 10][..], abs_all <= 0.);
+        assert_float_eq!(vs, &[0.][..], abs_all <= 0.); // constant block: single-valued
     }
 
     #[test]
@@ -4044,7 +4058,7 @@ mod cancel_and_hold_regression_tests {
         render.handle_incoming_event(param.cancel_and_hold_at_time_raw(5.));
 
         let vs = render.compute_intrinsic_values(0., 1., 10);
-        assert_float_eq!(vs, &[1.; 10][..], abs_all <= 0.);
+        assert_float_eq!(vs, &[1.][..], abs_all <= 0.); // constant block: single-valued
     }
 
     #[test]
@@ -4071,5 +4085,44 @@ mod cancel_and_hold_regression_tests {
             vs[9] > 1.,
             "the truncated setTarget must survive the second cancel"
         );
+    }
+
+    #[test]
+    fn test_arate_boundary_event_yields_constant_block() {
+        // An event that lands exactly on the first frame of a block settles
+        // before any sample of that block is produced; if nothing else is
+        // scheduled inside the block, the block is constant. The spec's
+        // single-valued optimization then applies and
+        // AudioWorkletProcessor.process() must receive a length-1 parameter
+        // array (WPT audioworklet-audioparam-size checks the array sizes).
+        let context = OfflineAudioContext::new(1, 1, 48000.);
+        let opts = AudioParamDescriptor {
+            name: String::new(),
+            automation_rate: AutomationRate::A,
+            default_value: 0.,
+            min_value: -10.,
+            max_value: 10.,
+        };
+        let (param, mut render) = audio_param_pair(opts, context.mock_registration());
+        render.handle_incoming_event(param.set_value_at_time_raw(1., 128.));
+        render.handle_incoming_event(param.set_value_at_time_raw(2., 256.));
+
+        {
+            let b0 = render.compute_intrinsic_values(0., 1., 128);
+            assert_eq!(b0.len(), 1); // nothing scheduled inside block 0
+            assert_float_eq!(b0[0], 0., abs <= 0.);
+        }
+        {
+            // the t=128 event applies on this block's first frame; the next
+            // event starts the following block: constant, single-valued
+            let b1 = render.compute_intrinsic_values(128., 1., 128);
+            assert_eq!(b1.len(), 1);
+            assert_float_eq!(b1[0], 1., abs <= 0.);
+        }
+        {
+            let b2 = render.compute_intrinsic_values(256., 1., 128);
+            assert_eq!(b2.len(), 1);
+            assert_float_eq!(b2[0], 2., abs <= 0.);
+        }
     }
 }

--- a/src/param.rs
+++ b/src/param.rs
@@ -896,8 +896,26 @@ impl AudioParamProcessor {
 
             // remove all events in queue where event.time >= cancel_time
             // i.e. keep all events where event.time < cancel_time
-            self.event_timeline
-                .retain(|queued| queued.time < event.time);
+            //
+            // For SetValueCurveAtTime `time` is the *start* T0. Per the spec,
+            // cancelScheduledValues removes the whole curve when the cancel time
+            // falls inside its interval [T0, T0 + D). Keeping it merely because
+            // T0 < cancelTime leaves the curve on the timeline, and any
+            // automation event later scheduled inside [T0, T0 + D) then trips
+            // the exclusivity assert above - on the render thread.
+            self.event_timeline.retain(|queued| {
+                if queued.time >= event.time {
+                    return false;
+                }
+                if queued.event_type == AudioParamEventType::SetValueCurveAtTime {
+                    if let Some(duration) = queued.duration {
+                        // T0 < cancelTime < T0 + D: cancel the whole curve;
+                        // cancelTime >= T0 + D: the curve has ended, keep it.
+                        return event.time >= queued.time + duration;
+                    }
+                }
+                true
+            });
             return; // cancel_values events are not inserted in queue
         }
 
@@ -2863,6 +2881,64 @@ mod tests {
         // then this block should be [0.; 10]
         let vs = render.compute_intrinsic_values(30., 1., 10);
         assert_float_eq!(vs, &[0.; 10][..], abs_all <= 0.);
+    }
+
+    #[test]
+    fn test_cancel_scheduled_values_mid_curve() {
+        // Mirrors WPT the-audioparam-interface/cancel-scheduled-values.html
+        // (subtest "cancel1"). When the cancel time falls inside a
+        // SetValueCurve's interval [T0, T0 + D), the spec requires the whole
+        // curve to be cancelled. Retaining events merely by `time <
+        // cancel_time` (the curve's `time` is its start T0) leaves the curve on
+        // the timeline, and scheduling any automation event inside [T0, T0 + D)
+        // afterwards trips the "scheduling automation event during
+        // SetValueCurveAtTime" assert on the render thread.
+        let context = OfflineAudioContext::new(1, 1, 8000.);
+
+        let opts = AudioParamDescriptor {
+            name: String::new(),
+            automation_rate: AutomationRate::A,
+            default_value: 0.,
+            min_value: 0.,
+            max_value: 10.,
+        };
+        let (param, mut render) = audio_param_pair(opts, context.mock_registration());
+        render.handle_incoming_event(param.set_value_at_time_raw(0.5, 0.));
+        render.handle_incoming_event(param.set_value_at_time_raw(1.5, 0.25));
+        render.handle_incoming_event(param.set_value_curve_at_time_raw(&[1., -1.], 0.25, 0.25));
+        render.handle_incoming_event(param.set_value_at_time_raw(9., 0.5));
+        // The cancel lands inside the curve (0.25 < 0.3 < 0.5): the curve and
+        // the event at 0.5 are cancelled, the setValue at 0.25 survives.
+        render.handle_incoming_event(param.cancel_scheduled_values_raw(0.3));
+        // Without the fix this insertion panics against the leftover curve.
+        render.handle_incoming_event(param.set_value_at_time_raw(3., 0.375));
+
+        let vs = render.compute_intrinsic_values(0., 0.05, 12);
+        assert_float_eq!(vs[..5], &[0.5; 5][..], abs_all <= 0.); // t in [0, 0.25)
+        assert_float_eq!(vs[5..7], &[1.5; 2][..], abs_all <= 0.); // t = 0.25, 0.30
+        assert_float_eq!(vs[8..], &[3.; 4][..], abs_all <= 0.); // t >= 0.40
+    }
+
+    #[test]
+    fn test_cancel_scheduled_values_curve_boundary() {
+        // Boundary: cancelTime == T0 + D (the curve ends exactly at the cancel
+        // time) keeps the curve - the interval is half-open on the right.
+        let context = OfflineAudioContext::new(1, 1, 8000.);
+
+        let opts = AudioParamDescriptor {
+            name: String::new(),
+            automation_rate: AutomationRate::A,
+            default_value: 0.,
+            min_value: 0.,
+            max_value: 10.,
+        };
+        let (param, mut render) = audio_param_pair(opts, context.mock_registration());
+        render.handle_incoming_event(param.set_value_curve_at_time_raw(&[0., 4.], 0., 0.5));
+        render.handle_incoming_event(param.cancel_scheduled_values_raw(0.5));
+
+        let vs = render.compute_intrinsic_values(0., 0.125, 8);
+        // The curve ramps 0 to 4 over [0, 0.5); its end value holds afterwards.
+        assert_float_eq!(vs, &[0., 1., 2., 3., 4., 4., 4., 4.][..], abs_all <= 0.);
     }
 
     #[test]

--- a/src/param.rs
+++ b/src/param.rs
@@ -1612,6 +1612,117 @@ impl AudioParamProcessor {
         false
     }
 
+    /// Catch-up pass for the k-rate first-frame value.
+    ///
+    /// Applies queued head events whose *actual* time is <= block_time to
+    /// intrinsic_value (strict comparison, no sample quantization): they may
+    /// have just arrived from the control thread without any previous block
+    /// having consumed them. Handling:
+    ///   - SetValue / SetValueAtTime (time == 0 treated as block_time, same
+    ///     rule as the main loop) take effect immediately;
+    ///   - completed Linear/Exponential ramps (end <= block_time, including a
+    ///     cancel truncation) jump to their end/truncation value;
+    ///   - completed SetValueCurve events jump to their final sample;
+    ///   - in-progress ramps/curves and SetTargetAtTime stop the pass (the
+    ///     a-rate machinery evaluates them at block_time into buffer[0]).
+    /// last_event bookkeeping mirrors the corresponding main-loop branches
+    /// (subsequent ramps depend on it for their start point).
+    fn krate_catch_up(&mut self, block_time: f64) {
+        loop {
+            let Some(event) = self.event_timeline.peek() else {
+                return;
+            };
+            match event.event_type {
+                AudioParamEventType::SetValue | AudioParamEventType::SetValueAtTime => {
+                    let mut time = event.time;
+                    if time == 0. {
+                        time = block_time;
+                    }
+                    if time > block_time {
+                        return;
+                    }
+                    self.intrinsic_value = event.value;
+                    let mut ev = self.event_timeline.pop().unwrap();
+                    ev.time = time;
+                    self.last_event = Some(ev);
+                }
+                AudioParamEventType::LinearRampToValueAtTime
+                | AudioParamEventType::ExponentialRampToValueAtTime => {
+                    let end_time = event.cancel_time.unwrap_or(event.time);
+                    if end_time > block_time {
+                        return; // in progress or future: the machinery fills buffer[0]
+                    }
+                    let cancelled = event.cancel_time.is_some();
+                    let is_linear =
+                        event.event_type == AudioParamEventType::LinearRampToValueAtTime;
+                    // Ramps always have a predecessor (an implicit SetValueAtTime
+                    // is inserted as a fallback), same unwrap precondition as the
+                    // main loop.
+                    let last = self.last_event.as_ref().unwrap();
+                    let start_time = last.time;
+                    let start_value = last.value;
+                    let end_value = event.value;
+                    let duration = event.time - start_time; // slope uses the declared end, as in the main loop
+                    let value = if is_linear {
+                        if cancelled {
+                            compute_linear_ramp_sample(
+                                start_time,
+                                duration,
+                                start_value,
+                                end_value - start_value,
+                                end_time,
+                            )
+                        } else {
+                            end_value
+                        }
+                    } else if start_value == 0. || start_value * end_value < 0. {
+                        // Degenerate exponential ramp (same as the main loop):
+                        // v(t) = V0 until the end time, then jumps to V1.
+                        end_value
+                    } else if cancelled {
+                        compute_exponential_ramp_sample(
+                            start_time,
+                            duration,
+                            start_value,
+                            end_value / start_value,
+                            end_time,
+                        )
+                    } else {
+                        end_value
+                    };
+                    self.intrinsic_value = value;
+                    let mut ev = self.event_timeline.pop().unwrap();
+                    ev.time = end_time;
+                    ev.value = value;
+                    self.last_event = Some(ev);
+                }
+                AudioParamEventType::SetValueCurveAtTime => {
+                    let start_time = event.time;
+                    let duration = event.duration.unwrap();
+                    let mut end_time = start_time + duration;
+                    if let Some(cancel_time) = event.cancel_time {
+                        end_time = cancel_time;
+                    }
+                    if end_time > block_time {
+                        return; // in progress or future: the machinery fills buffer[0]
+                    }
+                    let values = event.values.as_ref().unwrap();
+                    let value =
+                        compute_set_value_curve_sample(start_time, duration, values, end_time);
+                    self.intrinsic_value = value;
+                    let mut ev = self.event_timeline.pop().unwrap();
+                    ev.time = end_time;
+                    ev.value = value;
+                    self.last_event = Some(ev);
+                }
+                // SetTargetAtTime has no completion of its own (replacement and
+                // cancellation are handled by the main loop). Stop the pass; its
+                // value at block_time is produced by the machinery into buffer[0].
+                _ => return,
+            }
+        }
+    }
+
     fn compute_buffer(&mut self, block_time: f64, dt: f64, count: usize) {
         // Set [[current value]] to the value of paramIntrinsicValue at the
         // beginning of this render quantum.
@@ -1649,20 +1760,52 @@ impl AudioParamProcessor {
             }
         };
 
-        if !is_a_rate || is_constant_block {
-            self.buffer.push(self.intrinsic_value);
+        if is_constant_block {
             // nothing to compute in timeline, for both k-rate and a-rate
-            if is_constant_block {
-                return;
-            }
+            self.buffer.push(self.intrinsic_value);
+            return;
         }
 
-        // pack block infos for automation methods
+        // The previous k-rate implementation snapshotted intrinsic_value
+        // *before* the timeline loop. For the first block after scheduling
+        // (events not yet consumed by any earlier block) the snapshot predates
+        // the events: after setValueAtTime(v, 0) the first quantum still reads
+        // the default value and only the second block self-heals. WPT's
+        // k-rate-*-connections catch this - the reference path is wrong for the
+        // whole first block and the oscillator phase drifts for the rest of the
+        // render.
+        //
+        // Per the spec (computation of value), the k-rate value is the value at
+        // the time of the *first frame* of the quantum: events at or before the
+        // first frame count, strictly later ones do not - even when they are
+        // less than half a sample late and the a-rate rounding would quantize
+        // them onto sample 0.
+        //
+        // Two steps:
+        //   1. Catch-up (krate_catch_up): apply queued head events whose actual
+        //      time is <= block_time to intrinsic_value (root fix for the
+        //      first-block problem); strictly later events stay queued.
+        //   2. Run the full a-rate machinery and keep only buffer[0] (the
+        //      first-frame value). In-progress ramps/curves/setTargets are then
+        //      evaluated by the same code at the same instant as an a-rate
+        //      signal driving the same param - bit-identical reference/test
+        //      paths - and intrinsic advances across blocks exactly like
+        //      a-rate. When the machinery fills no samples (all consumed events
+        //      quantized onto sample 0), fall back to the post-catch-up
+        //      snapshot; the post-loop intrinsic would wrongly fold
+        //      "less-than-half-a-sample late" future events into this block
+        //      (see test_update_automation_rate_to_k).
+        let k_first_frame = if is_a_rate {
+            0.0 // unused
+        } else {
+            self.krate_catch_up(block_time);
+            self.intrinsic_value
+        };
         let block_infos = BlockInfos {
             block_time,
             dt,
             count,
-            is_a_rate,
+            is_a_rate: true,
             next_block_time,
         };
 
@@ -1704,6 +1847,20 @@ impl AudioParamProcessor {
 
             if exit_loop {
                 break;
+            }
+        }
+
+        // k-rate: keep only the first-frame value (a length-1 buffer is the
+        // k-rate contract). Non-empty means some event pre-fill ran, so
+        // buffer[0] is the first-frame value (the post-catch-up intrinsic or an
+        // in-progress event evaluated at block_time). Empty means every applied
+        // event quantized onto sample 0 - use the post-catch-up snapshot for
+        // strict first-frame semantics.
+        if !is_a_rate {
+            if self.buffer.is_empty() {
+                self.buffer.push(k_first_frame);
+            } else {
+                self.buffer.truncate(1);
             }
         }
     }
@@ -1978,6 +2135,39 @@ mod tests {
                 abs_all <= 0.
             );
         }
+    }
+
+    #[test]
+    fn test_k_rate_first_block_includes_block_start_events() {
+        // After setValueAtTime(v, 0) the k-rate value of the *first* quantum
+        // must already be v (spec: k-rate is the value at the time of the first
+        // frame; events at or before the first frame count). The previous
+        // implementation snapshotted intrinsic_value before applying events, so
+        // the first block read the default value and only the second block
+        // self-healed - WPT's k-rate-*-connections fail across the board
+        // because the reference oscillator drifts in phase from block one.
+        let context = OfflineAudioContext::new(1, 1, 48000.);
+        let opts = AudioParamDescriptor {
+            name: String::new(),
+            automation_rate: AutomationRate::K,
+            default_value: 0.,
+            min_value: -20.,
+            max_value: 20.,
+        };
+        let (param, mut render) = audio_param_pair(opts, context.mock_registration());
+        render.handle_incoming_event(param.set_value_at_time_raw(5., 0.));
+        render.handle_incoming_event(param.linear_ramp_to_value_at_time_raw(15., 20.));
+
+        // First block at t = 0: setValue(5, 0) already applies (previously 0).
+        let vs = render.compute_intrinsic_values(0., 1., 10);
+        assert_float_eq!(vs, &[5.; 1][..], abs_all <= 0.);
+        // Second block at t = 10: ramp 5 -> 15 over [0, 20], value(10) = 10.
+        let vs = render.compute_intrinsic_values(10., 1., 10);
+        assert_float_eq!(vs, &[10.; 1][..], abs_all <= 0.);
+        // Events inside a block (past its first frame) do not affect it: at
+        // t = 20 the block starts at 15 (the ramp just completed).
+        let vs = render.compute_intrinsic_values(20., 1., 10);
+        assert_float_eq!(vs, &[15.; 1][..], abs_all <= 0.);
     }
 
     #[test]

--- a/src/param.rs
+++ b/src/param.rs
@@ -1218,9 +1218,22 @@ impl AudioParamProcessor {
 
         if infos.is_a_rate {
             let start_index = self.buffer.len();
-            // TODO use ceil() or round() when `end_time` is between two samples?
-            // <https://github.com/orottier/web-audio-api-rs/pull/460>
-            let end_index = ((end_time - infos.block_time).max(0.) / infos.dt).round() as usize;
+            let mut end_index = ((end_time - infos.block_time).max(0.) / infos.dt).round() as usize;
+            // Sub-sample ramp (0 < duration < dt/2): round() collapses it to zero samples in this
+            // block, and the fall-through below would then write end_value into the sample at
+            // start_index. If that sample is still on the ramp (its time <= end_time) it must instead
+            // take the ramp value (which at t == start_time is the start value), not the end value.
+            // The `duration > 0` guard is essential: zero-duration ramps (multiple ramps scheduled at
+            // the SAME time, event-insertion's junction ramps) must NOT be bumped -- they legitimately
+            // collapse to end_value, and compute_linear_ramp_sample would divide by a zero duration.
+            // (audioparam-close: frame 0 at t == start_time must equal the previous event's value.)
+            if end_index == start_index
+                && duration > 0.
+                && start_index < infos.count
+                && (start_index as f64).mul_add(infos.dt, infos.block_time) <= end_time
+            {
+                end_index = start_index + 1;
+            }
             let end_index_clipped = end_index.min(infos.count);
 
             // compute "real" value according to `t` then clamp it

--- a/src/param.rs
+++ b/src/param.rs
@@ -171,6 +171,35 @@ pub(crate) struct AudioParamEvent {
     values: Option<Box<[f32]>>, // populated by `SetValueCurveAtTime` events
 }
 
+impl AudioParamEvent {
+    /// Effective position of the event on the timeline (used as the sort key and
+    /// as the E1/E2 selection criterion in `CancelAndHoldAtTime`).
+    ///
+    /// `cancel_time` has *opposite* meanings for the two families of events, so a
+    /// plain `cancel_time.unwrap_or(time)` would be wrong for one of them:
+    ///   - A ramp truncated by cancelAndHoldAtTime keeps its original end time in
+    ///     `time` while `cancel_time = tc < time`. Ramps are positioned on the
+    ///     timeline by their end time, so after truncation the effective position
+    ///     is `cancel_time`. Sorting by the raw `time` pushes the truncated ramp
+    ///     *after* events that were scheduled after tc, and the renderer processes
+    ///     them out of order.
+    ///   - A truncated setTarget / setValueCurve keeps its *start* time t3 in
+    ///     `time` while `cancel_time = tc >= time` (tc is where it gets held, not
+    ///     where it is positioned). The key must remain `time`; using
+    ///     `cancel_time` would push the event after anything scheduled inside
+    ///     (t3, tc) - the same ordering inversion in the other direction.
+    ///
+    /// Both collapse into one rule: take the smaller of the two. For ramps
+    /// min(endTime, tc) = tc, for setTarget/curves min(t3, tc) = t3. Truncation
+    /// can only make an event end earlier, never move it later.
+    fn effective_time(&self) -> f64 {
+        match self.cancel_time {
+            Some(cancel_time) => cancel_time.min(self.time),
+            None => self.time,
+        }
+    }
+}
+
 // Event queue that contains `AudioParamEvent`s, most of the time, events must be
 // ordered (using stable sort), some operation may break this ordering (e.g. `push`)
 // in which cases `sort` must be called explicitly.
@@ -249,8 +278,14 @@ impl AudioParamEventTimeline {
     }
 
     fn sort(&mut self) {
+        // Sort by the *effective* position of each event (see
+        // `AudioParamEvent::effective_time` for why `cancel_time.unwrap_or(time)`
+        // would be wrong). Sorting by the raw `time` places a ramp truncated by
+        // cancelAndHoldAtTime (whose `time` still holds the original end time)
+        // after events scheduled later than the cancel time, and the renderer
+        // then processes the timeline out of order.
         self.inner
-            .sort_by(|a, b| a.time.partial_cmp(&b.time).unwrap());
+            .sort_by(|a, b| a.effective_time().partial_cmp(&b.effective_time()).unwrap());
         self.dirty = false;
     }
 
@@ -879,15 +914,30 @@ impl AudioParamProcessor {
             self.event_timeline.sort();
 
             for queued in self.event_timeline.iter_mut() {
+                // The E1/E2 selection must use the same effective position as the
+                // sort above, otherwise the sorted order and the selection
+                // criterion disagree. See `AudioParamEvent::effective_time`:
+                //   - a ramp truncated by a previous cancelAndHoldAtTime (whose
+                //     `time` still holds the original end time) has an effective
+                //     position of the old tc and is correctly picked as an E1
+                //     candidate instead of E2;
+                //   - a truncated setTarget (`time` = start t3, `cancel_time` =
+                //     old tc >= t3) has an effective position of t3. Using
+                //     `cancel_time` instead would misclassify it as E2 whenever a
+                //     second cancel comes in with tc' < old tc (the E2 branch does
+                //     nothing for non-ramps), after which the retain below drops
+                //     the whole event because old tc > tc' - an already-started
+                //     setTarget silently disappears.
+                let qt = queued.effective_time();
                 // closest before cancel time: if several events at same time,
                 // we want the last one
-                if queued.time >= t1 && queued.time <= event.time {
-                    t1 = queued.time;
+                if qt >= t1 && qt <= event.time {
+                    t1 = qt;
                     e1 = Some(queued);
                     // closest after cancel time: if several events at same time,
                     // we want the first one
-                } else if queued.time < t2 && queued.time > event.time {
-                    t2 = queued.time;
+                } else if qt < t2 && qt > event.time {
+                    t2 = qt;
                     e2 = Some(queued);
                 }
             }
@@ -910,7 +960,16 @@ impl AudioParamProcessor {
                     // Implicitly insert a setValueAtTime event at time 𝑡𝑐 with
                     // the value that the setTarget would
                     // @note - same strategy as for ramps
-                    matched.cancel_time = Some(event.time);
+                    // Only truncate-and-hold events that have actually started
+                    // (t3 < tc). An event starting exactly at tc has not begun:
+                    // per the spec ("cancels all scheduled parameter changes with
+                    // times greater than or equal to cancelTime") it must be
+                    // removed entirely, which the retain below takes care of.
+                    // This matches Chromium's strict `Time() < cancel_time` check
+                    // in AudioParamHandler::CancelAndHoldAtTime.
+                    if matched.time < event.time {
+                        matched.cancel_time = Some(event.time);
+                    }
                 } else if matched.event_type == AudioParamEventType::SetValueCurveAtTime {
                     // If 𝐸1 is a setValueCurve with a start time of 𝑡3 and a duration of 𝑑
                     // If 𝑡𝑐 <= 𝑡3 + 𝑑 :
@@ -924,7 +983,10 @@ impl AudioParamProcessor {
                     let start_time = matched.time;
                     let duration = matched.duration.unwrap();
 
-                    if event.time <= start_time + duration {
+                    // Same strictness as the setTarget branch above: a curve
+                    // starting exactly at tc has not begun and must be removed
+                    // entirely rather than truncated.
+                    if start_time < event.time && event.time <= start_time + duration {
                         matched.cancel_time = Some(event.time);
                     }
                 }
@@ -936,6 +998,19 @@ impl AudioParamProcessor {
                 // if the event has a `cancel_time` we use it instead of `time`
                 if let Some(cancel_time) = queued.cancel_time {
                     time = cancel_time;
+                }
+
+                // A SetTarget/SetValueCurve starting exactly at tc has not
+                // started (it was deliberately not marked with a cancel_time
+                // above) and must be removed per the spec wording "times greater
+                // than or equal to cancelTime". In-progress events of the same
+                // kind carry a cancel_time and are unaffected.
+                if queued.cancel_time.is_none()
+                    && time == event.time
+                    && (queued.event_type == AudioParamEventType::SetTargetAtTime
+                        || queued.event_type == AudioParamEventType::SetValueCurveAtTime)
+                {
+                    return false;
                 }
 
                 time <= event.time
@@ -1365,6 +1440,16 @@ impl AudioParamProcessor {
         }
 
         if !ended {
+            // Do not extrapolate an event that has not started yet
+            // (next_block_time < start_time). The SetTarget formula evaluates to
+            // e^(positive) for t < T0, which explodes; once written into
+            // intrinsic_value it becomes the output of every following block via
+            // the is_constant_block early return in compute_buffer. The a-rate
+            // sampling loop already guards against this (`time - start_time <
+            // 0.`); only this end-of-block evaluation was missing the guard.
+            if infos.next_block_time < start_time {
+                return true;
+            }
             // compute value for `next_block_time` so that `param.value()`
             // stays coherent (see. comment in `AudioParam`)
             // allows to properly fill k-rate within next block too
@@ -1468,6 +1553,12 @@ impl AudioParamProcessor {
 
         // event will continue in next tick
         if end_time >= infos.next_block_time {
+            // Same guard as for SetTarget above: do not extrapolate a curve
+            // that has not started yet. A negative position saturates to 0 via
+            // `position as usize` and yields a bogus phase in [0, 1).
+            if infos.next_block_time < start_time {
+                return true;
+            }
             // compute value for `next_block_time` so that `param.value()`
             // stays coherent (see. comment in `AudioParam`)
             // allows to properly fill k-rate within next block too
@@ -3541,5 +3632,123 @@ mod tests {
         expected[0] = 2.;
 
         assert_float_eq!(output.channel_data(0)[..], &expected[..], abs_all <= 0.);
+    }
+}
+
+#[cfg(test)]
+mod cancel_and_hold_regression_tests {
+    use float_eq::assert_float_eq;
+
+    use crate::context::{BaseAudioContext, OfflineAudioContext};
+
+    use super::*;
+
+    fn test_param(max: f32) -> (AudioParam, AudioParamProcessor) {
+        let context = OfflineAudioContext::new(1, 1, 48000.);
+        let opts = AudioParamDescriptor {
+            name: String::new(),
+            automation_rate: AutomationRate::A,
+            default_value: 0.,
+            min_value: -10.,
+            max_value: max,
+        };
+        audio_param_pair(opts, context.mock_registration())
+    }
+
+    #[test]
+    fn test_set_target_not_started_is_not_extrapolated() {
+        // Evaluating a SetTargetAtTime event before its start time plugs a
+        // positive exponent into the formula (e^((T0 - t) / tau) with t < T0),
+        // which explodes. The bogus value used to be written into
+        // intrinsic_value at the end of the block and then became the output of
+        // every following block through the is_constant_block early return.
+        let (param, mut render) = test_param(10.);
+        render.handle_incoming_event(param.set_value_at_time_raw(0.5, 0.));
+        render.handle_incoming_event(param.set_target_at_time_raw(0., 20., 5.));
+
+        // The buffer may legitimately be a single-element constant block, so
+        // assert on the values rather than on the length.
+        let vs = render.compute_intrinsic_values(0., 1., 10);
+        assert!(vs.iter().all(|v| *v == 0.5), "block [0, 10): {vs:?}");
+        // The block right before the event starts must still hold the previous
+        // value; without the guard it reads the extrapolated garbage instead.
+        let vs = render.compute_intrinsic_values(10., 1., 10);
+        assert!(vs.iter().all(|v| *v == 0.5), "block [10, 20): {vs:?}");
+    }
+
+    #[test]
+    fn test_set_value_curve_not_started_is_not_extrapolated() {
+        // Same guard for SetValueCurveAtTime: a negative position saturates to
+        // index 0 via `position as usize` and produces a bogus phase in [0, 1).
+        let (param, mut render) = test_param(10.);
+        render.handle_incoming_event(param.set_value_at_time_raw(0.5, 0.));
+        render.handle_incoming_event(param.set_value_curve_at_time_raw(&[0., 1.], 20., 5.));
+
+        let vs = render.compute_intrinsic_values(0., 1., 10);
+        assert!(vs.iter().all(|v| *v == 0.5), "block [0, 10): {vs:?}");
+        let vs = render.compute_intrinsic_values(10., 1., 10);
+        assert!(vs.iter().all(|v| *v == 0.5), "block [10, 20): {vs:?}");
+    }
+
+    #[test]
+    fn test_cancel_and_hold_truncated_ramp_ordering() {
+        // A ramp truncated by cancelAndHoldAtTime keeps its original end time in
+        // `time`. Sorting the timeline by the raw `time` pushes the truncated
+        // ramp after events that were scheduled later than the cancel time, and
+        // the renderer replays the timeline out of order (the freshly scheduled
+        // event is processed first, then the old ramp rewinds the value).
+        let (param, mut render) = test_param(10.);
+        render.handle_incoming_event(param.set_value_at_time_raw(0., 0.));
+        render.handle_incoming_event(param.linear_ramp_to_value_at_time_raw(10., 10.));
+        render.handle_incoming_event(param.cancel_and_hold_at_time_raw(2.));
+        render.handle_incoming_event(param.set_value_at_time_raw(5., 3.));
+
+        let vs = render.compute_intrinsic_values(0., 1., 10);
+        assert_float_eq!(
+            vs,
+            &[0., 1., 2., 5., 5., 5., 5., 5., 5., 5.][..],
+            abs_all <= 0.
+        );
+    }
+
+    #[test]
+    fn test_cancel_and_hold_removes_event_starting_at_cancel_time() {
+        // Per the spec, cancelAndHoldAtTime "cancels all scheduled parameter
+        // changes with times greater than or equal to cancelTime". An event
+        // starting exactly at the cancel time has not begun and must be removed
+        // entirely instead of being truncated into a held no-op.
+        let (param, mut render) = test_param(10.);
+        render.handle_incoming_event(param.set_value_at_time_raw(1., 0.));
+        render.handle_incoming_event(param.set_target_at_time_raw(9., 5., 1.));
+        render.handle_incoming_event(param.cancel_and_hold_at_time_raw(5.));
+
+        let vs = render.compute_intrinsic_values(0., 1., 10);
+        assert_float_eq!(vs, &[1.; 10][..], abs_all <= 0.);
+    }
+
+    #[test]
+    fn test_double_cancel_and_hold_keeps_truncated_set_target() {
+        // A setTarget already truncated by a first cancelAndHoldAtTime carries
+        // `time` = its start t3 and `cancel_time` = the first tc. When a second
+        // cancel comes in with tc' < tc, selecting E1/E2 by `cancel_time` (or by
+        // cancel_time.unwrap_or(time)) misclassifies the event as E2, after
+        // which the retain pass drops it entirely because cancel_time > tc' -
+        // an automation that already started silently disappears and the output
+        // collapses to the pre-automation value.
+        let (param, mut render) = test_param(20.);
+        render.handle_incoming_event(param.set_value_at_time_raw(0., 0.));
+        render.handle_incoming_event(param.set_target_at_time_raw(10., 1., 2.));
+        render.handle_incoming_event(param.cancel_and_hold_at_time_raw(8.));
+        render.handle_incoming_event(param.cancel_and_hold_at_time_raw(4.));
+
+        let vs = render.compute_intrinsic_values(0., 1., 10);
+        // v(t) = 10 - 10 * e^(-(t - 1) / 2) for t in [1, 4], held afterwards.
+        let held = 10. - 10. * (-1.5f32).exp();
+        assert_float_eq!(vs[4], held, abs <= 1e-4);
+        assert_float_eq!(vs[9], held, abs <= 1e-4);
+        assert!(
+            vs[9] > 1.,
+            "the truncated setTarget must survive the second cancel"
+        );
     }
 }

--- a/src/render/graph.rs
+++ b/src/render/graph.rs
@@ -5,6 +5,7 @@ mod test;
 
 use std::any::Any;
 use std::cell::RefCell;
+use std::collections::HashSet;
 use std::panic::{self, AssertUnwindSafe};
 
 use crate::context::AudioNodeId;
@@ -131,11 +132,11 @@ pub(crate) struct Graph {
     /// Topological ordering of the nodes
     ordered: Vec<AudioNodeId>,
     /// Topological sorting helper
-    marked: Vec<AudioNodeId>,
+    marked: HashSet<AudioNodeId>,
     /// Topological sorting helper
     marked_temp: Vec<AudioNodeId>,
     /// Topological sorting helper
-    in_cycle: Vec<AudioNodeId>,
+    in_cycle: HashSet<AudioNodeId>,
     /// Topological sorting helper
     cycle_breakers: Vec<AudioNodeId>,
 }
@@ -156,9 +157,9 @@ impl Graph {
             alloc: Alloc::with_capacity(64),
             reclaim_id_channel,
             ordered: vec![],
-            marked: vec![],
+            marked: HashSet::new(),
             marked_temp: vec![],
-            in_cycle: vec![],
+            in_cycle: HashSet::new(),
             cycle_breakers: vec![],
         }
     }
@@ -331,10 +332,10 @@ impl Graph {
     fn visit(
         &self,
         node_id: AudioNodeId,
-        marked: &mut Vec<AudioNodeId>,
+        marked: &mut HashSet<AudioNodeId>,
         marked_temp: &mut Vec<AudioNodeId>,
         ordered: &mut Vec<AudioNodeId>,
-        in_cycle: &mut Vec<AudioNodeId>,
+        in_cycle: &mut HashSet<AudioNodeId>,
         cycle_breakers: &mut Vec<AudioNodeId>,
     ) -> bool {
         // If this node is in the cycle detection list, it is part of a cycle!
@@ -354,7 +355,7 @@ impl Graph {
                 }
                 None => {
                     // Mark all nodes in the cycle
-                    in_cycle.extend_from_slice(&marked_temp[pos..]);
+                    in_cycle.extend(marked_temp[pos..].iter().copied());
                     // Do not continue, as we already have visited all these nodes
                     return false;
                 }
@@ -367,7 +368,7 @@ impl Graph {
         }
 
         // Add node to the visited list
-        marked.push(node_id);
+        marked.insert(node_id);
         // Add node to the current cycle detection list
         marked_temp.push(node_id);
 
@@ -957,5 +958,46 @@ mod tests {
 
         // No other dropped nodes
         assert!(node_id_consumer.pop().is_none());
+    }
+}
+
+#[cfg(test)]
+mod ordering_tests {
+    use crate::context::{BaseAudioContext, OfflineAudioContext};
+    use crate::node::{AudioNode, AudioScheduledSourceNode};
+
+    #[test]
+    fn test_large_graph_ordering() {
+        // order_nodes() previously tracked visited/cycle membership in Vecs and
+        // answered membership queries with linear scans, making a re-order
+        // O(N^2) in the number of nodes. A graph of ~4000 nodes took 7.5 ms to
+        // re-order - far beyond a 2.67 ms render quantum budget at 48 kHz.
+        // Sets make it O(N + E). This test pins the *correctness* of the
+        // ordering at a size where the quadratic version was already painful:
+        // a long chain must come out in source-to-destination order, i.e. the
+        // signal must arrive intact after one pass.
+        let mut context = OfflineAudioContext::new(1, 256, 48000.);
+
+        let mut src = context.create_constant_source();
+        src.offset().set_value(1.);
+        src.start();
+
+        let mut head = context.create_gain();
+        src.connect(&head);
+        for _ in 0..300 {
+            let next = context.create_gain();
+            head.connect(&next);
+            head = next;
+        }
+        head.connect(&context.destination());
+
+        let result = context.start_rendering_sync();
+        let channel = result.get_channel_data(0);
+        // The chain of unity gains must pass the constant through unchanged.
+        assert!(
+            channel[255] > 0.99,
+            "signal did not propagate through the chain: {}",
+            channel[255]
+        );
     }
 }

--- a/src/render/quantum.rs
+++ b/src/render/quantum.rs
@@ -547,7 +547,30 @@ impl AudioRenderQuantum {
         };
 
         // fast path if both buffers are upmixed mono signals
+        //
+        // `all_channels_identical()` is a pointer-based heuristic and cannot
+        // distinguish between
+        //   (a) a quantum genuinely up-mixed from mono (all channels share one
+        //       buffer by construction), and
+        //   (b) a quantum whose channels merely happen to share one buffer while
+        //       being semantically independent.
+        // Case (b) exists in practice: when several ChannelMerger inputs are fed
+        // from the same upstream node, all N output channels point at that single
+        // Rc (see `*output.channel_data_mut(i) = input.channel_data(0).clone()`
+        // in node/channel_merger.rs).
+        //
+        // This fast path collapses `self` to one channel, adds, then re-mixes to
+        // `new_channels`. That round-trip is only lossless when the speakers
+        // up-mix is a plain copy, i.e. (1,2). For (1,4)/(1,6) and any channel
+        // count > 2 the extra channels are filled with silence by mix_inner, so
+        // channels 1..N get wiped to zero.
+        //
+        // Restricting the fast path to new_channels <= 2 keeps the optimization
+        // for the overwhelmingly common mono/stereo connections while never
+        // collapsing data on wider quanta; those take the generic per-channel add
+        // below, which produces identical results for case (a).
         if interpretation == ChannelInterpretation::Speakers
+            && new_channels <= 2
             && self.all_channels_identical()
             && other.all_channels_identical()
         {
@@ -722,6 +745,49 @@ mod tests {
         // test add two signals
         signal1.add(&signal2);
         assert_float_eq!(&signal1[..], &[3.; RENDER_QUANTUM_SIZE][..], abs_all <= 0.);
+    }
+
+    #[test]
+    fn test_add_preserves_aliased_channels_beyond_stereo() {
+        // ChannelMerger outputs quanta whose N channels all point at the same
+        // Rc when several inputs are fed from one upstream node. The
+        // identical-channels fast path in add() cannot tell such quanta apart
+        // from genuine mono up-mixes; collapsing them to mono and re-mixing
+        // wipes channels 1..N to silence for channel counts > 2 (the speakers
+        // up-mix is only a plain copy for mono/stereo).
+        use crate::node::{ChannelConfigInner, ChannelCountMode, ChannelInterpretation};
+
+        let alloc = Alloc::with_capacity(4);
+
+        let mut signal = alloc.silence();
+        signal.copy_from_slice(&[1.; RENDER_QUANTUM_SIZE]);
+        let mut quantum = AudioRenderQuantum::from(signal);
+        // All three channels share the same underlying buffer, exactly like a
+        // ChannelMerger fed three times from the same source.
+        quantum.set_number_of_channels(3);
+        assert!(quantum.channels().windows(2).all(|w| {
+            use std::ops::Deref;
+            std::ptr::eq(w[0].deref().as_ptr(), w[1].deref().as_ptr())
+        }));
+
+        let mut other = AudioRenderQuantum::from(alloc.silence());
+        other.set_number_of_channels(3);
+
+        let config = ChannelConfigInner {
+            count: 3,
+            count_mode: ChannelCountMode::Max,
+            interpretation: ChannelInterpretation::Speakers,
+        };
+        quantum.add(&other, &config);
+
+        assert_eq!(quantum.number_of_channels(), 3);
+        for ch in 0..3 {
+            assert_float_eq!(
+                &quantum.channel_data(ch)[..],
+                &[1.; RENDER_QUANTUM_SIZE][..],
+                abs_all <= 0.
+            );
+        }
     }
 
     #[test]

--- a/src/render/thread.rs
+++ b/src/render/thread.rs
@@ -301,6 +301,40 @@ impl RenderThread {
         AudioBuffer::from(buffer, sample_rate)
     }
 
+    /// Number of output channels (used by incremental rendering to size its
+    /// buffer; the field is private across modules, hence the accessor).
+    pub(crate) fn output_channels(&self) -> usize {
+        self.number_of_channels
+    }
+
+    /// Incremental offline rendering: renders `n` quanta into `buffer` without
+    /// consuming self, so it can be called repeatedly to continue.
+    /// render_audiobuffer_sync takes `self` and renders everything in one go -
+    /// embedders need to render a segment, hand control back to the control
+    /// side to mutate the graph, and then continue, hence this split.
+    pub fn render_offline_quanta(
+        &mut self,
+        buffer: &mut [Vec<f32>],
+        n: usize,
+        event_loop: &EventLoop,
+    ) {
+        self.handle_control_messages();
+        for _ in 0..n {
+            self.render_offline_quantum(buffer);
+            if event_loop.handle_pending_events() {
+                self.handle_control_messages();
+            }
+        }
+    }
+
+    /// Finalizes an incremental render: runs node destructors and drains
+    /// pending events (mirrors the tail of render_audiobuffer_sync). Consumes
+    /// self - unload_graph already takes `self` by value.
+    pub fn finish_offline_render(self, event_loop: &EventLoop) {
+        self.unload_graph();
+        event_loop.handle_pending_events();
+    }
+
     // Render method of the `OfflineAudioContext::start_rendering`
     //
     // This is the async interface, as compared to render_audiobuffer_sync

--- a/tests/offline.rs
+++ b/tests/offline.rs
@@ -242,3 +242,31 @@ fn test_cycle_breaker() {
         abs_all <= 0.
     );
 }
+
+#[test]
+fn test_repeated_connect_with_identical_termini_is_a_single_connection() {
+    // Spec: "There can only be one connection between a given output of one
+    // specific node and a given input of another specific node. Multiple
+    // connections with the same termini are ignored."
+    //
+    // The connections set on the control thread already deduplicated, but the
+    // ConnectNode message was sent unconditionally and Graph::add_edge is a
+    // plain push - so every repeated connect() call added another render edge
+    // and the destination summed the source once more (2x, 3x, ... louder).
+    let mut context = OfflineAudioContext::new(1, RENDER_QUANTUM_SIZE, 44_100.);
+
+    let mut constant = context.create_constant_source();
+    constant.offset().set_value(1.);
+    constant.connect(&context.destination());
+    constant.connect(&context.destination()); // must be ignored
+    constant.connect(&context.destination()); // must be ignored
+    constant.start();
+
+    let output = context.start_rendering_sync();
+    let samples = output.get_channel_data(0);
+    assert_float_eq!(samples[64], 1., abs <= 0.);
+
+    // after an explicit disconnect the connection can be re-established
+    constant.disconnect_dest(&context.destination());
+    constant.connect(&context.destination());
+}

--- a/tests/online.rs
+++ b/tests/online.rs
@@ -376,3 +376,29 @@ fn test_control_messages_do_not_block_while_suspended() {
         "control messages blocked while the render callback was suspended"
     );
 }
+
+#[test]
+fn test_invalid_sink_id_is_rejected_without_closing_the_context() {
+    // An unknown sinkId is rejected before any teardown of the current
+    // backend, so it must leave the context fully operational. This guards
+    // the sink-change failure ordering: once the old backend has been closed
+    // and the graph taken out of the render thread, a failure to build the
+    // *new* backend closes the context (nothing can produce audio anymore) -
+    // but a mere validation error must never take that path.
+    let options = AudioContextOptions {
+        sink_id: "none".to_string(),
+        ..AudioContextOptions::default()
+    };
+    let context = AudioContext::new(options);
+    assert_eq!(context.state(), AudioContextState::Running);
+
+    let result = context.set_sink_id_sync("no-such-device".to_string());
+    assert!(result.is_err());
+
+    // the context is still alive and usable
+    assert_eq!(context.state(), AudioContextState::Running);
+    assert_eq!(context.sink_id(), "none");
+
+    context.close_sync();
+    assert_eq!(context.state(), AudioContextState::Closed);
+}


### PR DESCRIPTION
This branch collects a set of fixes on top of `main`, grouped by area below. Each change is a separate commit with a full description and, where applicable, tests.

### Hang safety

- **Never block the control thread indefinitely on a stalled render thread.** `send_control_msg` and the suspend/resume/close acknowledgements now wait on render-thread liveness (playhead progress) rather than blocking forever when the output device disappears mid-session.
- **Do not hang or silently kill the context when a sink change fails.**
- **Never block in `MediaStreamAudioDestinationNode`'s stream provider.**
- **Fall back to silence-flag suspension when native pause is unsupported**, so `suspend` still takes effect on backends without a native pause.

### AudioParam automation

- **Compute k-rate params at the first frame of the render quantum.**
- **Settle first-frame events before the constant-block check**, so a block whose only event lands on its first frame is classified as constant and produces a single-valued array (matches the WPT `audioworklet-audioparam-size` expectation).
- **Fix `cancelAndHoldAtTime` interactions with `setTargetAtTime` and `setValueCurveAtTime`.**
- **Cancel the whole `setValueCurve` when `cancelScheduledValues` lands inside it.**
- **Avoid FMA in linear-ramp sample computation** for reproducible ramp values.
- **Include source params in the EqualPower single-valued check.**

### Graph and rendering

- **Ignore repeated `connect()` calls with identical termini** instead of creating duplicate edges.
- **Use sets for visited/cycle bookkeeping in graph ordering.**
- **Restrict the identical-channels fast path in `add()` to mono/stereo.**

### API

- **Add an incremental rendering API to `OfflineAudioContext`.**

### Misc

- **Use the standard separator in stop-before-start panic messages.**
