### PR TITLE
Free non-cyclic DelayNodes when the output is unused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `decode_audio_data` and `decode_audio_data_sync` no longer require the reader to be `'static`,
   so an audio source that borrows from the stack can be decoded
+- Fix: automatically free the resources of non-cyclic `DelayNode`s when their output is unused
 
 ## Version 1.7.0 (2026-08-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - `decode_audio_data` and `decode_audio_data_sync` no longer require the reader to be `'static`,
   so an audio source that borrows from the stack can be decoded
 - Fix: automatically free the resources of non-cyclic `DelayNode`s when their output is unused
+- Fix: a fire-and-forget `DelayNode` no longer re-emits a phantom copy of its input one
+  `max_delay_time` later, after the `DelayWriter` end has been reclaimed
 
 ## Version 1.7.0 (2026-08-06)
 

--- a/src/node/delay.rs
+++ b/src/node/delay.rs
@@ -313,6 +313,9 @@ impl DelayNode {
         let latest_frame_written = Rc::new(Cell::new(u64::MAX));
         let latest_frame_written_clone = Rc::clone(&latest_frame_written);
 
+        let in_cycle = Rc::new(Cell::new(false));
+        let in_cycle_clone = Rc::clone(&in_cycle);
+
         let node = context.base().register(move |writer_registration| {
             let node = context.base().register(move |reader_registration| {
                 let param_opts = AudioParamDescriptor {
@@ -331,7 +334,7 @@ impl DelayNode {
                     ring_buffer: shared_ring_buffer_clone,
                     index: 0,
                     last_written_index: last_written_index_clone,
-                    in_cycle: false,
+                    in_cycle: in_cycle_clone,
                     last_written_index_checked: None,
                     latest_frame_written: latest_frame_written_clone,
                 };
@@ -351,6 +354,7 @@ impl DelayNode {
                 index: 0,
                 last_written_index,
                 latest_frame_written,
+                in_cycle,
             };
 
             (node, Box::new(writer_render))
@@ -378,6 +382,7 @@ struct DelayWriter {
     index: usize,
     latest_frame_written: Rc<Cell<u64>>,
     last_written_index: Rc<Cell<Option<usize>>>,
+    in_cycle: Rc<Cell<bool>>,
 }
 
 // SAFETY:
@@ -461,7 +466,11 @@ impl AudioProcessor for DelayWriter {
     }
 
     fn has_side_effects(&self) -> bool {
-        true // message passing
+        // The writer produces no output; it only mutates the shared ring buffer. It must stay in
+        // the graph when it is breaking a feedback cycle (its reader feeds back into it), otherwise
+        // the loop would go silent. When it is not in a cycle it can be reclaimed once nothing
+        // reads from it any more. The reader reports cycle membership through this shared flag.
+        self.in_cycle.get()
     }
 }
 
@@ -493,7 +502,7 @@ struct DelayReader {
     ring_buffer: Rc<RefCell<Vec<AudioRenderQuantum>>>,
     index: usize,
     latest_frame_written: Rc<Cell<u64>>,
-    in_cycle: bool,
+    in_cycle: Rc<Cell<bool>>,
     last_written_index: Rc<Cell<Option<usize>>>,
     // local copy of shared `last_written_index` so as to avoid render ordering issues
     last_written_index_checked: Option<usize>,
@@ -532,11 +541,12 @@ impl AudioProcessor for DelayReader {
         let number_of_channels = ring_buffer[0].number_of_channels();
         output.set_number_of_channels(number_of_channels);
 
-        if !self.in_cycle {
+        if !self.in_cycle.get() {
             // check the latest written frame by the delay writer
             let latest_frame_written = self.latest_frame_written.get();
             // if the delay writer has not rendered before us, the cycle breaker has been applied
-            self.in_cycle = latest_frame_written != scope.current_frame;
+            self.in_cycle
+                .set(latest_frame_written != scope.current_frame);
             // once we store in_cycle = true, we do not want to go back to false
             // https://github.com/orottier/web-audio-api-rs/pull/198#discussion_r945326200
         }
@@ -553,7 +563,7 @@ impl AudioProcessor for DelayReader {
         if delay.len() == 1 {
             playback_infos[0] = Self::get_playback_infos(
                 f64::from(delay[0]),
-                self.in_cycle,
+                self.in_cycle.get(),
                 0.,
                 quantum_duration,
                 sample_rate,
@@ -590,7 +600,7 @@ impl AudioProcessor for DelayReader {
                 .for_each(|(index, (&d, infos))| {
                     *infos = Self::get_playback_infos(
                         f64::from(d),
-                        self.in_cycle,
+                        self.in_cycle.get(),
                         index as f64,
                         quantum_duration,
                         sample_rate,

--- a/src/node/delay.rs
+++ b/src/node/delay.rs
@@ -304,9 +304,10 @@ impl DelayNode {
         let shared_ring_buffer = Rc::new(RefCell::new(ring_buffer));
         let shared_ring_buffer_clone = Rc::clone(&shared_ring_buffer);
 
-        // shared value set by the writer when it is dropped
-        let last_written_index = Rc::new(Cell::<Option<usize>>::new(None));
-        let last_written_index_clone = Rc::clone(&last_written_index);
+        // shared flag, set by the writer when it is decommissioned so the reader knows to flush
+        // its buffered tail and then stop
+        let writer_dropped = Rc::new(Cell::new(false));
+        let writer_dropped_clone = Rc::clone(&writer_dropped);
 
         // shared value for reader/writer to determine who was rendered first,
         // this will indicate if the delay node acts as a cycle breaker
@@ -333,9 +334,9 @@ impl DelayNode {
                     delay_time: proc,
                     ring_buffer: shared_ring_buffer_clone,
                     index: 0,
-                    last_written_index: last_written_index_clone,
+                    writer_dropped: writer_dropped_clone,
                     in_cycle: in_cycle_clone,
-                    last_written_index_checked: None,
+                    flush_quanta: None,
                     latest_frame_written: latest_frame_written_clone,
                 };
 
@@ -352,7 +353,7 @@ impl DelayNode {
             let writer_render = DelayWriter {
                 ring_buffer: shared_ring_buffer,
                 index: 0,
-                last_written_index,
+                writer_dropped,
                 latest_frame_written,
                 in_cycle,
             };
@@ -381,7 +382,7 @@ struct DelayWriter {
     ring_buffer: Rc<RefCell<Vec<AudioRenderQuantum>>>,
     index: usize,
     latest_frame_written: Rc<Cell<u64>>,
-    last_written_index: Rc<Cell<Option<usize>>>,
+    writer_dropped: Rc<Cell<bool>>,
     in_cycle: Rc<Cell<bool>>,
 }
 
@@ -413,13 +414,7 @@ trait RingBufferChecker {
 
 impl Drop for DelayWriter {
     fn drop(&mut self) {
-        let last_written_index = if self.index == 0 {
-            self.ring_buffer.borrow().capacity() - 1
-        } else {
-            self.index - 1
-        };
-
-        self.last_written_index.set(Some(last_written_index));
+        self.writer_dropped.set(true);
     }
 }
 
@@ -503,9 +498,10 @@ struct DelayReader {
     index: usize,
     latest_frame_written: Rc<Cell<u64>>,
     in_cycle: Rc<Cell<bool>>,
-    last_written_index: Rc<Cell<Option<usize>>>,
-    // local copy of shared `last_written_index` so as to avoid render ordering issues
-    last_written_index_checked: Option<usize>,
+    writer_dropped: Rc<Cell<bool>>,
+    // number of render quanta the reader may still emit after the writer was decommissioned,
+    // to flush the audio that is already buffered; `None` while the writer is still alive
+    flush_quanta: Option<usize>,
 }
 
 // SAFETY:
@@ -541,7 +537,7 @@ impl AudioProcessor for DelayReader {
         let number_of_channels = ring_buffer[0].number_of_channels();
         output.set_number_of_channels(number_of_channels);
 
-        if !self.in_cycle.get() {
+        if !self.in_cycle.get() && !self.writer_dropped.get() {
             // check the latest written frame by the delay writer
             let latest_frame_written = self.latest_frame_written.get();
             // if the delay writer has not rendered before us, the cycle breaker has been applied
@@ -673,19 +669,18 @@ impl AudioProcessor for DelayReader {
             output.make_silent();
         }
 
-        if matches!(self.last_written_index_checked, Some(index) if index == self.index) {
-            return false;
+        match &mut self.flush_quanta {
+            Some(0) => return false,
+            Some(remaining) => *remaining -= 1,
+            None if self.writer_dropped.get() => {
+                let max_delay = delay.iter().copied().fold(0.0_f32, f32::max);
+                let delay_samples = f64::from(max_delay) * sample_rate;
+                self.flush_quanta =
+                    Some((delay_samples / RENDER_QUANTUM_SIZE as f64).ceil() as usize);
+            }
+            None => {}
         }
 
-        // check if the writer has been decommissioned
-        // we need this local copy because if the writer has been processed
-        // before the reader, the direct check against `self.last_written_index`
-        // would be true earlier than we want
-        let last_written_index = self.last_written_index.get();
-
-        if last_written_index.is_some() && self.last_written_index_checked.is_none() {
-            self.last_written_index_checked = last_written_index;
-        }
         // increment ring buffer cursor
         self.index = (self.index + 1) % ring_buffer.capacity();
 

--- a/tests/delay_lifecycle.rs
+++ b/tests/delay_lifecycle.rs
@@ -1,0 +1,155 @@
+//! Resource cleanup of `DelayNode`.
+//!
+//! Regression tests that a non-cyclic delay subgraph is disposed once every control handle is
+//! dropped, while a delay inside a feedback cycle keeps rendering its tail.
+
+use web_audio_api::context::{BaseAudioContext, OfflineAudioContext};
+use web_audio_api::node::{AudioNode, AudioScheduledSourceNode};
+
+/// A plain delay connected to the destination, then fully dropped, must still emit the delayed copy
+/// of its finite input.
+#[test]
+fn plain_delay_fire_and_forget_still_delays() {
+    let sample_rate = 48_000.0_f32;
+    let length = sample_rate as usize;
+    let mut context = OfflineAudioContext::new(1, length, sample_rate);
+
+    {
+        let mut src = context.create_constant_source();
+        src.offset().set_value(1.0);
+
+        let delay = context.create_delay(1.0);
+        delay.delay_time().set_value(0.15);
+
+        src.connect(&delay);
+        delay.connect(&context.destination());
+
+        src.start_at(0.0);
+        src.stop_at(0.02);
+    }
+
+    let out = context.start_rendering_sync();
+    let ch = out.get_channel_data(0);
+
+    // a 20 ms pulse delayed by 150 ms: silence at 100 ms, the pulse at 160 ms
+    assert!(
+        ch[(0.10 * sample_rate) as usize].abs() < 1e-6,
+        "output should be silent before the delay time"
+    );
+    assert!(
+        ch[(0.16 * sample_rate) as usize].abs() > 0.5,
+        "delayed signal missing"
+    );
+}
+
+/// A delay in a feedback cycle keeps rendering its decaying echo tail after every handle is
+/// dropped. Its reader flags the writer as breaking a cycle, so the writer reports side effects and
+/// is not reclaimed while the loop is still ringing.
+#[test]
+fn feedback_delay_fire_and_forget_keeps_echoing() {
+    let sample_rate = 48_000.0_f32;
+    let length = sample_rate as usize; // 1 second
+    let mut context = OfflineAudioContext::new(1, length, sample_rate);
+
+    {
+        // 20 ms DC pulse
+        let mut src = context.create_constant_source();
+        src.offset().set_value(1.0);
+
+        let delay = context.create_delay(1.0);
+        delay.delay_time().set_value(0.15);
+
+        let feedback = context.create_gain();
+        feedback.gain().set_value(0.6);
+
+        //  src --> delay(writer)
+        //          delay(reader) --> feedback --> delay(writer)   (cycle)
+        //          delay(reader) --> destination
+        src.connect(&delay);
+        delay.connect(&feedback);
+        feedback.connect(&delay);
+        delay.connect(&context.destination());
+
+        src.start_at(0.0);
+        src.stop_at(0.02);
+
+        // fire and forget: every handle drops here
+    }
+
+    let out = context.start_rendering_sync();
+    let ch = out.get_channel_data(0);
+
+    // the pulse is repeated every 150 ms, each repeat scaled by the 0.6 feedback gain
+    let echo_early = ch[(0.16 * sample_rate) as usize].abs(); // direct delayed pulse (~1.0)
+    let echo_mid = ch[(0.31 * sample_rate) as usize].abs(); // 1 feedback repeat  (~0.6)
+    let echo_late = ch[(0.61 * sample_rate) as usize].abs(); // 3 feedback repeats (~0.216)
+
+    assert!(echo_early > 0.5, "delayed signal missing");
+    assert!(
+        echo_late > 0.05,
+        "feedback echoes died out - the writer was reclaimed"
+    );
+    assert!(
+        echo_mid < echo_early && echo_late < echo_mid,
+        "echo train is not decaying"
+    );
+}
+
+/// A non-cyclic delay whose reader output is connected to nothing must be reclaimed from the render
+/// graph once its handles are dropped - even while a source is still feeding its writer. Before the
+/// fix, the writer lingered forever because it is registered as a cycle breaker.
+#[cfg(feature = "diagnostics")]
+#[test]
+fn non_cyclic_delay_with_unused_output_is_disposed() {
+    use std::sync::mpsc;
+    use std::time::Duration;
+    use web_audio_api::context::{AudioContext, AudioContextOptions};
+
+    /// Poll the render graph for its current node count. The 'none' backend renders in real time,
+    /// so callers sleep between snapshots to let the lifecycle collector run.
+    fn node_count(context: &AudioContext) -> usize {
+        let (tx, rx) = mpsc::channel();
+        context.run_diagnostics(move |d| {
+            let _ = tx.send(d);
+        });
+        rx.recv_timeout(Duration::from_secs(1))
+            .expect("timed out waiting for diagnostics")
+            .graph
+            .node_count
+    }
+
+    let context = AudioContext::new(AudioContextOptions {
+        sink_id: "none".into(),
+        ..AudioContextOptions::default()
+    });
+    std::thread::sleep(Duration::from_millis(150));
+    let baseline = node_count(&context);
+
+    {
+        let mut src = context.create_constant_source();
+        src.offset().set_value(1.0);
+
+        let delay = context.create_delay(0.1);
+        delay.delay_time().set_value(0.05);
+
+        src.connect(&delay);
+        // NB. the delay output is deliberately left unconnected
+        src.start(); // no stop: keeps feeding the writer
+
+        std::thread::sleep(Duration::from_millis(100));
+        assert!(
+            node_count(&context) > baseline,
+            "delay subgraph was never registered"
+        );
+
+        // fire and forget: drop the source and delay handles
+    }
+
+    std::thread::sleep(Duration::from_millis(600));
+
+    assert_eq!(
+        node_count(&context),
+        baseline,
+        "the unused non-cyclic delay subgraph was not reclaimed after its handles were dropped"
+    );
+}

--- a/tests/delay_lifecycle.rs
+++ b/tests/delay_lifecycle.rs
@@ -42,6 +42,64 @@ fn plain_delay_fire_and_forget_still_delays() {
     );
 }
 
+/// After the `DelayWriter` is reclaimed, the `DelayReader` must flush only what is still buffered
+/// and then stop. It must not keep sweeping the ring buffer and re-emit its stale contents one
+/// `max_delay_time` later.
+#[test]
+fn delay_fire_and_forget_has_no_phantom_echo() {
+    const SAMPLE_RATE: f32 = 48_000.0;
+    const MAX_DELAY: f64 = 1.0;
+    const DELAY_TIME: f64 = 0.25;
+    const BURST_LEN: f64 = 0.5;
+
+    let render_len = (SAMPLE_RATE * 3.0) as usize;
+    let mut ctx = OfflineAudioContext::new(1, render_len, SAMPLE_RATE);
+
+    // a half-second burst of amplitude 1.0
+    let burst_samples = (SAMPLE_RATE as f64 * BURST_LEN) as usize;
+    let mut buffer = ctx.create_buffer(1, burst_samples, SAMPLE_RATE);
+    buffer.copy_to_channel(&vec![1.0_f32; burst_samples], 0);
+
+    let delay = ctx.create_delay(MAX_DELAY);
+    delay.delay_time().set_value(DELAY_TIME as f32);
+    delay.connect(&ctx.destination());
+
+    let mut src = ctx.create_buffer_source();
+    src.set_buffer(buffer);
+    src.connect(&delay);
+    src.start();
+
+    // fire and forget: the render thread reclaims the DelayWriter as soon as the source ends
+    drop(src);
+    drop(delay);
+
+    let rendered = ctx.start_rendering_sync();
+    let channel = rendered.get_channel_data(0);
+
+    let peak = |from: f64, to: f64| {
+        let a = (from * SAMPLE_RATE as f64) as usize;
+        let b = (to * SAMPLE_RATE as f64) as usize;
+        channel[a..b].iter().fold(0.0_f32, |m, s| m.max(s.abs()))
+    };
+
+    // the legitimate delayed copy lands at [DELAY_TIME, DELAY_TIME + BURST_LEN]
+    let legit = peak(DELAY_TIME, DELAY_TIME + BURST_LEN);
+    // everything one full max-delay period later must be silent
+    let phantom = peak(
+        MAX_DELAY + DELAY_TIME - 0.02,
+        MAX_DELAY + DELAY_TIME + BURST_LEN,
+    );
+
+    assert!(
+        legit > 0.5,
+        "expected the real delayed signal (peak {legit})"
+    );
+    assert!(
+        phantom < 1e-3,
+        "phantom echo: the burst is re-emitted {MAX_DELAY}s later (peak {phantom})"
+    );
+}
+
 /// A delay in a feedback cycle keeps rendering its decaying echo tail after every handle is
 /// dropped. Its reader flags the writer as breaking a cycle, so the writer reports side effects and
 /// is not reclaimed while the loop is still ringing.


### PR DESCRIPTION
## Summary

I am building a game engine which relies on `web-audio-api` under the hood. My use case involves making trees of `AudioNode`s, some of which are `DelayNode`s.

I'd like to be able to destroy an entire subtree of `AudioNode`s by disconnecting the root from the `AudioContext::destination` and then dropping their handles. However, the audio context will keep any subgraph alive that involves an `DelayNode` - even if its output is unused - when the `DelayNode` has active inputs. This can result in hard-to-spot memory leaks and wasted CPU time.

As a concrete example, imagine creating an `OscillatorNode -> DelayNode`, starting the oscillator, then dropping both nodes. This currently results in a memory leak.

As a fix, this PR shares the `in_cycle` flag computed by `DelayReader` with `DelayWriter`. `DelayWriter` will report that it does _not_ have side effects whenever `in_cycle` is `false`. This allows the audio context to reclaim resources from dead subgraphs involving `DelayNode`s.

I also encountered an issue with `DelayNode`s replaying stale data after being dropped from the control thread, so there's a unit test and fix for that too.

## Changes

- Turn `DelayReader::in_cycle` from `bool` into `Rc<Cell<bool>>`
- Send that data to the `DelayWriter`
- Report that value in `DelayWriter::has_side_effects`
- Make `DelayReader` count down the remaining render quanta it can read after the writer is dropped
- Add unit tests showing the issue and proving that this fixes it
- Update the changelog

## Notes

This does not fix the case of a dead cyclic graph. Imagine creating an `OscillatorNode -> DelayNode -> GainNode`, and then feeding the `GainNode` back into the `DelayNode`. That will still leak.