### PR TITLE
Update hrtf dependency version to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ futures-util = { version = "0.3.30", default-features = false, features = [
     "sink",
 ] }
 hound = "3.5"
-hrtf = "0.8.1"
+hrtf = "0.9"
 llq = "0.1.1"
 log = "0.4"
 num-complex = "0.4"


### PR DESCRIPTION
It has a fix for sample rate dependent volume

Fixes #601 