### PR TITLE
Remove 'static bound from `decode_audio_data` and `decode_audio_data_sync`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Version History
 
+## Unreleased
+
+- `decode_audio_data` and `decode_audio_data_sync` no longer require the reader to be `'static`,
+  so an audio source that borrows from the stack can be decoded
+
 ## Version 1.7.0 (2026-08-06)
 
 - Fix: Deduplicate connections between the same nodes

--- a/src/context/base.rs
+++ b/src/context/base.rs
@@ -65,7 +65,7 @@ pub trait BaseAudioContext {
     /// The following example shows how to use a thread pool for audio buffer decoding:
     ///
     /// `cargo run --release --example decode_multithreaded`
-    fn decode_audio_data_sync<R: std::io::Read + Send + Sync + 'static>(
+    fn decode_audio_data_sync<R: std::io::Read + Send + Sync>(
         &self,
         input: R,
     ) -> Result<AudioBuffer, Box<dyn std::error::Error + Send + Sync>> {
@@ -92,12 +92,11 @@ pub trait BaseAudioContext {
     /// This method returns an Error in various cases (IO, mime sniffing, decoding).
     // Use of `async fn` in public traits is discouraged as auto trait bounds cannot be specified,
     // hence we use `-> impl Future + ..` instead.
-    fn decode_audio_data<R: std::io::Read + Send + Sync + 'static>(
+    fn decode_audio_data<'a, R: std::io::Read + Send + Sync + 'a>(
         &self,
         input: R,
-    ) -> impl Future<Output = Result<AudioBuffer, Box<dyn std::error::Error + Send + Sync>>>
-           + Send
-           + 'static {
+    ) -> impl Future<Output = Result<AudioBuffer, Box<dyn std::error::Error + Send + Sync>>> + Send + 'a
+    {
         let sample_rate = self.sample_rate();
         async move { decode_media_data(input, sample_rate) }
     }
@@ -398,6 +397,29 @@ mod tests {
         let file = std::fs::File::open("samples/sample.wav").unwrap();
         let future = context.decode_audio_data(file);
         require_send_sync_static(future);
+    }
+
+    #[test]
+    fn test_decode_audio_data_sync_borrowed_reader() {
+        // the reader may borrow from the stack - it is only read from during the call
+        let bytes = std::fs::read("samples/sample.wav").unwrap();
+        let context = OfflineAudioContext::new(1, 1, 44100.);
+        let audio_buffer = context.decode_audio_data_sync(&bytes[..]).unwrap();
+
+        assert_eq!(audio_buffer.length(), 142_187);
+        assert_eq!(audio_buffer.number_of_channels(), 2);
+    }
+
+    #[test]
+    fn test_decode_audio_data_borrowed_reader() {
+        use futures::executor;
+        // the future borrows `bytes`, so it is not `'static`, but it can still be awaited here
+        let bytes = std::fs::read("samples/sample.wav").unwrap();
+        let context = OfflineAudioContext::new(1, 1, 44100.);
+        let audio_buffer = executor::block_on(context.decode_audio_data(&bytes[..])).unwrap();
+
+        assert_eq!(audio_buffer.length(), 142_187);
+        assert_eq!(audio_buffer.number_of_channels(), 2);
     }
 
     #[test]

--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -12,7 +12,7 @@ use symphonia::core::formats::probe::Hint;
 use symphonia::core::formats::{FormatOptions, FormatReader, TrackType};
 use symphonia::core::meta::MetadataOptions;
 
-pub(crate) fn decode_media_data<R: std::io::Read + Send + Sync + 'static>(
+pub(crate) fn decode_media_data<R: std::io::Read + Send + Sync>(
     input: R,
     target_sample_rate: f32,
 ) -> Result<AudioBuffer, Box<dyn std::error::Error + Send + Sync>> {
@@ -94,20 +94,20 @@ impl<R: Read + Send + Sync> symphonia::core::io::MediaSource for MediaInput<R> {
 /// Media stream decoder (OGG, WAV, FLAC, ..)
 ///
 /// The current implementation supports Symphonia's audio formats and codecs.
-pub(crate) struct MediaDecoder {
-    format: Box<dyn FormatReader>,
+pub(crate) struct MediaDecoder<'a> {
+    format: Box<dyn FormatReader + 'a>,
     decoder: Box<dyn AudioDecoder>,
     track_index: usize,
     packet_count: usize,
 }
 
-impl MediaDecoder {
+impl<'a> MediaDecoder<'a> {
     /// Try to construct a new instance from a `Read` implementer
     ///
     /// # Errors
     ///
     /// This method returns an Error in various cases (IO, mime sniffing, decoding).
-    pub fn try_new<R: std::io::Read + Send + Sync + 'static>(
+    pub fn try_new<R: std::io::Read + Send + Sync + 'a>(
         input: R,
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         // Symphonia lib needs a Box<dyn MediaSource> - use our own MediaInput
@@ -188,7 +188,7 @@ impl std::fmt::Display for UnsupportedAudioCodecError {
 
 impl std::error::Error for UnsupportedAudioCodecError {}
 
-impl Iterator for MediaDecoder {
+impl Iterator for MediaDecoder<'_> {
     type Item = Result<AudioBuffer, Box<dyn Error + Send + Sync>>;
 
     fn next(&mut self) -> Option<Self::Item> {


### PR DESCRIPTION
### Summary

`decode_audio_data` and `decode_audio_data_sync` required `R: 'static`, which forced callers to hand over an owned reader even though the reader is only ever read from during the call. This is overly-restrictive: Symphonia's `MediaSourceStream` and `FormatReader` are lifetime-generic, so nothing actually needs the `'static` bound. This PR removes the bound, so it's possible to decode types like `&[u8]`.

### Changes

- `MediaDecoder` gains a lifetime parameter and holds `Box<dyn FormatReader + 'a>`.
- `decode_media_data`, `decode_audio_data_sync` and `decode_audio_data` drop the `'static` bound on `R`. `decode_audio_data` returns a future bound by the reader's lifetime instead of `'static`.

### Notes

When the reader is `'static` (a `File`, an owned `Vec`/`Cursor`, ...) the future is still `'static` and `Send`, so `tokio::spawn` and the existing thread-pool pattern keep working unchanged.