### PR TITLE
Compute k-rate params at the first frame of the render quantum

### DIFF
--- a/src/param.rs
+++ b/src/param.rs
@@ -1503,6 +1503,117 @@ impl AudioParamProcessor {
         false
     }
 
+    /// Catch-up pass for the k-rate first-frame value.
+    ///
+    /// Applies queued head events whose *actual* time is <= block_time to
+    /// intrinsic_value (strict comparison, no sample quantization): they may
+    /// have just arrived from the control thread without any previous block
+    /// having consumed them. Handling:
+    ///   - SetValue / SetValueAtTime (time == 0 treated as block_time, same
+    ///     rule as the main loop) take effect immediately;
+    ///   - completed Linear/Exponential ramps (end <= block_time, including a
+    ///     cancel truncation) jump to their end/truncation value;
+    ///   - completed SetValueCurve events jump to their final sample;
+    ///   - in-progress ramps/curves and SetTargetAtTime stop the pass (the
+    ///     a-rate machinery evaluates them at block_time into buffer[0]).
+    /// last_event bookkeeping mirrors the corresponding main-loop branches
+    /// (subsequent ramps depend on it for their start point).
+    fn krate_catch_up(&mut self, block_time: f64) {
+        loop {
+            let Some(event) = self.event_timeline.peek() else {
+                return;
+            };
+            match event.event_type {
+                AudioParamEventType::SetValue | AudioParamEventType::SetValueAtTime => {
+                    let mut time = event.time;
+                    if time == 0. {
+                        time = block_time;
+                    }
+                    if time > block_time {
+                        return;
+                    }
+                    self.intrinsic_value = event.value;
+                    let mut ev = self.event_timeline.pop().unwrap();
+                    ev.time = time;
+                    self.last_event = Some(ev);
+                }
+                AudioParamEventType::LinearRampToValueAtTime
+                | AudioParamEventType::ExponentialRampToValueAtTime => {
+                    let end_time = event.cancel_time.unwrap_or(event.time);
+                    if end_time > block_time {
+                        return; // in progress or future: the machinery fills buffer[0]
+                    }
+                    let cancelled = event.cancel_time.is_some();
+                    let is_linear =
+                        event.event_type == AudioParamEventType::LinearRampToValueAtTime;
+                    // Ramps always have a predecessor (an implicit SetValueAtTime
+                    // is inserted as a fallback), same unwrap precondition as the
+                    // main loop.
+                    let last = self.last_event.as_ref().unwrap();
+                    let start_time = last.time;
+                    let start_value = last.value;
+                    let end_value = event.value;
+                    let duration = event.time - start_time; // slope uses the declared end, as in the main loop
+                    let value = if is_linear {
+                        if cancelled {
+                            compute_linear_ramp_sample(
+                                start_time,
+                                duration,
+                                start_value,
+                                end_value - start_value,
+                                end_time,
+                            )
+                        } else {
+                            end_value
+                        }
+                    } else if start_value == 0. || start_value * end_value < 0. {
+                        // Degenerate exponential ramp (same as the main loop):
+                        // v(t) = V0 until the end time, then jumps to V1.
+                        end_value
+                    } else if cancelled {
+                        compute_exponential_ramp_sample(
+                            start_time,
+                            duration,
+                            start_value,
+                            end_value / start_value,
+                            end_time,
+                        )
+                    } else {
+                        end_value
+                    };
+                    self.intrinsic_value = value;
+                    let mut ev = self.event_timeline.pop().unwrap();
+                    ev.time = end_time;
+                    ev.value = value;
+                    self.last_event = Some(ev);
+                }
+                AudioParamEventType::SetValueCurveAtTime => {
+                    let start_time = event.time;
+                    let duration = event.duration.unwrap();
+                    let mut end_time = start_time + duration;
+                    if let Some(cancel_time) = event.cancel_time {
+                        end_time = cancel_time;
+                    }
+                    if end_time > block_time {
+                        return; // in progress or future: the machinery fills buffer[0]
+                    }
+                    let values = event.values.as_ref().unwrap();
+                    let value =
+                        compute_set_value_curve_sample(start_time, duration, values, end_time);
+                    self.intrinsic_value = value;
+                    let mut ev = self.event_timeline.pop().unwrap();
+                    ev.time = end_time;
+                    ev.value = value;
+                    self.last_event = Some(ev);
+                }
+                // SetTargetAtTime has no completion of its own (replacement and
+                // cancellation are handled by the main loop). Stop the pass; its
+                // value at block_time is produced by the machinery into buffer[0].
+                _ => return,
+            }
+        }
+    }
+
     fn compute_buffer(&mut self, block_time: f64, dt: f64, count: usize) {
         // Set [[current value]] to the value of paramIntrinsicValue at the
         // beginning of this render quantum.
@@ -1540,20 +1651,52 @@ impl AudioParamProcessor {
             }
         };
 
-        if !is_a_rate || is_constant_block {
-            self.buffer.push(self.intrinsic_value);
+        if is_constant_block {
             // nothing to compute in timeline, for both k-rate and a-rate
-            if is_constant_block {
-                return;
-            }
+            self.buffer.push(self.intrinsic_value);
+            return;
         }
 
-        // pack block infos for automation methods
+        // The previous k-rate implementation snapshotted intrinsic_value
+        // *before* the timeline loop. For the first block after scheduling
+        // (events not yet consumed by any earlier block) the snapshot predates
+        // the events: after setValueAtTime(v, 0) the first quantum still reads
+        // the default value and only the second block self-heals. WPT's
+        // k-rate-*-connections catch this - the reference path is wrong for the
+        // whole first block and the oscillator phase drifts for the rest of the
+        // render.
+        //
+        // Per the spec (computation of value), the k-rate value is the value at
+        // the time of the *first frame* of the quantum: events at or before the
+        // first frame count, strictly later ones do not - even when they are
+        // less than half a sample late and the a-rate rounding would quantize
+        // them onto sample 0.
+        //
+        // Two steps:
+        //   1. Catch-up (krate_catch_up): apply queued head events whose actual
+        //      time is <= block_time to intrinsic_value (root fix for the
+        //      first-block problem); strictly later events stay queued.
+        //   2. Run the full a-rate machinery and keep only buffer[0] (the
+        //      first-frame value). In-progress ramps/curves/setTargets are then
+        //      evaluated by the same code at the same instant as an a-rate
+        //      signal driving the same param - bit-identical reference/test
+        //      paths - and intrinsic advances across blocks exactly like
+        //      a-rate. When the machinery fills no samples (all consumed events
+        //      quantized onto sample 0), fall back to the post-catch-up
+        //      snapshot; the post-loop intrinsic would wrongly fold
+        //      "less-than-half-a-sample late" future events into this block
+        //      (see test_update_automation_rate_to_k).
+        let k_first_frame = if is_a_rate {
+            0.0 // unused
+        } else {
+            self.krate_catch_up(block_time);
+            self.intrinsic_value
+        };
         let block_infos = BlockInfos {
             block_time,
             dt,
             count,
-            is_a_rate,
+            is_a_rate: true,
             next_block_time,
         };
 
@@ -1595,6 +1738,20 @@ impl AudioParamProcessor {
 
             if exit_loop {
                 break;
+            }
+        }
+
+        // k-rate: keep only the first-frame value (a length-1 buffer is the
+        // k-rate contract). Non-empty means some event pre-fill ran, so
+        // buffer[0] is the first-frame value (the post-catch-up intrinsic or an
+        // in-progress event evaluated at block_time). Empty means every applied
+        // event quantized onto sample 0 - use the post-catch-up snapshot for
+        // strict first-frame semantics.
+        if !is_a_rate {
+            if self.buffer.is_empty() {
+                self.buffer.push(k_first_frame);
+            } else {
+                self.buffer.truncate(1);
             }
         }
     }
@@ -1869,6 +2026,39 @@ mod tests {
                 abs_all <= 0.
             );
         }
+    }
+
+    #[test]
+    fn test_k_rate_first_block_includes_block_start_events() {
+        // After setValueAtTime(v, 0) the k-rate value of the *first* quantum
+        // must already be v (spec: k-rate is the value at the time of the first
+        // frame; events at or before the first frame count). The previous
+        // implementation snapshotted intrinsic_value before applying events, so
+        // the first block read the default value and only the second block
+        // self-healed - WPT's k-rate-*-connections fail across the board
+        // because the reference oscillator drifts in phase from block one.
+        let context = OfflineAudioContext::new(1, 1, 48000.);
+        let opts = AudioParamDescriptor {
+            name: String::new(),
+            automation_rate: AutomationRate::K,
+            default_value: 0.,
+            min_value: -20.,
+            max_value: 20.,
+        };
+        let (param, mut render) = audio_param_pair(opts, context.mock_registration());
+        render.handle_incoming_event(param.set_value_at_time_raw(5., 0.));
+        render.handle_incoming_event(param.linear_ramp_to_value_at_time_raw(15., 20.));
+
+        // First block at t = 0: setValue(5, 0) already applies (previously 0).
+        let vs = render.compute_intrinsic_values(0., 1., 10);
+        assert_float_eq!(vs, &[5.; 1][..], abs_all <= 0.);
+        // Second block at t = 10: ramp 5 -> 15 over [0, 20], value(10) = 10.
+        let vs = render.compute_intrinsic_values(10., 1., 10);
+        assert_float_eq!(vs, &[10.; 1][..], abs_all <= 0.);
+        // Events inside a block (past its first frame) do not affect it: at
+        // t = 20 the block starts at 15 (the ramp just completed).
+        let vs = render.compute_intrinsic_values(20., 1., 10);
+        assert_float_eq!(vs, &[15.; 1][..], abs_all <= 0.);
     }
 
     #[test]

--- a/src/param.rs
+++ b/src/param.rs
@@ -1518,7 +1518,7 @@ impl AudioParamProcessor {
     ///     a-rate machinery evaluates them at block_time into buffer[0]).
     /// last_event bookkeeping mirrors the corresponding main-loop branches
     /// (subsequent ramps depend on it for their start point).
-    fn krate_catch_up(&mut self, block_time: f64) {
+    fn catch_up_head_events(&mut self, block_time: f64) {
         loop {
             let Some(event) = self.event_timeline.peek() else {
                 return;
@@ -1626,6 +1626,19 @@ impl AudioParamProcessor {
         let is_a_rate = self.automation_rate.is_a_rate();
         let next_block_time = dt.mul_add(count as f64, block_time);
 
+        // Settle queued head events that take effect at or before the first
+        // frame of this block (SetValue/SetValueAtTime at the block boundary,
+        // ramps and curves that already ended). Running this before the
+        // constant-block check lets a block whose only event lands exactly on
+        // its first frame be classified as constant, so the single-valued
+        // optimization below applies and AudioWorkletProcessor.process()
+        // receives a length-1 parameter array as the spec describes (WPT
+        // audioworklet-audioparam-size). For k-rate params this is the same
+        // catch-up that used to run just before the timeline loop (first-frame
+        // semantics); consuming these events here is equivalent for a-rate:
+        // the timeline loop would have applied them on sample 0.
+        self.catch_up_head_events(block_time);
+
         // Check if we can safely return a buffer of length 1 even for a-rate params.
         // Several cases allow us to do so:
         // - The timeline is empty
@@ -1673,7 +1686,7 @@ impl AudioParamProcessor {
         // them onto sample 0.
         //
         // Two steps:
-        //   1. Catch-up (krate_catch_up): apply queued head events whose actual
+        //   1. Catch-up (catch_up_head_events, ran above): apply queued head events whose actual
         //      time is <= block_time to intrinsic_value (root fix for the
         //      first-block problem); strictly later events stay queued.
         //   2. Run the full a-rate machinery and keep only buffer[0] (the
@@ -1689,7 +1702,7 @@ impl AudioParamProcessor {
         let k_first_frame = if is_a_rate {
             0.0 // unused
         } else {
-            self.krate_catch_up(block_time);
+            // catch-up already ran above; intrinsic_value is the first-frame value
             self.intrinsic_value
         };
         let block_infos = BlockInfos {
@@ -1940,7 +1953,7 @@ mod tests {
             let vs = render.compute_intrinsic_values(0., 1., 10);
 
             assert_float_eq!(param.value(), 2., abs_all <= 0.);
-            assert_float_eq!(vs, &[2.; 10][..], abs_all <= 0.);
+            assert_float_eq!(vs, &[2.][..], abs_all <= 0.); // constant block: single-valued
         }
 
         // make sure param.value() is properly clamped
@@ -1964,7 +1977,7 @@ mod tests {
 
             // value should clamped while intrinsic value should not
             assert_float_eq!(param.value(), 1., abs_all <= 0.);
-            assert_float_eq!(vs, &[2.; 10][..], abs_all <= 0.);
+            assert_float_eq!(vs, &[2.][..], abs_all <= 0.); // constant block: single-valued
         }
     }
 
@@ -2176,9 +2189,10 @@ mod tests {
             abs_all <= 0.
         );
 
-        // ramp finishes on first value of this block, i.e. length is 10
+        // ramp finishes on the first value of this block: settled before any
+        // sample is produced, so the block is constant and single-valued
         let vs = render.compute_intrinsic_values(20., 1., 10);
-        assert_float_eq!(vs, &[10.; 10][..], abs_all <= 0.);
+        assert_float_eq!(vs, &[10.][..], abs_all <= 0.); // constant block: single-valued
     }
 
     #[test]
@@ -2218,7 +2232,7 @@ mod tests {
 
         // ramp finished t = 20..30
         let vs = render.compute_intrinsic_values(20., 1., 10);
-        assert_float_eq!(vs, &[20.0; 10][..], abs_all <= 0.);
+        assert_float_eq!(vs, &[20.0][..], abs_all <= 0.); // constant block: single-valued
         assert_float_eq!(param.value(), 20., abs <= 0.);
     }
 
@@ -2304,7 +2318,7 @@ mod tests {
         );
 
         let vs = render.compute_intrinsic_values(10., 1., 10);
-        assert_float_eq!(vs, &[-1.; 10][..], abs_all <= 0.);
+        assert_float_eq!(vs, &[-1.][..], abs_all <= 0.); // constant block: single-valued
 
         // start time should be end time of last event, i.e. 10.
         render.handle_incoming_event(param.linear_ramp_to_value_at_time_raw(1., 30.));
@@ -2350,7 +2364,7 @@ mod tests {
         assert_float_eq!(vs, &res[..], abs_all <= 0.);
 
         let vs = render.compute_intrinsic_values(10., 1., 10);
-        assert_float_eq!(vs, &[1.0; 10][..], abs_all <= 0.);
+        assert_float_eq!(vs, &[1.0][..], abs_all <= 0.); // constant block: single-valued
     }
 
     #[test]
@@ -2573,7 +2587,7 @@ mod tests {
         );
 
         let vs = render.compute_intrinsic_values(10., 1., 10);
-        assert_float_eq!(vs, &[1.; 10][..], abs_all <= 0.);
+        assert_float_eq!(vs, &[1.][..], abs_all <= 0.); // constant block: single-valued
 
         // start time should be end time of last event, i.e. 10.
         render.handle_incoming_event(param.exponential_ramp_to_value_at_time_raw(0.0001, 30.));
@@ -2882,7 +2896,7 @@ mod tests {
             assert_float_eq!(vs, &res[10..20], abs_all <= 1.0e-6);
             // ramp ended
             let vs = render.compute_intrinsic_values(20., 1., 10);
-            assert_float_eq!(vs, &[v1; 10][..], abs_all <= 0.);
+            assert_float_eq!(vs, &[v1][..], abs_all <= 0.); // constant block: single-valued
         }
     }
 
@@ -2959,9 +2973,9 @@ mod tests {
         let vs = render.compute_intrinsic_values(20., 1., 10);
         assert_float_eq!(vs, &res[20..30], abs_all <= 0.);
 
-        // then this block should be [0.; 10]
+        // then this block is constant at 0 (single-valued)
         let vs = render.compute_intrinsic_values(30., 1., 10);
-        assert_float_eq!(vs, &[0.; 10][..], abs_all <= 0.);
+        assert_float_eq!(vs, &[0.][..], abs_all <= 0.); // constant block: single-valued
     }
 
     #[test]
@@ -3010,7 +3024,7 @@ mod tests {
             render.handle_incoming_event(param.cancel_scheduled_values_raw(10.));
 
             let vs = render.compute_intrinsic_values(0., 1., 10);
-            assert_float_eq!(vs, &[0.; 10][..], abs_all <= 0.);
+            assert_float_eq!(vs, &[0.][..], abs_all <= 0.); // constant block: single-valued
         }
 
         // ramp already started, go back to previous value
@@ -3061,7 +3075,7 @@ mod tests {
             render.handle_incoming_event(param.cancel_scheduled_values_raw(10.)); // cancels the ramp
 
             let vs = render.compute_intrinsic_values(0., 1., 10);
-            assert_float_eq!(vs, &[0.; 10][..], abs_all <= 0.);
+            assert_float_eq!(vs, &[0.][..], abs_all <= 0.); // constant block: single-valued
         }
 
         {
@@ -3356,7 +3370,7 @@ mod tests {
         );
 
         let vs = render.compute_intrinsic_values(10., 1., 10);
-        assert_float_eq!(vs, &[0.; 10][..], abs_all <= 0.);
+        assert_float_eq!(vs, &[0.][..], abs_all <= 0.); // constant block: single-valued
     }
 
     #[test]
@@ -3391,7 +3405,7 @@ mod tests {
         );
 
         let vs = render.compute_intrinsic_values(20., 1., 10);
-        assert_float_eq!(vs, &[0.; 10][..], abs_all <= 0.);
+        assert_float_eq!(vs, &[0.][..], abs_all <= 0.); // constant block: single-valued
     }
 
     #[test]
@@ -3731,5 +3745,53 @@ mod tests {
         expected[0] = 2.;
 
         assert_float_eq!(output.channel_data(0)[..], &expected[..], abs_all <= 0.);
+    }
+}
+
+#[cfg(test)]
+mod first_frame_event_regression_tests {
+    use float_eq::assert_float_eq;
+
+    use crate::context::{BaseAudioContext, OfflineAudioContext};
+
+    use super::*;
+
+    #[test]
+    fn test_arate_boundary_event_yields_constant_block() {
+        // An event that lands exactly on the first frame of a block settles
+        // before any sample of that block is produced; if nothing else is
+        // scheduled inside the block, the block is constant. The spec's
+        // single-valued optimization then applies and
+        // AudioWorkletProcessor.process() must receive a length-1 parameter
+        // array (WPT audioworklet-audioparam-size checks the array sizes).
+        let context = OfflineAudioContext::new(1, 1, 48000.);
+        let opts = AudioParamDescriptor {
+            name: String::new(),
+            automation_rate: AutomationRate::A,
+            default_value: 0.,
+            min_value: -10.,
+            max_value: 10.,
+        };
+        let (param, mut render) = audio_param_pair(opts, context.mock_registration());
+        render.handle_incoming_event(param.set_value_at_time_raw(1., 128.));
+        render.handle_incoming_event(param.set_value_at_time_raw(2., 256.));
+
+        {
+            let b0 = render.compute_intrinsic_values(0., 1., 128);
+            assert_eq!(b0.len(), 1); // nothing scheduled inside block 0
+            assert_float_eq!(b0[0], 0., abs <= 0.);
+        }
+        {
+            // the t=128 event applies on this block's first frame; the next
+            // event starts the following block: constant, single-valued
+            let b1 = render.compute_intrinsic_values(128., 1., 128);
+            assert_eq!(b1.len(), 1);
+            assert_float_eq!(b1[0], 1., abs <= 0.);
+        }
+        {
+            let b2 = render.compute_intrinsic_values(256., 1., 128);
+            assert_eq!(b2.len(), 1);
+            assert_float_eq!(b2[0], 2., abs <= 0.);
+        }
     }
 }


### PR DESCRIPTION
This PR groups two commits on the same first-frame parameter mechanism; the second builds directly on the first, so they are kept together.

## Compute k-rate params at the first frame of the render quantum

Per the spec's "computation of value" section, a k-rate AudioParam takes
a single value for the whole render quantum: the value computed at the
time of the quantum's *first frame*. Events at or before that first
frame are included; strictly later events belong to the next quantum.

compute_buffer() snapshotted intrinsic_value into the k-rate buffer
*before* running the timeline loop. For the first block after events are
scheduled - events that no previous block ever consumed - the snapshot
predates them all:

    param.set_automation_rate(AutomationRate::K);
    param.set_value_at_time(440., 0.);
    // first rendered quantum still uses the *default* value

The second block self-heals (the loop advanced intrinsic_value at the
end of block one), but the damage is done: in WPT's
k-rate-*-connections suites, the reference oscillator renders its whole
first block at the wrong frequency and stays phase-shifted from the
comparison path for the remainder of the render, failing every
subsequent sample comparison (~25 subtests across five files).

Fix, in two steps:

1. krate_catch_up(): before the snapshot, apply queued head events whose
   actual time is <= block_time (strict comparison, no sample
   quantization) - SetValue family, completed ramps (including cancel
   truncations) and completed curves. In-progress events and
   SetTargetAtTime stop the pass.
2. Run the regular a-rate machinery over the block and keep only
   buffer[0], which is exactly the first-frame value. In-progress
   ramps/curves/setTargets are thereby evaluated by the same code at the
   same instant as an a-rate signal connected to the same param, making
   the k-rate automation path and an audio-input path bit-identical -
   which is precisely what the WPT connection suites assert. When the
   machinery fills no samples (all consumed events quantized onto sample
   0), the post-catch-up snapshot is used; the post-loop intrinsic would
   wrongly fold events that are less than half a sample in the future
   into the current block (pinned by test_update_automation_rate_to_k).

Regression tests included; the existing k-rate tests (steps, ramps over
multiple blocks, automation-rate switching) keep passing unchanged.


## Settle first-frame events before the constant-block check

compute_buffer classified a block as constant only when the head of the
event timeline was already past the end of the block. An event that
lands exactly on the block's first frame (a very common shape: automate
one quantum, then setValueAtTime at the next quantum boundary) kept the
block on the full a-rate path, producing a 128-sample buffer of one
repeated value. The spec's single-valued optimization allows - and WPT
expects - a length-1 array here: audioworklet-audioparam-size asserts
that an AudioWorkletProcessor receives parameter arrays of length 1 for
every render quantum in which the parameter is constant, including the
quantum whose only event settles on its first frame.

Fix: run the head-event catch-up (previously a k-rate-only step,
renamed from krate_catch_up to catch_up_head_events) before the
constant-block check for both automation rates. The catch-up applies
instantaneous events at or before block_time to the intrinsic value and
finalizes ramps/curves that already ended - exactly what the a-rate
timeline loop would have done on sample 0 - so consuming them early is
value-identical; in-progress ramps, curves and setTargets stay queued
and keep taking the full path. The k-rate branch no longer needs its
own catch-up call.

Reproduce: on an a-rate param, setValueAtTime(v, t) exactly at a render
quantum boundary with nothing else scheduled inside that quantum, then
inspect the parameter array length in an AudioWorkletProcessor: 128
before, 1 after (value identical).

Existing unit tests that asserted full-length constant blocks were
updated to expect the single-valued form (values unchanged); a new
regression test pins the boundary-event case across three consecutive
blocks.

