### PR TITLE
Ignore repeated connect() calls with identical termini

### DIFF
--- a/src/context/concrete_base.rs
+++ b/src/context/concrete_base.rs
@@ -441,11 +441,25 @@ impl ConcreteBaseAudioContext {
 
     /// Connects the output of the `from` audio node to the input of the `to` audio node
     pub(crate) fn connect(&self, from: AudioNodeId, to: AudioNodeId, output: usize, input: usize) {
-        self.inner
+        // The connections set is the authoritative list of established
+        // connections, but the ConnectNode message used to be sent
+        // unconditionally. Graph::add_edge on the render thread is a plain
+        // Vec::push, so a repeated connect() with identical termini created a
+        // duplicate render edge and the destination summed the source twice
+        // (audibly louder, and N-fold after N calls). The spec requires the
+        // repeat call to be a no-op: "There can only be one connection between
+        // a given output of one specific node and a given input of another
+        // specific node. Multiple connections with the same termini are
+        // ignored."
+        let inserted = self
+            .inner
             .connections
             .lock()
             .unwrap()
             .insert((from, output, to, input));
+        if !inserted {
+            return;
+        }
         let message = ControlMessage::ConnectNode {
             from,
             to,

--- a/tests/offline.rs
+++ b/tests/offline.rs
@@ -242,3 +242,31 @@ fn test_cycle_breaker() {
         abs_all <= 0.
     );
 }
+
+#[test]
+fn test_repeated_connect_with_identical_termini_is_a_single_connection() {
+    // Spec: "There can only be one connection between a given output of one
+    // specific node and a given input of another specific node. Multiple
+    // connections with the same termini are ignored."
+    //
+    // The connections set on the control thread already deduplicated, but the
+    // ConnectNode message was sent unconditionally and Graph::add_edge is a
+    // plain push - so every repeated connect() call added another render edge
+    // and the destination summed the source once more (2x, 3x, ... louder).
+    let mut context = OfflineAudioContext::new(1, RENDER_QUANTUM_SIZE, 44_100.);
+
+    let mut constant = context.create_constant_source();
+    constant.offset().set_value(1.);
+    constant.connect(&context.destination());
+    constant.connect(&context.destination()); // must be ignored
+    constant.connect(&context.destination()); // must be ignored
+    constant.start();
+
+    let output = context.start_rendering_sync();
+    let samples = output.get_channel_data(0);
+    assert_float_eq!(samples[64], 1., abs <= 0.);
+
+    // after an explicit disconnect the connection can be re-established
+    constant.disconnect_dest(&context.destination());
+    constant.connect(&context.destination());
+}


### PR DESCRIPTION
ConcreteBaseAudioContext::connect records connections in a HashSet, but
the ConnectNode control message was sent unconditionally. On the render
thread Graph::add_edge is a plain Vec push, so every repeated connect()
call with the same (source, output, destination, input) tuple added
another render edge and the destination summed the source once more:
twice as loud after two calls, N-fold after N.

The spec requires the repeat call to be a no-op: "There can only be one
connection between a given output of one specific node and a given
input of another specific node. Multiple connections with the same
termini are ignored."

Reproduce: connect a ConstantSourceNode (offset 1.0) to the destination
of an OfflineAudioContext twice and render - the output is 2.0 instead
of 1.0.

Node teardown already clears the connection set for recycled ids, so
suppressing the duplicate message cannot mask a legitimate reconnect;
an explicit disconnect removes the entry and a subsequent connect
re-establishes the edge.

Includes an offline-render regression test.

