### PR TITLE
Include source params in the EqualPower single-valued check

### DIFF
--- a/src/node/panner.rs
+++ b/src/node/panner.rs
@@ -1273,23 +1273,16 @@ mod tests {
         let right = output.channel_data(1).as_slice();
         assert!(right[128..256].iter().any(|v| *v >= 1E-6));
     }
-}
-
-#[cfg(test)]
-mod arate_position_tests {
-    use crate::context::{BaseAudioContext, OfflineAudioContext};
-    use crate::node::{AudioNode, AudioScheduledSourceNode};
 
     #[test]
     fn test_arate_position_automation_varies_within_quantum() {
-        // The EqualPower fast path decides whether spatialization parameters
-        // are constant over the render quantum ("single valued"). It only
-        // inspected the nine *listener* parameter buffers and ignored the
-        // panner's own position/orientation params. A static listener is the
-        // common case, so the check almost always passed and any automation on
-        // the panner's positionX/Y/Z (a-rate per spec) was silently evaluated
-        // once per quantum, i.e. degraded to k-rate: the output moves in
-        // 128-frame stair steps instead of per-sample.
+        // Regression test for when `single_valued` method only inspected the
+        // nine *listener* parameter buffers and ignored the panner's own
+        // position/orientation params. A static listener is the common case,
+        // so the check almost always passed and any automation on the panner's
+        // positionX/Y/Z (a-rate per spec) was silently evaluated once per
+        // quantum, i.e. degraded to k-rate: the output moves in 128-frame
+        // stair steps instead of per-sample.
         let mut context = OfflineAudioContext::new(2, 256, 48000.);
 
         let mut src = context.create_constant_source();

--- a/src/node/panner.rs
+++ b/src/node/panner.rs
@@ -831,7 +831,13 @@ impl AudioProcessor for PannerRenderer {
             // EqualPower panning
 
             // Optimize for static Panner & Listener
-            let single_valued = listener_position_x.len() == 1
+            let single_valued = source_position_x.len() == 1
+                && source_position_y.len() == 1
+                && source_position_z.len() == 1
+                && source_orientation_x.len() == 1
+                && source_orientation_y.len() == 1
+                && source_orientation_z.len() == 1
+                && listener_position_x.len() == 1
                 && listener_position_y.len() == 1
                 && listener_position_z.len() == 1
                 && listener_forward_x.len() == 1
@@ -1266,5 +1272,50 @@ mod tests {
 
         let right = output.channel_data(1).as_slice();
         assert!(right[128..256].iter().any(|v| *v >= 1E-6));
+    }
+}
+
+#[cfg(test)]
+mod arate_position_tests {
+    use crate::context::{BaseAudioContext, OfflineAudioContext};
+    use crate::node::{AudioNode, AudioScheduledSourceNode};
+
+    #[test]
+    fn test_arate_position_automation_varies_within_quantum() {
+        // The EqualPower fast path decides whether spatialization parameters
+        // are constant over the render quantum ("single valued"). It only
+        // inspected the nine *listener* parameter buffers and ignored the
+        // panner's own position/orientation params. A static listener is the
+        // common case, so the check almost always passed and any automation on
+        // the panner's positionX/Y/Z (a-rate per spec) was silently evaluated
+        // once per quantum, i.e. degraded to k-rate: the output moves in
+        // 128-frame stair steps instead of per-sample.
+        let mut context = OfflineAudioContext::new(2, 256, 48000.);
+
+        let mut src = context.create_constant_source();
+        src.offset().set_value(1.);
+        src.start();
+
+        let panner = context.create_panner();
+        // Sweep the source across the listener within the very first quantum.
+        panner.position_x().set_value_at_time(-10., 0.);
+        panner
+            .position_x()
+            .linear_ramp_to_value_at_time(10., 128. / 48000.);
+
+        src.connect(&panner);
+        panner.connect(&context.destination());
+
+        let result = context.start_rendering_sync();
+        let left = result.get_channel_data(0);
+
+        // With per-sample (a-rate) evaluation the left-channel gain must vary
+        // inside the first quantum; the k-rate degradation renders the whole
+        // quantum with the frame-0 position and the samples are all equal.
+        let varies = left.windows(2).take(127).any(|w| w[0] != w[1]);
+        assert!(
+            varies,
+            "position automation was evaluated once per quantum (k-rate degradation)"
+        );
     }
 }


### PR DESCRIPTION
The EqualPower panning path optimizes the static case: when all
spatialization parameters are constant over the render quantum
("single valued"), azimuth and gain are computed once and reused for all
128 frames. The check only inspected the nine *listener* parameter
buffers (position/forward/up) and ignored the panner's own six
(position_x/y/z, orientation_x/y/z), despite the comment saying
"Optimize for static Panner & Listener".

A static listener is by far the common case, so the check nearly always
evaluated to true and any automation on the panner's position or
orientation - a-rate per spec - was silently evaluated once per render
quantum. The output moves in 128-frame stair steps instead of
per-sample: a k-rate degradation that WPT k-rate-panner-connections and
panner automation suites catch as whole-quantum-constant output.

Reproduction: automate position_x with a linear ramp crossing the
listener within a single quantum and render; every sample in the quantum
comes out identical. As a control, adding a no-op 0 -> 0 ramp on any
*listener* param (physically nothing moves, but it makes its buffer
non-single-valued) flips the fast path off and produces the expected
per-sample values - demonstrating the automation itself reached the
renderer and only the fast-path predicate was wrong.

Add the six source parameter buffers to the predicate. Static panners
keep the fast path; the cone gain evaluation shares the same predicate
and is fixed by the same change. A regression test asserting per-sample
variation within the first quantum is included.

