### PR TITLE
Restrict the identical-channels fast path in add() to mono/stereo

### DIFF
--- a/src/render/quantum.rs
+++ b/src/render/quantum.rs
@@ -530,12 +530,12 @@ impl AudioRenderQuantum {
     ///
     /// Both buffers will be mixed up front according to the supplied `channel_config`
     pub(crate) fn add(&mut self, other: &Self, channel_config: &ChannelConfigInner) {
-        // gather initial channel counts
+        // Gather initial channel counts
         let channels_self = self.number_of_channels();
         let channels_other = other.number_of_channels();
         let max_channels = channels_self.max(channels_other);
 
-        // up/down-mix the to the desired channel count for the receiving node
+        // Up/down-mix the to the desired channel count for the receiving node
         let interpretation = channel_config.interpretation;
         let mode = channel_config.count_mode;
         let count = channel_config.count;
@@ -546,29 +546,9 @@ impl AudioRenderQuantum {
             ChannelCountMode::ClampedMax => max_channels.min(count),
         };
 
-        // fast path if both buffers are upmixed mono signals
-        //
-        // `all_channels_identical()` is a pointer-based heuristic and cannot
-        // distinguish between
-        //   (a) a quantum genuinely up-mixed from mono (all channels share one
-        //       buffer by construction), and
-        //   (b) a quantum whose channels merely happen to share one buffer while
-        //       being semantically independent.
-        // Case (b) exists in practice: when several ChannelMerger inputs are fed
-        // from the same upstream node, all N output channels point at that single
-        // Rc (see `*output.channel_data_mut(i) = input.channel_data(0).clone()`
-        // in node/channel_merger.rs).
-        //
-        // This fast path collapses `self` to one channel, adds, then re-mixes to
-        // `new_channels`. That round-trip is only lossless when the speakers
-        // up-mix is a plain copy, i.e. (1,2). For (1,4)/(1,6) and any channel
-        // count > 2 the extra channels are filled with silence by mix_inner, so
-        // channels 1..N get wiped to zero.
-        //
-        // Restricting the fast path to new_channels <= 2 keeps the optimization
-        // for the overwhelmingly common mono/stereo connections while never
-        // collapsing data on wider quanta; those take the generic per-channel add
-        // below, which produces identical results for case (a).
+        // Fast path if both buffers are upmixed mono signals, and when the
+        // desired output is mono/stereo. For higher channel counts `mix` is
+        // non-trivial so this fast path cannot apply.
         if interpretation == ChannelInterpretation::Speakers
             && new_channels <= 2
             && self.all_channels_identical()

--- a/src/render/quantum.rs
+++ b/src/render/quantum.rs
@@ -547,7 +547,30 @@ impl AudioRenderQuantum {
         };
 
         // fast path if both buffers are upmixed mono signals
+        //
+        // `all_channels_identical()` is a pointer-based heuristic and cannot
+        // distinguish between
+        //   (a) a quantum genuinely up-mixed from mono (all channels share one
+        //       buffer by construction), and
+        //   (b) a quantum whose channels merely happen to share one buffer while
+        //       being semantically independent.
+        // Case (b) exists in practice: when several ChannelMerger inputs are fed
+        // from the same upstream node, all N output channels point at that single
+        // Rc (see `*output.channel_data_mut(i) = input.channel_data(0).clone()`
+        // in node/channel_merger.rs).
+        //
+        // This fast path collapses `self` to one channel, adds, then re-mixes to
+        // `new_channels`. That round-trip is only lossless when the speakers
+        // up-mix is a plain copy, i.e. (1,2). For (1,4)/(1,6) and any channel
+        // count > 2 the extra channels are filled with silence by mix_inner, so
+        // channels 1..N get wiped to zero.
+        //
+        // Restricting the fast path to new_channels <= 2 keeps the optimization
+        // for the overwhelmingly common mono/stereo connections while never
+        // collapsing data on wider quanta; those take the generic per-channel add
+        // below, which produces identical results for case (a).
         if interpretation == ChannelInterpretation::Speakers
+            && new_channels <= 2
             && self.all_channels_identical()
             && other.all_channels_identical()
         {
@@ -722,6 +745,49 @@ mod tests {
         // test add two signals
         signal1.add(&signal2);
         assert_float_eq!(&signal1[..], &[3.; RENDER_QUANTUM_SIZE][..], abs_all <= 0.);
+    }
+
+    #[test]
+    fn test_add_preserves_aliased_channels_beyond_stereo() {
+        // ChannelMerger outputs quanta whose N channels all point at the same
+        // Rc when several inputs are fed from one upstream node. The
+        // identical-channels fast path in add() cannot tell such quanta apart
+        // from genuine mono up-mixes; collapsing them to mono and re-mixing
+        // wipes channels 1..N to silence for channel counts > 2 (the speakers
+        // up-mix is only a plain copy for mono/stereo).
+        use crate::node::{ChannelConfigInner, ChannelCountMode, ChannelInterpretation};
+
+        let alloc = Alloc::with_capacity(4);
+
+        let mut signal = alloc.silence();
+        signal.copy_from_slice(&[1.; RENDER_QUANTUM_SIZE]);
+        let mut quantum = AudioRenderQuantum::from(signal);
+        // All three channels share the same underlying buffer, exactly like a
+        // ChannelMerger fed three times from the same source.
+        quantum.set_number_of_channels(3);
+        assert!(quantum.channels().windows(2).all(|w| {
+            use std::ops::Deref;
+            std::ptr::eq(w[0].deref().as_ptr(), w[1].deref().as_ptr())
+        }));
+
+        let mut other = AudioRenderQuantum::from(alloc.silence());
+        other.set_number_of_channels(3);
+
+        let config = ChannelConfigInner {
+            count: 3,
+            count_mode: ChannelCountMode::Max,
+            interpretation: ChannelInterpretation::Speakers,
+        };
+        quantum.add(&other, &config);
+
+        assert_eq!(quantum.number_of_channels(), 3);
+        for ch in 0..3 {
+            assert_float_eq!(
+                &quantum.channel_data(ch)[..],
+                &[1.; RENDER_QUANTUM_SIZE][..],
+                abs_all <= 0.
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
AudioRenderQuantum::add() takes a fast path when all channels of both
quanta compare pointer-identical (all_channels_identical), assuming the
quantum is a mono signal that was up-mixed by duplicating the channel Rc.
The heuristic cannot distinguish that case from quanta whose channels
merely happen to share one buffer while being semantically independent.
The latter exists in practice: when several ChannelMerger inputs are fed
from the same upstream node, every output channel points at that single
Rc (`*output.channel_data_mut(i) = input.channel_data(0).clone()` in
node/channel_merger.rs).

The fast path collapses the quantum to one channel, adds, and re-mixes to
the target channel count. That round-trip is only lossless when the
speakers up-mix is a plain copy, i.e. for mono/stereo. For any channel
count > 2 the extra channels are filled with silence by mix_inner, wiping
channels 1..N.

Reproduction: connect one source to inputs 0, 1 and 2 of a ChannelMerger
in an OfflineAudioContext and render - channels 1 and 2 of the merger
output are silent while channel 0 carries the signal. A minimal unit test
reproducing the aliasing shape directly against add() is included.

Restrict the fast path to channel counts <= 2. Mono/stereo connections
keep the optimization; wider quanta take the generic per-channel add,
which yields identical results for genuine mono up-mixes.

