### PR TITLE
Never block the control thread indefinitely on a stalled render thread

### DIFF
--- a/src/context/concrete_base.rs
+++ b/src/context/concrete_base.rs
@@ -13,10 +13,11 @@ use crate::spatial::AudioListenerParams;
 
 use crate::AudioListener;
 
-use crossbeam_channel::{SendError, Sender};
+use crossbeam_channel::{Receiver, RecvTimeoutError, SendError, SendTimeoutError, Sender};
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use std::sync::{Arc, Mutex, RwLock, RwLockWriteGuard};
+use std::time::Duration;
 
 /// This struct assigns new [`AudioNodeId`]s for [`AudioNode`]s
 ///
@@ -282,9 +283,138 @@ impl ConcreteBaseAudioContext {
                 return;
             }
 
-            let result = sender.send(msg);
-            if result.is_err() {
-                log::warn!("Discarding control message - render thread is closed");
+            self.send_to_render_thread(&sender, msg);
+        }
+    }
+
+    /// Hands one control message to the render thread without ever blocking
+    /// the control thread indefinitely.
+    ///
+    /// Previously this was a bare `sender.send(msg)`. The control channel is
+    /// bounded(256) (the receiving end lives on the render thread; a bounded
+    /// channel is allocation-free and therefore realtime-safe). Once the render
+    /// thread stops draining - the device was unplugged or the driver died,
+    /// and cpal's err_fn only logs - the 257th message blocks the control
+    /// thread forever. Hosts running script on the control thread hang wholesale.
+    ///
+    /// The fix keeps the channel semantics and only changes *how long* to wait:
+    ///   - the channel stays bounded (render-side realtime safety untouched);
+    ///   - back-pressure stays blocking, so messages are neither dropped nor
+    ///     reordered (single FIFO channel, one-for-one with the old behavior);
+    ///   - the indefinite wait becomes a wait on render-thread *liveness*:
+    ///     while the channel is full, wake every `POLL` and check whether
+    ///     `frames_played` advanced (the render thread bumps it by 128 per
+    ///     rendered quantum).
+    ///       - progress: the render thread is alive, we are merely producing
+    ///         faster than it consumes - keep waiting (same as upstream);
+    ///       - zero progress across the whole `STALL_GRACE` window: the render
+    ///         side is gone - mark the context Closed and drop this message.
+    ///         The `state() != Closed` check at the top of send_control_msg
+    ///         then short-circuits every later message, so the control thread
+    ///         never touches this channel again.
+    ///
+    /// Liveness (frames_played) instead of a fixed send timeout: a fixed
+    /// timeout misfires on healthy-but-busy devices or during device startup.
+    /// One quantum is ~2.9 ms (128 frames at 44.1 kHz); zero progress across
+    /// the grace window means the render thread has skipped hundreds of quanta
+    /// - that is not busyness.
+    ///
+    /// Dropping is safe here: it only happens once the context is deemed
+    /// Closed, and a Closed context discards all control messages anyway (same
+    /// log line upstream) - with the device dead there is no render thread
+    /// left to execute the message regardless.
+    ///
+    /// Offline contexts are unaffected: their control channel is unbounded, so
+    /// send_timeout always succeeds immediately.
+    fn send_to_render_thread(&self, sender: &Sender<ControlMessage>, msg: ControlMessage) {
+        // Poll interval while the channel is full (much coarser than a quantum
+        // to keep wakeups cheap).
+        const POLL: Duration = Duration::from_millis(50);
+        // Zero playhead progress for this long means the render side stalled
+        // (~700 quanta; also comfortably covers device startup jitter).
+        const STALL_GRACE: Duration = Duration::from_secs(2);
+
+        let mut msg = msg;
+        let mut last_frames = self.inner.frames_played.load(Ordering::Relaxed);
+        let mut stalled = Duration::ZERO;
+
+        loop {
+            match sender.send_timeout(msg, POLL) {
+                Ok(()) => return,
+                Err(SendTimeoutError::Disconnected(_)) => {
+                    log::warn!("Discarding control message - render thread is closed");
+                    return;
+                }
+                Err(SendTimeoutError::Timeout(returned)) => {
+                    msg = returned; // send_timeout hands the message back - nothing is lost
+                    let frames = self.inner.frames_played.load(Ordering::Relaxed);
+                    if frames != last_frames {
+                        last_frames = frames;
+                        stalled = Duration::ZERO; // the render thread is progressing - plain back-pressure
+                        continue;
+                    }
+                    stalled += POLL;
+                    if stalled < STALL_GRACE {
+                        continue;
+                    }
+                    log::error!(
+                        "Render thread did not consume any control message for {:?} and did not \
+                         advance the playhead - assuming the audio device is gone, closing the \
+                         AudioContext",
+                        STALL_GRACE
+                    );
+                    self.set_state(AudioContextState::Closed);
+                    return;
+                }
+            }
+        }
+    }
+
+    /// Waits until the render thread acknowledges a *synchronous* control
+    /// message (the oneshot notify used by Suspend / Resume / Close).
+    ///
+    /// online.rs used a bare `receiver.recv().ok()` - the same hang surface as
+    /// the send side: with the render thread stalled the notify never arrives
+    /// and close_sync()/suspend_sync() block the control thread forever.
+    /// "Device unplugged, app calls ctx.close()" is precisely the most likely
+    /// call sequence in that situation. The wait uses the same frames_played
+    /// liveness rule: zero progress across `STALL_GRACE` deems the device dead,
+    /// marks the context Closed and returns `false` so the caller can skip
+    /// further operations against a device that no longer exists.
+    ///
+    /// On a healthy device the behavior is identical to upstream: the notify
+    /// arrives within one quantum (the render thread drains control messages on
+    /// every callback).
+    pub(crate) fn wait_for_render_thread(&self, receiver: &Receiver<()>) -> bool {
+        const POLL: Duration = Duration::from_millis(50);
+        const STALL_GRACE: Duration = Duration::from_secs(2);
+
+        let mut last_frames = self.inner.frames_played.load(Ordering::Relaxed);
+        let mut stalled = Duration::ZERO;
+
+        loop {
+            match receiver.recv_timeout(POLL) {
+                Ok(()) => return true,
+                Err(RecvTimeoutError::Disconnected) => return true, // render thread is gone - nothing to wait for
+                Err(RecvTimeoutError::Timeout) => {
+                    let frames = self.inner.frames_played.load(Ordering::Relaxed);
+                    if frames != last_frames {
+                        last_frames = frames;
+                        stalled = Duration::ZERO;
+                        continue;
+                    }
+                    stalled += POLL;
+                    if stalled < STALL_GRACE {
+                        continue;
+                    }
+                    log::error!(
+                        "Render thread did not respond within {:?} - assuming the audio device is \
+                         gone, closing the AudioContext",
+                        STALL_GRACE
+                    );
+                    self.set_state(AudioContextState::Closed);
+                    return false;
+                }
             }
         }
     }
@@ -292,9 +422,10 @@ impl ConcreteBaseAudioContext {
     pub(crate) fn suspend_control_msgs(&self, msg: ControlMessage) {
         let sender = self.inner.render_channel.read().unwrap();
         *self.inner.suspended_messages.lock().unwrap() = Some(Vec::new());
-        if sender.send(msg).is_err() {
-            log::warn!("Discarding control message - render thread is closed");
-        }
+        // Same as send_control_msg: this path must not hang either. Routing
+        // through the same function keeps a single FIFO, which preserves
+        // ordering with any messages already queued.
+        self.send_to_render_thread(&sender, msg);
     }
 
     pub(crate) fn resume_control_msgs(&self, msg: ControlMessage) {
@@ -308,15 +439,10 @@ impl ConcreteBaseAudioContext {
             .unwrap_or_default();
 
         for msg in messages {
-            if sender.send(msg).is_err() {
-                log::warn!("Discarding control message - render thread is closed");
-                return;
-            }
+            self.send_to_render_thread(&sender, msg);
         }
 
-        if sender.send(msg).is_err() {
-            log::warn!("Discarding control message - render thread is closed");
-        }
+        self.send_to_render_thread(&sender, msg);
     }
 
     pub(crate) fn send_event(&self, msg: EventDispatch) -> Result<(), SendError<EventDispatch>> {

--- a/src/context/concrete_base.rs
+++ b/src/context/concrete_base.rs
@@ -419,6 +419,62 @@ impl ConcreteBaseAudioContext {
         }
     }
 
+    /// Same liveness rule as `wait_for_render_thread`, for protocol steps that
+    /// expect a payload back from the render thread - currently the audio
+    /// graph handed back during a sink change (`CloseAndRecycle`).
+    ///
+    /// `set_sink_id_sync` used a bare `graph_recv.recv().unwrap()`. With the
+    /// render thread stalled (device unplugged, driver dead - cpal only calls
+    /// err_fn and stops issuing callbacks) the graph never arrives and the
+    /// control thread blocks forever; "output device disappeared, application
+    /// switches to another sink" is precisely the sequence that hits this.
+    ///
+    /// Returns `None` when the render thread is deemed gone: zero playhead
+    /// progress across `STALL_GRACE`, or the reply channel disconnected
+    /// without a payload. The context is marked Closed in both cases - the
+    /// graph is unrecoverable at that point, so no later operation could
+    /// succeed anyway.
+    pub(crate) fn recv_from_render_thread<T>(&self, receiver: &Receiver<T>) -> Option<T> {
+        const POLL: Duration = Duration::from_millis(50);
+        const STALL_GRACE: Duration = Duration::from_secs(2);
+
+        let mut last_frames = self.inner.frames_played.load(Ordering::Relaxed);
+        let mut stalled = Duration::ZERO;
+
+        loop {
+            match receiver.recv_timeout(POLL) {
+                Ok(v) => return Some(v),
+                Err(RecvTimeoutError::Disconnected) => {
+                    log::error!(
+                        "Render thread dropped the reply channel without responding - closing \
+                         the AudioContext"
+                    );
+                    self.set_state(AudioContextState::Closed);
+                    return None;
+                }
+                Err(RecvTimeoutError::Timeout) => {
+                    let frames = self.inner.frames_played.load(Ordering::Relaxed);
+                    if frames != last_frames {
+                        last_frames = frames;
+                        stalled = Duration::ZERO;
+                        continue;
+                    }
+                    stalled += POLL;
+                    if stalled < STALL_GRACE {
+                        continue;
+                    }
+                    log::error!(
+                        "Render thread did not respond within {:?} - assuming the audio device \
+                         is gone, closing the AudioContext",
+                        STALL_GRACE
+                    );
+                    self.set_state(AudioContextState::Closed);
+                    return None;
+                }
+            }
+        }
+    }
+
     pub(crate) fn suspend_control_msgs(&self, msg: ControlMessage) {
         let sender = self.inner.render_channel.read().unwrap();
         *self.inner.suspended_messages.lock().unwrap() = Some(Vec::new());

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -684,7 +684,15 @@ impl AudioContext {
         // Wait for the render thread to have processed the suspend message.
         // The AudioContextState will be updated by the render thread.
         log::debug!("Suspending audio graph, waiting for signal..");
-        receiver.recv().ok();
+        // Liveness wait (see ConcreteBaseAudioContext::wait_for_render_thread):
+        // with the render thread stalled the notify never arrives and a bare
+        // recv() would block the control thread forever.
+        if !self.base.wait_for_render_thread(&receiver) {
+            // The render side is dead and the context has been marked Closed;
+            // do not touch a device that no longer exists (backend.suspend()
+            // would fail).
+            return;
+        }
 
         // Then ask the audio host to suspend the stream
         log::debug!("Suspended audio graph. Suspending audio stream..");
@@ -731,7 +739,11 @@ impl AudioContext {
 
         // Wait for the render thread to have processed the resume message
         // The AudioContextState will be updated by the render thread.
-        receiver.recv().ok();
+        // Liveness wait - same reasoning as in suspend_sync (a stalled render
+        // thread never sends the notify and a bare recv() hangs).
+        if !self.base.wait_for_render_thread(&receiver) {
+            return; // render side is dead - the context is Closed now
+        }
         log::debug!("Resumed audio graph");
     }
 
@@ -768,7 +780,12 @@ impl AudioContext {
             // Wait for the render thread to have processed the suspend message.
             // The AudioContextState will be updated by the render thread.
             log::debug!("Suspending audio graph, waiting for signal..");
-            receiver.recv().ok();
+            // Liveness wait - the notify never arrives when the render thread
+            // is stalled, and close() is exactly the API an application calls
+            // right after a device disappears. On a stall the wait marks the
+            // context Closed; execution then continues below to shut down the
+            // audio stream and release device resources (no early return).
+            self.base.wait_for_render_thread(&receiver);
         } else {
             // if the context is not running, change the state manually
             self.base.set_state(AudioContextState::Closed);
@@ -1007,5 +1024,39 @@ mod tests {
             .any(|node| node.id == DESTINATION_NODE_ID.0
                 && node.inputs == node.input_channels.len()
                 && node.outputs == node.output_channels.len()));
+    }
+}
+
+#[cfg(test)]
+mod render_stall_tests {
+    use super::*;
+    use crate::node::AudioNode;
+
+    #[test]
+    fn test_stall_detector_does_not_misfire_on_suspended_context() {
+        // Guard against false positives of the liveness-based stall detection:
+        // a suspended context keeps draining its control channel even though
+        // the playhead does not advance, so flooding it with far more messages
+        // than the channel capacity (256) must neither block the control
+        // thread nor close the context. (The stall direction itself - a device
+        // that disappeared, taking the draining render callback with it -
+        // cannot be simulated deterministically without hardware; see the
+        // commit message for the manual reproduction.)
+        let options = AudioContextOptions {
+            sink_id: "none".into(),
+            ..AudioContextOptions::default()
+        };
+        let context = AudioContext::new(options);
+        context.suspend_sync();
+
+        let gain = context.create_gain();
+        for i in 0..2000 {
+            gain.gain().set_value(i as f32);
+        }
+
+        assert_eq!(context.state(), AudioContextState::Suspended);
+        context.resume_sync();
+        assert_eq!(context.state(), AudioContextState::Running);
+        let _ = context.close_sync();
     }
 }

--- a/src/context/online.rs
+++ b/src/context/online.rs
@@ -411,7 +411,20 @@ impl AudioContext {
                 // No new audio will be produced because it will receive the shutdown command first.
                 backend_manager_guard.resume()?;
             }
-            graph_recv.recv().unwrap()
+            // Do not block indefinitely: with the render thread stalled (device
+            // unplugged / driver dead) the graph never comes back and a bare
+            // recv() hangs the control thread forever. The liveness wait marks
+            // the context Closed when the render side is deemed gone.
+            match self.base.recv_from_render_thread(&graph_recv) {
+                Some(graph) => graph,
+                None => {
+                    return Err(
+                        "InvalidStateError - the render thread is unresponsive, the AudioContext \
+                         has been closed"
+                            .into(),
+                    );
+                }
+            }
         };
 
         log::debug!("SinkChange: closing audio stream");

--- a/tests/online.rs
+++ b/tests/online.rs
@@ -376,3 +376,29 @@ fn test_control_messages_do_not_block_while_suspended() {
         "control messages blocked while the render callback was suspended"
     );
 }
+
+#[test]
+fn test_invalid_sink_id_is_rejected_without_closing_the_context() {
+    // An unknown sinkId is rejected before any teardown of the current
+    // backend, so it must leave the context fully operational. This guards
+    // the sink-change failure ordering: once the old backend has been closed
+    // and the graph taken out of the render thread, a failure to build the
+    // *new* backend closes the context (nothing can produce audio anymore) -
+    // but a mere validation error must never take that path.
+    let options = AudioContextOptions {
+        sink_id: "none".to_string(),
+        ..AudioContextOptions::default()
+    };
+    let context = AudioContext::new(options);
+    assert_eq!(context.state(), AudioContextState::Running);
+
+    let result = context.set_sink_id_sync("no-such-device".to_string());
+    assert!(result.is_err());
+
+    // the context is still alive and usable
+    assert_eq!(context.state(), AudioContextState::Running);
+    assert_eq!(context.sink_id(), "none");
+
+    context.close_sync();
+    assert_eq!(context.state(), AudioContextState::Closed);
+}


### PR DESCRIPTION
This PR groups two commits that make the control thread resilient to a stalled render thread; the sink-change fix reuses the liveness rule introduced by the first commit, so they are kept together.

## Never block the control thread indefinitely on a stalled render thread

Two related hang surfaces, both triggered by a render thread that stops
draining its channels - in practice: the output device was unplugged or
the driver died, upon which cpal only invokes err_fn (which logs) and
stops issuing callbacks.

1. send_control_msg() performed a blocking send() into the bounded(256)
   control channel. Once the render callback stops draining, the 257th
   message blocks the sending thread forever. Applications hosting a
   scripting engine send control messages from their main thread, which
   then hangs wholesale.

2. suspend_sync()/resume_sync()/close_sync() send a oneshot notify
   through the same machinery and then wait with a bare recv() for the
   render thread to acknowledge. With the render thread gone the notify
   never arrives. close() is exactly the API an application calls right
   after a device disappears, and it hung forever.

Manual reproduction: play audio through a USB audio interface, unplug
it, then keep using the context (schedule >256 param changes, or call
ctx.close()). The control thread never returns.

Fix: keep the channel bounded (the receiving side lives on the render
thread; a bounded channel is allocation-free and realtime-safe) and keep
blocking back-pressure semantics (single FIFO: no drops, no reordering),
but replace the indefinite waits with waits on render-thread liveness.
While the channel is full (or the ack is pending), poll every 50 ms and
check whether frames_played advanced - the render thread bumps it by 128
per rendered quantum. Progress means plain back-pressure: keep waiting,
exactly like before. Zero progress across a 2 s window (~700 missed
quanta - not busyness) means the render side is gone: mark the context
Closed, drop the in-flight message / stop waiting, and let the existing
Closed short-circuit discard all subsequent messages. Dropping is safe
at that point: a Closed context discards control messages anyway, and
there is no render thread left to execute them.

Liveness (playhead progress) is used instead of a fixed send timeout so
that healthy-but-busy devices and device startup cannot misfire the
detection. Offline contexts are unaffected (their control channel is
unbounded, and their playhead only advances under explicit rendering
calls on the control thread itself).

A regression test guards the false-positive direction: a suspended
context keeps draining its channel without advancing the playhead, so
flooding it with thousands of messages must neither hang nor close it.
The stall direction requires actual device removal and remains a manual
test.


## Do not hang or silently kill the context when a sink change fails

set_sink_id_sync had two failure paths that misbehaved when the audio
device disappears mid-protocol (unplugged USB interface, dead driver -
cpal only reports through err_fn and stops issuing callbacks):

1. After sending CloseAndRecycle it waited for the render thread to
   hand back the audio graph with a bare graph_recv.recv().unwrap().
   With the render thread stalled the graph never arrives and the
   control thread blocks forever. "Device disappeared, application
   switches to another sink" is precisely the sequence that hits this.

2. If io::build_output for the new sink failed after the old backend
   had already been closed, the error was returned but the context kept
   claiming its previous state - typically Running - while the graph
   had been taken out of the render thread and dropped. Nothing can
   produce audio at that point; every later call quietly operates on a
   dead context.

The graph wait now uses the same frames_played liveness rule introduced
for send_control_msg and the suspend/resume/close acknowledgements:
poll every 50 ms and only declare the render thread gone after 2 s
without playhead progress. Progress means plain back-pressure and the
wait continues exactly as before. On a stall (or a disconnected reply
channel) the context is marked Closed and the call returns an error
instead of hanging. A build_output failure after teardown also marks
the context Closed so the observable state reflects reality.

The stall direction requires physically removing a device and remains a
manual test. A regression test covers the ordering guarantee that must
not change: rejecting an invalid sinkId happens before any teardown and
must leave the context running and usable.

