### PR TITLE
Never block in MediaStreamAudioDestinationNode's stream provider

### DIFF
--- a/src/media_streams/mod.rs
+++ b/src/media_streams/mod.rs
@@ -249,3 +249,78 @@ mod tests {
         assert!(iter.next().is_none());
     }
 }
+
+#[cfg(test)]
+mod loopback_tests {
+    use crate::context::{AudioContext, AudioContextOptions, BaseAudioContext};
+    use crate::node::AudioNode;
+    use crate::node::AudioScheduledSourceNode;
+
+    #[test]
+    fn test_same_context_loopback_does_not_deadlock() {
+        // Loopback within one context: dest.stream -> create_media_stream_source.
+        // AudioDestinationNodeStream::next used a blocking recv(); in any
+        // quantum where the source node is ordered before the destination node
+        // the render thread waits for data that only it can produce, and
+        // rendering deadlocks (currentTime freezes). With try_recv plus
+        // underrun silence the iterator never blocks.
+        let options = AudioContextOptions {
+            sink_id: "none".into(),
+            ..AudioContextOptions::default()
+        };
+        let context = AudioContext::new(options);
+
+        let dest = context.create_media_stream_destination();
+        let mut osc = context.create_oscillator();
+        osc.connect(&dest);
+        osc.start();
+        let src = context.create_media_stream_source(dest.stream());
+        src.connect(&context.destination());
+
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        let t = context.current_time();
+        assert!(
+            t > 0.2,
+            "render thread deadlocked: currentTime = {t} after 500ms"
+        );
+    }
+
+    #[test]
+    fn test_cross_rate_stream_consumption_does_not_panic() {
+        // Consuming a MediaStream in a context running at a different sample
+        // rate sends the chunks through the Resampler, which stitches adjacent
+        // chunks with AudioBuffer::extend. extend() asserts equal channel
+        // counts, so underrun silence emitted with a channel count different
+        // from the real data panics the consumer's render thread (its clock
+        // then freezes while the producer keeps running).
+        let mk = |rate: f32| {
+            AudioContext::new(AudioContextOptions {
+                sink_id: "none".into(),
+                sample_rate: Some(rate),
+                ..AudioContextOptions::default()
+            })
+        };
+        let producer = mk(48000.);
+        let consumer = mk(44100.);
+
+        let dest = producer.create_media_stream_destination();
+        let mut osc = producer.create_oscillator();
+        osc.connect(&dest);
+        osc.start();
+
+        let src = consumer.create_media_stream_source(dest.stream());
+        src.connect(&consumer.destination());
+
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        assert!(
+            producer.current_time() > 0.2,
+            "producer stalled: {}",
+            producer.current_time()
+        );
+        assert!(
+            consumer.current_time() > 0.2,
+            "consumer render thread died (channel count mismatch panic): {}",
+            consumer.current_time()
+        );
+    }
+}

--- a/src/node/media_stream_destination.rs
+++ b/src/node/media_stream_destination.rs
@@ -83,11 +83,15 @@ impl AudioNode for MediaStreamAudioDestinationNode {
 impl MediaStreamAudioDestinationNode {
     /// Create a new MediaStreamAudioDestinationNode
     pub fn new<C: BaseAudioContext>(context: &C, options: AudioNodeOptions) -> Self {
+        let sample_rate = context.sample_rate();
+        let silence_channels = options.channel_count;
         context.base().register(move |registration| {
             let (send, recv) = crossbeam_channel::bounded(1);
 
             let iter = AudioDestinationNodeStream {
                 receiver: recv.clone(),
+                sample_rate,
+                channels: silence_channels,
             };
             let track = MediaStreamTrack::from_iter(iter);
             let stream = MediaStream::from_tracks(vec![track]);
@@ -145,14 +149,38 @@ impl AudioProcessor for DestinationRenderer {
 
 struct AudioDestinationNodeStream {
     receiver: Receiver<AudioBuffer>,
+    sample_rate: f32,
+    /// Channel count for underrun silence: starts at the node's channel_count
+    /// and then follows the most recent real buffer. Consumers (the Resampler
+    /// on cross-sample-rate paths) stitch buffers with AudioBuffer::extend,
+    /// whose assert requires adjacent chunks to have equal channel counts - a
+    /// drifting silence channel count panics the render thread.
+    channels: usize,
 }
 
 impl Iterator for AudioDestinationNodeStream {
     type Item = Result<AudioBuffer, Box<dyn Error + Send + Sync>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        match self.receiver.recv() {
-            Ok(buf) => Some(Ok(buf)),
+        // This iterator must never block. When the stream is consumed by a
+        // MediaStreamAudioSourceNode living in the *same* context (a loopback:
+        // dest.stream -> createMediaStreamSource), it is pulled from the render
+        // thread itself. A blocking recv() then deadlocks the render thread in
+        // any quantum where the source node is ordered before the destination
+        // node - the thread waits for data that only it can produce, and
+        // currentTime freezes. try_recv instead: on Empty emit one quantum of
+        // silence (initial block / underrun; a source ordered first simply sees
+        // one quantum of latency), on data pass it through, and a disconnected
+        // channel still reports the error so the source node stops.
+        match self.receiver.try_recv() {
+            Ok(buf) => {
+                self.channels = buf.number_of_channels();
+                Some(Ok(buf))
+            }
+            Err(crossbeam_channel::TryRecvError::Empty) => Some(Ok(AudioBuffer::from(
+                vec![vec![0.; crate::RENDER_QUANTUM_SIZE]; self.channels.max(1)],
+                self.sample_rate,
+            ))),
             Err(e) => Some(Err(Box::new(e))),
         }
     }


### PR DESCRIPTION
The MediaStreamTrack exposed by MediaStreamAudioDestinationNode delivers
audio through an iterator that performed a blocking recv() on the
channel filled by the node's renderer.

That is fine while the consumer lives on another thread (a recorder,
WebRTC), but consuming the stream inside the *same* context - the
standard Web Audio loopback dest.stream -> createMediaStreamSource(),
used by WPT mediastreamaudiosourcenode-routing.html among others - pulls
the iterator from the render thread itself. In any render quantum where
the graph happens to order the source node before the destination node,
the render thread blocks waiting for a buffer that only it can produce.
Rendering deadlocks and currentTime freezes.

Reproduction:

    let context = AudioContext::new(options);       // sink "none" works
    let dest = context.create_media_stream_destination();
    let mut osc = context.create_oscillator();
    osc.connect(&dest);
    osc.start();
    let src = context.create_media_stream_source(dest.stream());
    src.connect(&context.destination());
    // currentTime stays near 0 forever

Fix: use try_recv. On Empty the provider emits one quantum of silence
(the initial block, or an underrun; a source ordered before the
destination simply observes one quantum of latency), on data it passes
the buffer through, and a disconnected channel still surfaces the error
so the consuming source node stops.

The silence quantum must also carry a stable channel count: consumers on
a different sample rate stitch chunks through the Resampler with
AudioBuffer::extend, which asserts equal channel counts on adjacent
chunks - silence with a drifting channel count panics the consumer's
render thread. The count starts at the node's channel_count and then
follows the most recent real buffer.

Tests: a same-context loopback must keep the clock advancing, and a
cross-sample-rate consumer must not kill its render thread.

