### PR TITLE
Removing a graph edge does not need a topological sort

### DIFF
--- a/benches/my_benchmark.rs
+++ b/benches/my_benchmark.rs
@@ -320,27 +320,30 @@ pub fn bench_graph_reordering() {
         nodes.last().unwrap().connect(&ctx.destination());
     }
 
-    // Keep these handles alive after their callbacks disconnect them. Otherwise
-    // dropping a handle would add node reclamation to the measurement.
-    let switches = Arc::new(
+    // Each pair is initially disconnected. Because the source is registered before
+    // its destination, the initial unconstrained order puts the destination first.
+    // Connecting the pair therefore invalidates the current ordering.
+    let pending_edges = Arc::new(
         (0..REORDER_COUNT)
             .map(|_| {
-                let node = ctx.create_gain();
-                node.connect(&ctx.destination());
-                node
+                let source = ctx.create_gain();
+                let destination = ctx.create_gain();
+                (source, destination)
             })
             .collect::<Vec<_>>(),
     );
 
     for index in 0..REORDER_COUNT {
-        let switches = Arc::clone(&switches);
+        let pending_edges = Arc::clone(&pending_edges);
         let suspend_time = ((index + 1) * RENDER_QUANTUM_SIZE) as f64 / SAMPLE_RATE as f64;
-        ctx.suspend_sync(suspend_time, move |_| switches[index].disconnect());
+        ctx.suspend_sync(suspend_time, move |_| {
+            pending_edges[index].0.connect(&pending_edges[index].1);
+        });
     }
 
     assert_eq!(ctx.start_rendering_sync().length(), length);
     black_box(nodes);
-    black_box(switches);
+    black_box(pending_edges);
 }
 
 macro_rules! iai_or_criterion {

--- a/src/render/graph.rs
+++ b/src/render/graph.rs
@@ -288,7 +288,11 @@ impl Graph {
                 edge.other_id != dest.0 || edge.self_index != source.1 || edge.other_index != dest.1
             });
 
-        self.ordered.clear(); // void current ordering
+        // Removing an edge cannot invalidate an existing topological order. Re-sort only when
+        // this removal may release nodes that were omitted because they are part of a cycle.
+        if !self.in_cycle.is_empty() {
+            self.ordered.clear();
+        }
     }
 
     pub fn mark_control_handle_dropped(&mut self, index: AudioNodeId) {
@@ -704,6 +708,43 @@ mod tests {
             .position(|&n| n == AudioNodeId(2))
             .unwrap();
         assert!(pos2 < pos1); // node 1 depends on node 2
+    }
+
+    #[test]
+    fn remove_edge_preserves_acyclic_ordering() {
+        let mut graph = Graph::new(llq::Queue::new().split().0);
+        let node = Box::new(TestNode { tail_time: false });
+        add_node(&mut graph, 0, node.clone());
+        add_node(&mut graph, 1, node);
+        add_edge(&mut graph, 1, 0);
+        graph.order_nodes();
+
+        let ordered = graph.ordered.clone();
+        graph.remove_edge((AudioNodeId(1), 0), (AudioNodeId(0), 0));
+
+        assert_eq!(graph.ordered, ordered);
+    }
+
+    #[test]
+    fn remove_edge_invalidates_ordering_with_cycle() {
+        let mut graph = Graph::new(llq::Queue::new().split().0);
+        let node = Box::new(TestNode { tail_time: false });
+        add_node(&mut graph, 0, node.clone());
+        add_node(&mut graph, 1, node.clone());
+        add_node(&mut graph, 2, node);
+        add_edge(&mut graph, 1, 2);
+        add_edge(&mut graph, 2, 1);
+        graph.order_nodes();
+
+        assert!(graph.in_cycle.contains(&AudioNodeId(1)));
+        assert!(graph.in_cycle.contains(&AudioNodeId(2)));
+
+        graph.remove_edge((AudioNodeId(2), 0), (AudioNodeId(1), 0));
+        assert!(graph.ordered.is_empty());
+
+        graph.order_nodes();
+        assert!(graph.ordered.contains(&AudioNodeId(1)));
+        assert!(graph.ordered.contains(&AudioNodeId(2)));
     }
 
     #[test]


### PR DESCRIPTION
Relates to #129