### PR TITLE
Optimization: make ConstantSourceRenderer report near-zero output as silent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - `decode_audio_data` and `decode_audio_data_sync` no longer require the reader to be `'static`,
   so an audio source that borrows from the stack can be decoded
+- Fix: a running `ConstantSourceNode` outputting (near) zero now reports its output as silent
+  instead of materializing a zeroed buffer, so downstream `AudioParam`s and `GainNode`s can take
+  their near-zero fast paths again instead of processing at full a-rate cost indefinitely
 
 ## Version 1.7.0 (2026-08-06)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,10 @@ pub(crate) const RENDER_QUANTUM_SIZE: usize = 128;
 /// Maximum number of channels for audio processing
 pub const MAX_CHANNELS: usize = 32;
 
+/// Amplitude below which a signal is treated as inaudible silence (-120 dB). Used to fast-path
+/// near-zero values instead of processing/materializing a buffer that is effectively zero.
+pub(crate) const SILENCE_THRESHOLD: f32 = 1e-6;
+
 mod buffer;
 pub use buffer::*;
 

--- a/src/node/constant_source.rs
+++ b/src/node/constant_source.rs
@@ -224,19 +224,23 @@ impl AudioProcessor for ConstantSourceRenderer {
         output.force_mono();
 
         let offset = params.get(&self.offset);
-        let output_channel = output.channel_data_mut(0);
 
         // fast path
         if offset.len() == 1
             && self.start_time <= scope.current_time
             && self.stop_time >= next_block_time
         {
-            output_channel.fill(offset[0]);
+            if offset[0].abs() <= crate::SILENCE_THRESHOLD {
+                output.make_silent();
+            } else {
+                output.channel_data_mut(0).fill(offset[0]);
+            }
         } else {
             // sample accurate path
             let mut current_time = scope.current_time;
 
-            output_channel
+            output
+                .channel_data_mut(0)
                 .iter_mut()
                 .zip(offset.iter().cycle())
                 .for_each(|(o, &value)| {
@@ -305,6 +309,57 @@ mod tests {
         let options = ConstantSourceOptions { offset: 12. };
         let src = ConstantSourceNode::new(&context, options);
         assert_float_eq!(src.offset.value(), 12., abs_all <= 0.);
+    }
+
+    #[cfg(feature = "spec-compliant-worklet-inputs")]
+    #[test]
+    fn test_zero_offset_output_is_silent() {
+        use crate::worklet::AudioParamValues as WorkletParamValues;
+        use crate::worklet::{AudioWorkletNode, AudioWorkletNodeOptions, AudioWorkletProcessor};
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        struct SetBoolWhenInputSilent(Arc<AtomicBool>);
+
+        impl AudioWorkletProcessor for SetBoolWhenInputSilent {
+            type ProcessorOptions = Arc<AtomicBool>;
+
+            fn constructor(opts: Self::ProcessorOptions) -> Self {
+                Self(opts)
+            }
+
+            fn process<'a, 'b>(
+                &mut self,
+                inputs: &'b [&'a [&'a [f32]]],
+                _outputs: &'b mut [&'a mut [&'a mut [f32]]],
+                _params: WorkletParamValues<'b>,
+                _scope: &'b AudioWorkletGlobalScope,
+            ) -> bool {
+                if inputs[0].is_empty() {
+                    self.0.store(true, Ordering::Relaxed);
+                }
+                false
+            }
+        }
+
+        let mark_silent = Arc::new(AtomicBool::new(false));
+
+        let mut context = OfflineAudioContext::new(1, 256, 48000.);
+        let options = AudioWorkletNodeOptions {
+            number_of_inputs: 1,
+            number_of_outputs: 0,
+            processor_options: Arc::clone(&mark_silent),
+            ..AudioWorkletNodeOptions::default()
+        };
+        let worklet = AudioWorkletNode::new::<SetBoolWhenInputSilent>(&context, options);
+
+        let mut src = context.create_constant_source();
+        src.offset().set_value(0.);
+        src.connect(&worklet);
+        src.start();
+
+        let _ = context.start_rendering_sync();
+        assert!(mark_silent.load(Ordering::Relaxed));
     }
 
     #[test]

--- a/src/node/gain.rs
+++ b/src/node/gain.rs
@@ -163,16 +163,14 @@ impl AudioProcessor for GainRenderer {
         if gain.len() == 1 {
             // 1e-6 is -120 dB when close to 0 and ±8.283506e-6 dB when close to 1
             // very probably small enough to not be audible
-            let threshold = 1e-6;
-
             let diff_to_zero = gain[0].abs();
-            if diff_to_zero <= threshold {
+            if diff_to_zero <= crate::SILENCE_THRESHOLD {
                 output.make_silent();
                 return false;
             }
 
             let diff_to_one = (1. - gain[0]).abs();
-            if diff_to_one <= threshold {
+            if diff_to_one <= crate::SILENCE_THRESHOLD {
                 *output = input.clone();
                 return false;
             }


### PR DESCRIPTION
### Summary

I'm attempting to drive the value of multiple `GainNode`s by connecting a single `ConstantSourceNode` to their `GainNode::gain` param. When I set the value of the `ConstantSourceNode` to `0.0`, ideally downstream nodes would stop wasting CPU time.

The problem is that, when a started `ConstantSourceNode` is hooked up to an `AudioParam`, it will always fill an audio buffer with values, and never output the silent buffer:

https://github.com/orottier/web-audio-api-rs/blob/2af21af6ff2bbee17201b2dd2a5ebc56f55c3511/src/node/constant_source.rs#L228-L254

This causes the downstream `AudioParam` to always be treated as active A-rate:

https://github.com/orottier/web-audio-api-rs/blob/2af21af6ff2bbee17201b2dd2a5ebc56f55c3511/src/param.rs#L739-L781

Which, according to my understanding, will keep the associated `GainNode` awake. This PR makes it so that `ConstantSourceNode`s will output the silent buffer when they are near zero. I used the same `1e-6` threshold for silence that the `GainNode` already has.

### Changes

- Define `SILENCE_THRESHOLD` as a shared constant
- Refactor `GainNode` to use  `SILENCE_THRESHOLD`
- Make `ConstantSourceNode` additionally use `SILENCE_THRESHOLD` when the input is near zero
- Update CHANGELOG