### PR TITLE
Avoid FMA in linear ramp sample computation

### DIFF
--- a/src/param.rs
+++ b/src/param.rs
@@ -61,7 +61,19 @@ fn assert_sequence_length(values: &[f32]) {
     );
 }
 
-// 𝑣(𝑡) = 𝑉0 + (𝑉1−𝑉0) * ((𝑡−𝑇0) / (𝑇1−𝑇0))
+// v(t) = V0 + (V1 - V0) * ((t - T0) / (T1 - T0))
+//
+// Deliberately NOT mul_add: an FMA rounds once, while the natural
+// multiply-then-add rounds twice. WPT's k-rate connection suites (e.g.
+// k-rate-dynamics-compressor-connections) assert *bit-equality* between a
+// param automated with ramp(min -> max) and a param whose intrinsic value is
+// min with an audio-rate input ramping 0 -> max - min. With FMA the automated
+// path computes fma(diff, phase, min) while the input path computes
+// min + round(diff * phase), which differ by 1 ulp whenever min != 0 (the
+// compressor's ratio has min = 1 and threshold has min = -100). Browsers
+// evaluate the plain expression, so both paths share one expression tree and
+// compare equal. Rust never re-fuses a spelled-out a * b + c, so writing it
+// out guarantees the two-rounding form.
 #[inline(always)]
 fn compute_linear_ramp_sample(
     start_time: f64,
@@ -71,7 +83,7 @@ fn compute_linear_ramp_sample(
     time: f64,
 ) -> f32 {
     let phase = (time - start_time) / duration;
-    diff.mul_add(phase as f32, start_value)
+    diff * (phase as f32) + start_value
 }
 
 // v(t) = v1 * (v2/v1)^((t-t1) / (t2-t1))
@@ -3541,5 +3553,48 @@ mod tests {
         expected[0] = 2.;
 
         assert_float_eq!(output.channel_data(0)[..], &expected[..], abs_all <= 0.);
+    }
+}
+
+#[cfg(test)]
+mod linear_ramp_rounding_tests {
+    use crate::context::{BaseAudioContext, OfflineAudioContext};
+
+    use super::*;
+
+    #[test]
+    fn test_linear_ramp_matches_offset_composition_bitwise() {
+        // A ramp from base to base+span must produce bit-identical samples to
+        // base + (a ramp from 0 to span). With mul_add in the sample formula
+        // the left side rounds once - fma(span, phase, base) - while any
+        // composed path rounds twice, and the two differ by 1 ulp for many
+        // phases whenever base != 0. WPT's k-rate connection suites assert
+        // exact equality between exactly such paths.
+        let context = OfflineAudioContext::new(1, 1, 48000.);
+
+        let make = |base: f32, span: f32| {
+            let opts = AudioParamDescriptor {
+                name: String::new(),
+                automation_rate: AutomationRate::A,
+                default_value: 0.,
+                min_value: -200.,
+                max_value: 200.,
+            };
+            let (param, mut render) = audio_param_pair(opts, context.mock_registration());
+            render.handle_incoming_event(param.set_value_at_time_raw(base, 0.));
+            render.handle_incoming_event(param.linear_ramp_to_value_at_time_raw(base + span, 1.));
+            let dt = 1. / 128.;
+            render.compute_intrinsic_values(0., dt, 128).to_vec()
+        };
+
+        let automated = make(-100., 119.); // e.g. a compressor threshold sweep
+        let composed = make(0., 119.);
+        for (i, (a, c)) in automated.iter().zip(composed.iter()).enumerate() {
+            let expected = -100. + c;
+            assert!(
+                a.to_bits() == expected.to_bits(),
+                "sample {i}: {a:?} != -100 + {c:?} (= {expected:?})"
+            );
+        }
     }
 }


### PR DESCRIPTION
compute_linear_ramp_sample() used f32::mul_add, which contracts the
multiply and add into a single fused operation with one rounding step.
Browsers evaluate the spec formula v(t) = V0 + (V1 - V0) * k as a plain
multiply followed by an add, i.e. with two rounding steps. The two forms
differ by 1 ulp for many phase values whenever V0 != 0.

This is observable: the WPT k-rate connection suites (for example
k-rate-dynamics-compressor-connections.html) compare a param driven by a
ramp automation from min to max against a param sitting at its intrinsic
min with an audio-rate signal ramping from 0 to max - min connected to
it, and assert *sample-exact* equality. The audio-input path composes
min + round(diff * phase) while the automated path computed
fma(diff, phase, min); with the compressor's ratio (min = 1) and
threshold (min = -100) the outputs diverge by 1 ulp deep into the
render and the exact comparison fails.

Reproduction: render a ramp from -100 to 19 and separately a ramp from
0 to 119, then compare sample-wise `ramp1[i]` against `-100 + ramp2[i]`
with bitwise equality - with FMA they differ on many samples.

Spelling the expression out as `diff * phase + start_value` restores the
two-rounding form; Rust does not re-fuse explicit multiply-add without
fast-math, so the behavior is guaranteed. A bitwise composition test is
included.

