### PR TITLE
Add media_devices::default_output_device / default_input_device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added `media_devices::default_output_device` and `media_devices::default_input_device`, returning
+  the `device_id` of the system default device
 - `decode_audio_data` and `decode_audio_data_sync` no longer require the reader to be `'static`,
   so an audio source that borrows from the stack can be decoded
 

--- a/src/io/cpal.rs
+++ b/src/io/cpal.rs
@@ -638,6 +638,58 @@ impl AudioBackendManager for CpalBackend {
 
         Ok(list)
     }
+
+    fn default_device_id(kind: MediaDeviceInfoKind) -> BackendResult<Option<String>>
+    where
+        Self: Sized,
+    {
+        let host = get_host()?;
+
+        let default_device = match kind {
+            MediaDeviceInfoKind::AudioInput => host.default_input_device(),
+            MediaDeviceInfoKind::AudioOutput => host.default_output_device(),
+            MediaDeviceInfoKind::VideoInput => None,
+        };
+        let Some(default_device) = default_device else {
+            return Ok(None);
+        };
+        let default_description = default_device
+            .description()
+            .map_err(|e| map_cpal_error("device_name", e))?
+            .to_string();
+
+        let devices: Vec<Device> = match kind {
+            MediaDeviceInfoKind::AudioInput => host
+                .input_devices()
+                .map_err(|e| map_cpal_error("enumerate_input_devices", e))?
+                .collect(),
+            MediaDeviceInfoKind::AudioOutput => host
+                .output_devices()
+                .map_err(|e| map_cpal_error("enumerate_output_devices", e))?
+                .collect(),
+            MediaDeviceInfoKind::VideoInput => Vec::new(),
+        };
+
+        // Walk the device list in the same order and with the same collision handling as
+        // `enumerate_devices_sync` so the returned id matches one of its entries.
+        let mut seen = Vec::<String>::new();
+        for device in devices {
+            let Some(num_channels) = cpal_device_channels(&device, kind) else {
+                continue;
+            };
+            let stable_id = cpal_stable_device_id(&device, kind, num_channels, &seen)?;
+            let description = device
+                .description()
+                .map_err(|e| map_cpal_error("device_name", e))?
+                .to_string();
+            if description == default_description {
+                return Ok(Some(stable_id));
+            }
+            seen.push(stable_id);
+        }
+
+        Ok(None)
+    }
 }
 
 fn latency_in_seconds(infos: &OutputCallbackInfo) -> f64 {

--- a/src/io/cubeb.rs
+++ b/src/io/cubeb.rs
@@ -593,6 +593,38 @@ impl AudioBackendManager for CubebBackend {
 
         Ok(list)
     }
+
+    fn default_device_id(kind: MediaDeviceInfoKind) -> BackendResult<Option<String>>
+    where
+        Self: Sized,
+    {
+        let device_type = match kind {
+            MediaDeviceInfoKind::AudioInput => DeviceType::INPUT,
+            MediaDeviceInfoKind::AudioOutput => DeviceType::OUTPUT,
+            MediaDeviceInfoKind::VideoInput => return Ok(None),
+        };
+
+        let context = Context::init(None, None).map_err(|e| map_cubeb_error("init_context", e))?;
+        let devices = context
+            .enumerate_devices(device_type)
+            .map_err(|e| map_cubeb_error(enumerate_operation(kind), e))?;
+
+        // Walk the device list in the same order and with the same collision handling as
+        // `enumerate_devices_sync` so the returned id matches one of its entries. The default
+        // device for general playback/capture is the one flagged `MULTIMEDIA`.
+        let mut seen = Vec::<String>::new();
+        for device in devices.iter() {
+            let stable_id = cubeb_stable_device_id(device, kind, &seen)?;
+            let is_default =
+                device.preferred().bits() & cubeb::ffi::CUBEB_DEVICE_PREF_MULTIMEDIA != 0;
+            if is_default {
+                return Ok(Some(stable_id));
+            }
+            seen.push(stable_id);
+        }
+
+        Ok(None)
+    }
 }
 
 fn enumerate_cubeb_devices(

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -10,7 +10,7 @@ use crossbeam_channel::{Receiver, Sender};
 use crate::buffer::AudioBuffer;
 use crate::context::{AudioContextLatencyCategory, AudioContextOptions, AudioContextState};
 use crate::events::EventDispatch;
-use crate::media_devices::MediaDeviceInfo;
+use crate::media_devices::{MediaDeviceInfo, MediaDeviceInfoKind};
 use crate::media_streams::{MediaStream, MediaStreamTrack};
 use crate::message::ControlMessage;
 use crate::stats::AudioStats;
@@ -254,6 +254,12 @@ pub(crate) trait AudioBackendManager: Send + Sync + 'static {
     fn enumerate_devices_sync() -> BackendResult<Vec<MediaDeviceInfo>>
     where
         Self: Sized;
+
+    /// Returns the stable `device_id` of the system default device for the given kind, or `None`
+    /// when it cannot be determined (for example when there is no such device).
+    fn default_device_id(kind: MediaDeviceInfoKind) -> BackendResult<Option<String>>
+    where
+        Self: Sized;
 }
 
 /// Calculate buffer size in frames for a given latency category
@@ -298,4 +304,23 @@ pub(crate) fn enumerate_devices_sync() -> BackendResult<Vec<MediaDeviceInfo>> {
 
     #[cfg(all(not(feature = "cubeb"), not(feature = "cpal")))]
     Err(AudioBackendError::no_backend("enumerate_devices_sync"))
+}
+
+/// Resolves the default device id for the given kind using the selected backend (cubeb/cpal/none).
+pub(crate) fn default_device_id(kind: MediaDeviceInfoKind) -> BackendResult<Option<String>> {
+    #[cfg(feature = "cubeb")]
+    {
+        cubeb::CubebBackend::default_device_id(kind)
+    }
+
+    #[cfg(all(not(feature = "cubeb"), feature = "cpal"))]
+    {
+        cpal::CpalBackend::default_device_id(kind)
+    }
+
+    #[cfg(all(not(feature = "cubeb"), not(feature = "cpal")))]
+    {
+        let _ = kind;
+        Err(AudioBackendError::no_backend("default_device_id"))
+    }
 }

--- a/src/io/none.rs
+++ b/src/io/none.rs
@@ -7,7 +7,7 @@ use super::{
 
 use crate::buffer::AudioBuffer;
 use crate::context::AudioContextOptions;
-use crate::media_devices::MediaDeviceInfo;
+use crate::media_devices::{MediaDeviceInfo, MediaDeviceInfoKind};
 use crate::render::RenderThread;
 use crate::{MAX_CHANNELS, RENDER_QUANTUM_SIZE};
 
@@ -213,5 +213,12 @@ impl AudioBackendManager for NoneBackend {
         Self: Sized,
     {
         Ok(vec![])
+    }
+
+    fn default_device_id(_kind: MediaDeviceInfoKind) -> BackendResult<Option<String>>
+    where
+        Self: Sized,
+    {
+        Ok(None)
     }
 }

--- a/src/media_devices/mod.rs
+++ b/src/media_devices/mod.rs
@@ -35,6 +35,59 @@ pub(crate) fn try_enumerate_devices_sync() -> BackendResult<Vec<MediaDeviceInfo>
     crate::io::enumerate_devices_sync()
 }
 
+/// Returns the `device_id` of the system default audio output device (speakers), if one can be
+/// determined.
+///
+/// The returned id matches the corresponding entry from [`enumerate_devices_sync`] and can be used
+/// as the [`sink_id`](crate::context::AudioContextOptions::sink_id) of an `AudioContext`.
+///
+/// Returns `None` if there is no output device or the default cannot be determined.
+///
+/// ```no_run
+/// use web_audio_api::media_devices::{default_output_device, enumerate_devices_sync};
+///
+/// let default = default_output_device();
+/// for device in enumerate_devices_sync() {
+///     let marker = if Some(device.device_id().to_string()) == default { " (default)" } else { "" };
+///     println!("{}{}", device.label(), marker);
+/// }
+/// ```
+pub fn default_output_device() -> Option<String> {
+    default_device_id(MediaDeviceInfoKind::AudioOutput)
+}
+
+/// Returns the `device_id` of the system default audio input device (microphone), if one can be
+/// determined.
+///
+/// The returned id matches the corresponding entry from [`enumerate_devices_sync`].
+///
+/// Returns `None` if there is no input device or the default cannot be determined.
+///
+/// ```no_run
+/// use web_audio_api::media_devices::{default_input_device, enumerate_devices_sync, MediaDeviceInfoKind};
+///
+/// let default = default_input_device();
+/// for device in enumerate_devices_sync() {
+///     if device.kind() != MediaDeviceInfoKind::AudioInput {
+///         continue;
+///     }
+///     let marker = if Some(device.device_id().to_string()) == default { " (default)" } else { "" };
+///     println!("{}{}", device.label(), marker);
+/// }
+/// ```
+pub fn default_input_device() -> Option<String> {
+    default_device_id(MediaDeviceInfoKind::AudioInput)
+}
+
+/// Resolves the default device id for the given kind through the active audio backend, logging and
+/// returning `None` on error.
+fn default_device_id(kind: MediaDeviceInfoKind) -> Option<String> {
+    crate::io::default_device_id(kind).unwrap_or_else(|e| {
+        log::error!("Unable to determine default media device: {e}");
+        None
+    })
+}
+
 // Internal struct to derive a stable id for a given input / output device
 // cf. https://github.com/orottier/web-audio-api-rs/issues/356
 #[derive(Hash)]
@@ -247,4 +300,28 @@ pub(crate) fn try_get_user_media_sync(
     }
 
     crate::io::build_input(options, channel_count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A resolved default device id must be one of the enumerated devices of the matching kind.
+    /// In environments without an audio backend or devices both accessors return `None` and the
+    /// assertions are skipped.
+    #[test]
+    fn test_default_device_ids_are_enumerated() {
+        let devices = enumerate_devices_sync();
+
+        if let Some(id) = default_output_device() {
+            assert!(devices
+                .iter()
+                .any(|d| d.device_id() == id && d.kind() == MediaDeviceInfoKind::AudioOutput));
+        }
+        if let Some(id) = default_input_device() {
+            assert!(devices
+                .iter()
+                .any(|d| d.device_id() == id && d.kind() == MediaDeviceInfoKind::AudioInput));
+        }
+    }
 }


### PR DESCRIPTION
### Summary

This crate provides the [`enumerate_devices_sync`](https://docs.rs/web-audio-api/latest/web_audio_api/media_devices/fn.enumerate_devices_sync.html) function for querying what audio devices are available. As far as I can tell, though, there's no way to determine which device will be selected if the default ID `""` is requested. There's also no way to display the name of the default device to the user.

I'd like to suggest adding two extension functions to `media_devices`: `default_output_device` and `default_input_device`. These return a string ID that can be correlated with one from `enumerate_devices_sync`.

### Changes

- Expose `default_output_device` and `default_input_device`
- Hook them up to the `cpal` and `cubeb` backends
- Add unit test
- Update CHANGELOG